### PR TITLE
Align with Race Control API contract and fix authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,12 @@ GOOGLE_CLIENT_ID=your_google_client_id_here
 GOOGLE_CLIENT_SECRET=your_google_client_secret_here
 
 # API Configuration
-VITE_API_BASE_URL=https://dev-simracecenter.com
+# Base URL without trailing path — endpoint paths already include /api/...
+VITE_API_BASE_URL=https://simracecenter.com
+
+# Race Control API scope (Entra ID / MSAL)
+# This is the audience scope for the RC API — do NOT use User.Read for RC calls.
+VITE_RC_API_SCOPE=api://racecontrol-api-a780e279-1cb6-4ed0-9ef6-49029aa50a42/access_as_user
 
 # Application Insights Configuration
 # These values are pre-configured for the Sim RaceCenter Director app

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   description: API for Sim RaceCenter Race Control and Director Integration
 servers:
   - url: https://simracecenter.com
-    description: Production Server
+    description: Production Server (via SWA linked backend)
   - url: http://localhost:7071
     description: Local Development Server
 components:
@@ -15,101 +15,170 @@ components:
       scheme: bearer
       bearerFormat: JWT
   schemas:
-    DirectorCommandType:
-      type: string
-      enum:
-        - SWITCH_CAMERA
-        - PLAY_AUDIO
-        - SHOW_OVERLAY
-        - HIDE_OVERLAY
-      description: The type of command to execute.
-    DirectorCommand:
+    SequenceVariable:
       type: object
       properties:
-        commandType:
-          $ref: '#/components/schemas/DirectorCommandType'
-        target:
-          type: object
-          description: Target details for the command (e.g., car, camera, overlay).
-          properties:
-            carIndex:
-              type: integer
-              description: The index of the car to focus on.
-            driverName:
-              type: string
-              description: The name of the driver.
-            carNumber:
-              type: string
-              description: The number of the car.
-            cameraGroup:
-              type: string
-              description: The camera group to use (e.g., TV1, Cockpit).
-            sceneType:
-              type: string
-              description: The type of scene (e.g., Forward, Rear, General).
-            obsSceneId:
-              type: string
-              description: The OBS Scene ID to switch to.
-          additionalProperties: true
-        durationMs:
-          type: integer
-          description: Duration to hold this state in milliseconds.
-        offsetMs:
-          type: integer
-          description: Time offset from the start of the sequence to execute this command.
-        id:
+        name:
           type: string
-          format: uuid
+          description: Variable name for substitution.
+        label:
+          type: string
+          description: Human-readable label for UI.
         type:
           type: string
           enum:
-            - WAIT
-            - LOG
+            - text
+            - number
+            - select
+            - boolean
+            - sessionTime
+            - sessionTick
+          description: Variable data type.
+        required:
+          type: boolean
+          description: Whether the variable must be provided.
+        source:
+          type: string
+          enum:
+            - cloud
+            - context
+            - user
+          description: How the variable is resolved.
+        contextKey:
+          type: string
+          description: Context path for resolution (e.g., iracing.drivers).
+        defaultValue:
+          description: Default value if not provided.
+        constraints:
+          type: object
+          description: Validation constraints for the variable.
+          properties:
+            min:
+              type: number
+            max:
+              type: number
+            options:
+              type: array
+              items:
+                type: object
+                properties:
+                  label:
+                    type: string
+                  value:
+                    type: string
+            pattern:
+              type: string
+      required:
+        - name
+        - label
+        - type
+        - required
+        - source
+    SequenceStep:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique step identifier.
+        intent:
+          type: string
+          description: Semantic intent in domain.action notation (e.g., obs.switchScene).
         payload:
           type: object
+          additionalProperties: true
+          description: Step payload matching the intent's schema.
+        metadata:
+          type: object
+          properties:
+            label:
+              type: string
+            timeout:
+              type: number
+          additionalProperties: true
       required:
-        - commandType
-        - target
-        - offsetMs
-    DirectorSequence:
+        - id
+        - intent
+        - payload
+    PortableSequence:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique sequence identifier.
+        name:
+          type: string
+          description: Sequence name.
+        version:
+          type: string
+          description: Sequence version.
+        description:
+          type: string
+          description: Human-readable description.
+        category:
+          type: string
+          enum:
+            - cloud
+            - builtin
+            - custom
+          description: Sequence category.
+        priority:
+          type: boolean
+          description: >-
+            If true, the client should cancel any in-progress execution and run
+            this sequence immediately.
+        centerId:
+          type: string
+          description: Associated center ID for cloud sequences.
+        variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/SequenceVariable'
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/SequenceStep'
+        metadata:
+          type: object
+          description: Sequence-level metadata for auto-generated sequences.
+          properties:
+            totalDurationMs:
+              type: integer
+              description: >-
+                Expected total duration in milliseconds. Mandatory on
+                auto-director sequences.
+            generatedAt:
+              type: string
+              format: date-time
+              description: Timestamp when the sequence was generated.
+            source:
+              type: string
+              enum:
+                - ai-director
+                - command-buffer
+                - library
+              description: Origin of the sequence.
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - steps
+    ExecuteSequencePayload:
       type: object
       properties:
         sequenceId:
           type: string
-          format: uuid
-          description: Unique identifier for this generated sequence.
-        raceSessionId:
-          type: string
-          format: uuid
-          description: The session context.
-        commands:
-          type: array
-          items:
-            $ref: '#/components/schemas/DirectorCommand'
-          description: List of commands to execute.
-        totalDurationMs:
-          type: integer
-          description: Expected duration of the entire sequence in milliseconds.
-        generatedAt:
-          type: string
-          format: date-time
-          description: Timestamp when the sequence was generated.
-        createdAt:
-          type: string
-          format: date-time
-        priority:
-          type: string
-          enum:
-            - LOW
-            - NORMAL
-            - HIGH
-            - URGENT
+          description: ID of the sequence to execute.
+        variables:
+          type: object
+          additionalProperties: true
+          description: Variable bindings for the sequence.
       required:
         - sequenceId
-        - raceSessionId
-        - commands
-        - totalDurationMs
-        - generatedAt
     RaceSession:
       type: object
       properties:
@@ -200,17 +269,6 @@ components:
           type: array
           items:
             type: string
-    NextSequenceResponse:
-      type: object
-      properties:
-        status:
-          type: string
-          enum:
-            - IDLE
-            - BUSY
-            - ERROR
-        sequence:
-          $ref: '#/components/schemas/DirectorSequence'
 security:
   - bearerAuth: []
 paths:
@@ -295,6 +353,36 @@ paths:
                     type: string
         '500':
           description: Internal server error.
+  /api/chat:
+    post:
+      summary: Interact with the AI Agent
+      description: Ask questions about the current race progress, incidents, and standings.
+      tags:
+        - AI
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - sessionId
+                - message
+              properties:
+                sessionId:
+                  type: string
+                message:
+                  type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reply:
+                    type: string
   /api/director/v1/sessions/{raceSessionId}/sequences/next:
     get:
       summary: Generate Next Sequence
@@ -306,8 +394,9 @@ paths:
         This endpoint acts as an "AI Director", analyzing telemetry, gaps, and
         incidents to determine the most interesting shots to show.
 
-        The returned sequence contains a list of time-stamped commands (e.g.,
-        camera switches) that the client should execute.
+        The returned sequence contains a list of steps using semantic intents
+        (e.g., broadcast.showLiveCam, obs.switchScene) that the client executes
+        sequentially.
       parameters:
         - in: path
           name: raceSessionId
@@ -324,15 +413,46 @@ paths:
           description: >-
             The ID of the sequence that was just completed (for chaining and
             logging).
+        - in: query
+          name: intents
+          schema:
+            type: string
+          description: >-
+            Comma-separated list of intent handlers the Director currently
+            supports (e.g.,
+            "broadcast.showLiveCam,obs.switchScene,system.wait"). If absent, RC
+            generates with all registered intents.
       responses:
         '200':
           description: A new sequence is generated and returned.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DirectorSequence'
+                $ref: '#/components/schemas/PortableSequence'
+        '204':
+          description: >-
+            No sequence available. Director should retry after the indicated
+            interval.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Suggested retry interval in seconds.
         '404':
           description: Session not found or user not authorized for this center.
+        '410':
+          description: >-
+            Session has ended (COMPLETED or CANCELED). Director should stop
+            polling.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  sessionStatus:
+                    type: string
         '500':
           description: Internal server error during sequence generation.
   /api/director/v1/sessions:
@@ -528,12 +648,83 @@ paths:
           description: User not found.
         '500':
           description: Internal server error.
+  /api/director/v1/sequences:
+    get:
+      summary: List Portable Sequences
+      description: >
+        Retrieves a library of pre-defined portable sequences.
+
+
+        These sequences are configured in the cloud portal and appear in the
+        Director's
+
+        local library under the "Cloud" category. The Director App uses this
+        endpoint
+
+        to fetch sequences for display and execution.
+      parameters:
+        - in: query
+          name: centerId
+          schema:
+            type: string
+          required: false
+          description: Filter sequences by center ID (defaults to user's center).
+        - in: query
+          name: category
+          schema:
+            type: string
+            enum:
+              - cloud
+              - builtin
+              - custom
+          description: Filter sequences by category.
+      responses:
+        '200':
+          description: Array of portable sequences.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PortableSequence'
+        '401':
+          description: Not authenticated.
+        '403':
+          description: Access denied - RaceDirector role required.
+        '500':
+          description: Internal server error.
+  /api/director/v1/sequences/{id}:
+    get:
+      summary: Get Portable Sequence by ID
+      description: Retrieves a specific portable sequence by its ID.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+          description: The ID of the sequence to retrieve.
+      responses:
+        '200':
+          description: The portable sequence.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortableSequence'
+        '401':
+          description: Not authenticated.
+        '403':
+          description: Access denied - RaceDirector role required.
+        '404':
+          description: Sequence not found.
+        '500':
+          description: Internal server error.
   /api/director/v1/sessions/{id}/commands:
     post:
       summary: Queue a chat/voice command
       description: >
-        Queues a command (e.g., TTS_MESSAGE or SHOW_OVERLAY) to be included in
-        the next director sequence.
+        Queues a command using the shared intent registry to be included in the
+        next director sequence.
 
         This endpoint is called by external AI Bot webhooks to inject
         asynchronous commands into the broadcast.
@@ -554,30 +745,30 @@ paths:
             schema:
               type: object
               required:
-                - type
+                - intent
                 - payload
               properties:
-                type:
+                intent:
                   type: string
                   enum:
-                    - TTS_MESSAGE
-                    - SHOW_OVERLAY
-                  description: The type of command to queue
+                    - communication.announce
+                    - communication.talkToChat
+                    - overlay.show
+                    - overlay.hide
+                    - system.log
+                  description: Intent from the shared registry
                 payload:
                   type: object
                   properties:
-                    text:
+                    message:
                       type: string
                       description: The text content (for TTS or overlay)
-                    author:
-                      type: string
-                      description: The author of the message
                   additionalProperties: true
-                  description: Command-specific payload data
+                  description: Intent-specific payload data
                 priority:
                   type: integer
                   default: 5
-                  description: Command priority (lower number = higher priority)
+                  description: Command priority (lower number = higher priority, 1-10)
       responses:
         '201':
           description: Command queued successfully
@@ -592,7 +783,7 @@ paths:
                   sessionId:
                     type: string
                     format: uuid
-                  type:
+                  intent:
                     type: string
                   payload:
                     type: object

--- a/run-electron.js
+++ b/run-electron.js
@@ -3,7 +3,13 @@ const electron = require('electron');
 const path = require('path');
 require('dotenv').config();
 
-const args = ['.', '--no-sandbox', '--disable-gpu'];
+const args = [
+  '.',
+  '--no-sandbox',
+  '--disable-gpu',
+  '--in-process-gpu',           // Avoid GPU process crash loop in containers
+  '--disable-software-rasterizer',
+];
 
 const child = spawn(electron, args, {
   stdio: ['inherit', 'inherit', 'pipe'],
@@ -12,12 +18,17 @@ const child = spawn(electron, args, {
 
 child.stderr.on('data', (data) => {
   const output = data.toString();
-  // Filter out known harmless DBus/Chrome noise in dev containers
+  // Filter out known harmless Chromium noise in dev containers / headless environments
   if (output.includes('ERROR:dbus') || 
       output.includes('Failed to connect to the bus') ||
       output.includes('Autofill.enable') ||
       output.includes('Autofill.setAddresses') || 
-      output.includes('object_path= /org/freedesktop/DBus')) {
+      output.includes('object_path= /org/freedesktop/DBus') ||
+      output.includes('GPU process') ||
+      output.includes('zygote_communication_linux') ||
+      output.includes('network_service_instance') ||
+      output.includes('renderer.bundle.js script failed to run') ||
+      output.includes('node:electron/js2c/renderer_init')) {
     return;
   }
   process.stderr.write(data);

--- a/src/main/auth-config.ts
+++ b/src/main/auth-config.ts
@@ -28,8 +28,17 @@ export const msalConfig = {
   },
 };
 
+/**
+ * Race Control API scope for token acquisition.
+ * The Director must request this scope (not User.Read) so the access token
+ * is issued with the Race Control API audience.
+ */
+export const rcApiScope =
+  process.env.VITE_RC_API_SCOPE ||
+  'api://racecontrol-api-a780e279-1cb6-4ed0-9ef6-49029aa50a42/access_as_user';
+
 export const apiConfig = {
-  baseUrl: process.env.VITE_API_BASE_URL || 'https://dev-simracecenter.com',
+  baseUrl: process.env.VITE_API_BASE_URL || 'https://simracecenter.com',
   endpoints: {
     userProfile: '/api/auth/user',
     listSessions: '/api/director/v1/sessions',

--- a/src/main/auth-service.ts
+++ b/src/main/auth-service.ts
@@ -1,6 +1,6 @@
 import { PublicClientApplication, CryptoProvider } from '@azure/msal-node';
 import { shell, BrowserWindow } from 'electron';
-import { msalConfig, apiConfig } from './auth-config';
+import { msalConfig, apiConfig, rcApiScope } from './auth-config';
 import { UserProfile } from './director-types';
 
 export class AuthService {
@@ -25,7 +25,7 @@ export class AuthService {
       try {
         const response = await this.clientApplication.acquireTokenSilent({
           account: account,
-          scopes: ["User.Read"],
+          scopes: [rcApiScope],
         });
         this.account = response.account;
         return this.account;
@@ -39,21 +39,27 @@ export class AuthService {
 
   async getUserProfile(): Promise<UserProfile | null> {
     const token = await this.getAccessToken();
-    if (!token) return null;
+    if (!token) {
+      console.warn('[AuthService] getUserProfile: no access token available');
+      return null;
+    }
 
     try {
-      const response = await fetch(`${apiConfig.baseUrl}${apiConfig.endpoints.userProfile}`, {
+      const url = `${apiConfig.baseUrl}${apiConfig.endpoints.userProfile}`;
+      const response = await fetch(url, {
         headers: {
           'Authorization': `Bearer ${token}`
         }
       });
 
       if (!response.ok) {
-        console.error('Failed to fetch user profile:', response.status, response.statusText);
+        const body = await response.text();
+        console.error('[AuthService] Failed to fetch user profile:', response.status, response.statusText, body);
         return null;
       }
 
       const profile: UserProfile = await response.json();
+      console.log('[AuthService] User profile: userId=%s, centerId=%s', profile.userId, profile.centerId || profile.center?.id);
       return profile;
     } catch (error) {
       console.error('Error fetching user profile:', error);
@@ -70,7 +76,7 @@ export class AuthService {
       try {
         const response = await this.clientApplication.acquireTokenSilent({
           account: account,
-          scopes: ["User.Read"],
+          scopes: [rcApiScope],
         });
         return response.accessToken;
       } catch (error) {
@@ -102,7 +108,7 @@ export class AuthService {
 
     const authResponse = await this.clientApplication.acquireTokenInteractive({
       openBrowser,
-      scopes: ["User.Read"],
+      scopes: [rcApiScope],
       successTemplate: "<h1>Successfully signed in!</h1> <p>You can close this window now.</p>",
       errorTemplate: "<h1>Something went wrong</h1> <p>Check the console for more information.</p>",
     });

--- a/src/main/director-service.ts
+++ b/src/main/director-service.ts
@@ -1,11 +1,8 @@
 import { AuthService } from './auth-service';
 import { 
   RaceSession,
-  GetNextSequenceResponse, 
   DirectorStatus,
   DirectorState,
-  DirectorCommand,
-  DirectorSequence,
   PortableSequence,
   SequenceStep,
 } from './director-types';
@@ -113,7 +110,8 @@ export class DirectorService {
 
         const sequenceData: any = await response.json();
         
-        // Normalize API response to PortableSequence format
+        // API now returns PortableSequence format directly (with steps/intent)
+        // Fall back to legacy normalization if it still has old format
         const portable = this.normalizeApiResponse(sequenceData);
         
         this.executor.execute(portable);
@@ -136,7 +134,7 @@ export class DirectorService {
     const filterCenterId = centerId || profile?.centerId || profile?.center?.id;
 
     if (!filterCenterId) {
-      console.warn('No centerId available for session discovery');
+      console.warn('[DirectorService] No centerId available for session discovery');
       return [];
     }
 
@@ -211,6 +209,11 @@ export class DirectorService {
       this.status = 'BUSY';
       sequenceResult = await this.fetchAndExecuteNextSequence();
     } catch (error) {
+      if ((error as any)?.sessionEnded) {
+        console.log('[Director] Session has ended. Stopping director loop.');
+        this.stop();
+        return;
+      }
       console.error('Error in director loop:', error);
       this.status = 'ERROR';
     } finally {
@@ -233,6 +236,7 @@ export class DirectorService {
    * Intent mappings for legacy API CommandType values.
    * Maps the old enum-based command types from the OpenAPI spec
    * to the semantic intent names registered by extensions.
+   * @deprecated The API now returns PortableSequence with semantic intents directly.
    */
   private static readonly LEGACY_INTENT_MAP: Record<string, string> = {
     'SWITCH_CAMERA': 'broadcast.showLiveCam',
@@ -245,11 +249,33 @@ export class DirectorService {
   };
 
   /**
-   * Normalizes a raw API response (legacy DirectorCommand[]) into a PortableSequence.
-   * This is the single adapter point between the Race Control API format
-   * and the intent-driven execution engine.
+   * Normalizes a raw API response into a PortableSequence.
+   * The current API returns PortableSequence format directly (with `steps` and semantic `intent` fields).
+   * Legacy format (with `commands` and `commandType` fields) is still supported for backward compatibility.
    */
   private normalizeApiResponse(apiData: any): PortableSequence {
+    // New format: API returns PortableSequence directly with `steps`
+    if (apiData.steps && Array.isArray(apiData.steps)) {
+      return {
+        id: apiData.id || randomUUID(),
+        name: apiData.name,
+        version: apiData.version,
+        description: apiData.description,
+        category: apiData.category,
+        priority: apiData.priority,
+        variables: apiData.variables,
+        steps: apiData.steps.map((step: any) => ({
+          id: step.id || randomUUID(),
+          intent: step.intent,
+          payload: step.payload || {},
+          metadata: step.metadata,
+        })),
+        metadata: apiData.metadata,
+      };
+    }
+
+    // Legacy format: API returned DirectorSequence with `commands`
+    console.warn('[Director] Received legacy API format with commands[] — normalizing to PortableSequence');
     const commands: any[] = apiData.commands || [];
     
     const steps: SequenceStep[] = commands.map((cmd: any, index: number) => {
@@ -280,7 +306,6 @@ export class DirectorService {
       // Map legacy command types to semantic intents
       const intent = DirectorService.LEGACY_INTENT_MAP[type];
       if (intent) {
-        // Build payload from target object (OpenAPI format) or inline payload
         let payload = cmd.payload || {};
         
         if (cmd.target) {
@@ -318,8 +343,8 @@ export class DirectorService {
       steps,
       metadata: {
         priority: apiData.priority,
-        generatedAt: apiData.generatedAt,
-        totalDurationMs: apiData.totalDurationMs,
+        generatedAt: apiData.generatedAt || apiData.metadata?.generatedAt,
+        totalDurationMs: apiData.totalDurationMs || apiData.metadata?.totalDurationMs,
       },
     };
   }
@@ -337,10 +362,20 @@ export class DirectorService {
       return false;
     }
 
-    const params = new URLSearchParams({ status: this.status });
+    // Build query parameters per updated OpenAPI spec:
+    //   lastSequenceId — ID of the sequence just completed (for chaining/logging)
+    //   intents — comma-separated list of active intent handlers (capability reporting)
+    const params = new URLSearchParams();
     if (this.lastCompletedSequenceId) {
-      params.set('currentSequenceId', this.lastCompletedSequenceId);
+      params.set('lastSequenceId', this.lastCompletedSequenceId);
     }
+
+    // Report active intents so RC constrains sequence generation to what we can execute
+    const activeIntents = this.getActiveIntents();
+    if (activeIntents.length > 0) {
+      params.set('intents', activeIntents.join(','));
+    }
+
     const url = `${apiConfig.baseUrl}${apiConfig.endpoints.nextSequence(this.currentRaceSessionId)}?${params}`;
 
     try {
@@ -355,9 +390,22 @@ export class DirectorService {
 
       const duration = Date.now() - startTime;
 
+      // Handle 410 Gone — session has ended (COMPLETED or CANCELED)
+      if (response.status === 410) {
+        console.log('[Director] Session ended (410 Gone). Stopping polling.');
+        telemetryService.trackDependency(
+          'RaceControl API', url, duration, true, 410, 'HTTP',
+          { sessionId: this.currentRaceSessionId, result: 'session-ended' }
+        );
+        const error: any = new Error('Session has ended');
+        error.sessionEnded = true;
+        throw error;
+      }
+
       if (response.status === 204) {
-        // No new sequence available
-        console.log('No new sequence available (204)');
+        // No new sequence available — respect Retry-After header if present
+        const retryAfter = response.headers.get('Retry-After');
+        console.log(`No new sequence available (204)${retryAfter ? `, Retry-After: ${retryAfter}s` : ''}`);
         telemetryService.trackDependency(
           'RaceControl API',
           url,
@@ -370,6 +418,13 @@ export class DirectorService {
             result: 'no-sequence',
           }
         );
+        // Return negative value to signal the loop to use Retry-After as the poll interval
+        if (retryAfter) {
+          const retryMs = parseInt(retryAfter, 10) * 1000;
+          if (!isNaN(retryMs) && retryMs > 0) {
+            return retryMs;
+          }
+        }
         return false;
       }
 
@@ -394,7 +449,8 @@ export class DirectorService {
       const sequenceData: any = await response.json();
       console.log('Received sequence:', JSON.stringify(sequenceData, null, 2));
 
-      // Normalize API response to PortableSequence using the adapter
+      // Normalize API response — handles both new PortableSequence format (steps/intent)
+      // and legacy DirectorSequence format (commands/commandType) for backward compatibility
       const portable = this.normalizeApiResponse(sequenceData);
 
       this.currentSequenceId = portable.id;
@@ -405,7 +461,7 @@ export class DirectorService {
         sequenceId: portable.id,
         sessionId: this.currentRaceSessionId,
         commandCount: portable.steps.length.toString(),
-        priority: String(portable.metadata?.priority || 'NORMAL'),
+        priority: String(portable.priority || false),
       });
 
       await this.executor.execute(portable, (completed, total) => {
@@ -423,8 +479,13 @@ export class DirectorService {
         sessionId: this.currentRaceSessionId,
       });
 
-      return sequenceData.totalDurationMs ?? 0;
+      // Use metadata.totalDurationMs for poll pacing (per RFC agreement)
+      const totalDurationMs = (portable.metadata as any)?.totalDurationMs ?? 0;
+      return totalDurationMs;
     } catch (error) {
+      // Re-throw session-ended errors so the loop handler can stop
+      if ((error as any)?.sessionEnded) throw error;
+
       console.error('Error fetching/executing sequence:', error);
       const duration = Date.now() - startTime;
       telemetryService.trackDependency(
@@ -443,6 +504,26 @@ export class DirectorService {
         sessionId: this.currentRaceSessionId || 'unknown',
       });
       return false;
+    }
+  }
+
+  /**
+   * Returns the list of currently active intent handlers.
+   * Sent as the `intents` query parameter so Race Control constrains
+   * sequence generation to only emit steps we can execute.
+   * Always includes system.wait and system.log (built-in, always available).
+   */
+  private getActiveIntents(): string[] {
+    const builtIns = ['system.wait', 'system.log'];
+    try {
+      const catalog = this.extensionHost.getCapabilityCatalog();
+      const allIntents = catalog.getAllIntents();
+      const activeExtIntents = allIntents
+        .filter(entry => entry.enabled)
+        .map(entry => entry.intent.intent);
+      return [...builtIns, ...activeExtIntents];
+    } catch {
+      return builtIns;
     }
   }
 }

--- a/src/main/director-types.ts
+++ b/src/main/director-types.ts
@@ -31,7 +31,7 @@ export interface SequenceStep {
 export interface SequenceVariable {
   name: string;              // Variable identifier (alphanumeric, camelCase)
   label: string;             // Human-readable label for UI
-  type: 'string' | 'number' | 'boolean' | 'select' | 'sessionTime' | 'sessionTick';
+  type: 'text' | 'number' | 'boolean' | 'select' | 'sessionTime' | 'sessionTick';
   required: boolean;
   default?: unknown;         // Default value (used if not provided)
   description?: string;      // Help text shown in UI
@@ -44,7 +44,7 @@ export interface SequenceVariable {
     }>;
     pattern?: string;        // Regex for string type
   };
-  source?: 'user' | 'context';  // Where the value comes from
+  source?: 'user' | 'context' | 'cloud';  // Where the value comes from
   contextKey?: string;       // Dot-path for auto-population from telemetry/session data
 }
 
@@ -57,7 +57,7 @@ export interface PortableSequence {
   name?: string;
   version?: string;
   description?: string;                              // Human-readable description
-  category?: 'built-in' | 'cloud' | 'custom';       // Library category
+  category?: 'builtin' | 'cloud' | 'custom';         // Library category
   priority?: boolean;                                 // If true, executes immediately even during Director Loop
   variables?: SequenceVariable[];                     // Runtime variable definitions
   steps: SequenceStep[];
@@ -321,6 +321,10 @@ export interface ActiveSessionResponse {
 
 export type SequencePriority = 'LOW' | 'NORMAL' | 'HIGH' | 'URGENT';
 
+/**
+ * @deprecated The /sequences/next endpoint now returns PortableSequence directly.
+ * Kept for backward compatibility with any remaining code paths.
+ */
 export interface GetNextSequenceResponse {
   sequenceId: string;
   createdAt: string;

--- a/src/main/overlay/overlay-server.ts
+++ b/src/main/overlay/overlay-server.ts
@@ -187,8 +187,6 @@ export class OverlayServer {
     const relativePath = pathname.replace(/^\/overlay\/?/, '') || 'index.html';
     const filePath = path.join(this.overlayDir, relativePath);
 
-    console.log(`[OverlayServer] serveOverlay: pathname='${pathname}' → file='${filePath}' exists=${fs.existsSync(filePath)}`);
-
     // Security: prevent directory traversal
     if (!filePath.startsWith(this.overlayDir)) {
       res.writeHead(403, { 'Content-Type': 'text/plain' });

--- a/src/main/sequence-library-service.ts
+++ b/src/main/sequence-library-service.ts
@@ -241,7 +241,7 @@ export class SequenceLibraryService {
         jsonFiles.map(async (f) => {
           const content = await fs.readFile(path.join(this.builtInDir, f), 'utf-8');
           const seq = JSON.parse(content) as PortableSequence;
-          return { ...seq, category: 'built-in' as const };
+          return { ...seq, category: 'builtin' as const };
         })
       );
       this.builtInCache = sequences;

--- a/src/renderer/components/sequences/SequenceDetail.tsx
+++ b/src/renderer/components/sequences/SequenceDetail.tsx
@@ -148,7 +148,7 @@ export const SequenceDetail: React.FC<SequenceDetailProps> = ({
             )}
             {sequence.category && (
               <span className={`px-1.5 py-0.5 rounded text-[10px] font-bold uppercase ${
-                sequence.category === 'built-in'
+                sequence.category === 'builtin'
                   ? 'bg-secondary/10 text-secondary'
                   : sequence.category === 'cloud'
                     ? 'bg-primary/10 text-primary'

--- a/src/renderer/components/sequences/SequenceLibraryCard.tsx
+++ b/src/renderer/components/sequences/SequenceLibraryCard.tsx
@@ -30,7 +30,7 @@ export interface SequenceLibraryCardProps {
 }
 
 const categoryBadge: Record<string, { label: string; className: string }> = {
-  'built-in': { label: 'BUILT-IN', className: 'bg-secondary/20 text-secondary' },
+  'builtin': { label: 'BUILT-IN', className: 'bg-secondary/20 text-secondary' },
   cloud: { label: 'CLOUD', className: 'bg-primary/20 text-primary' },
   custom: { label: 'CUSTOM', className: 'bg-green-500/20 text-green-400' },
 };

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -86,7 +86,7 @@ export interface PortableSequence {
   name?: string;
   version?: string;
   description?: string;
-  category?: 'built-in' | 'cloud' | 'custom';
+  category?: 'builtin' | 'cloud' | 'custom';
   priority?: boolean;
   variables?: SequenceVariable[];
   steps: SequenceStep[];

--- a/src/sequences/built-in/safety-car-protocol.json
+++ b/src/sequences/built-in/safety-car-protocol.json
@@ -3,7 +3,7 @@
   "name": "Safety Car Protocol",
   "version": "1.0.0",
   "description": "Deploys the full safety car broadcast protocol: switches to track map, mutes drivers, announces to chat, then returns to normal after a delay.",
-  "category": "built-in",
+  "category": "builtin",
   "variables": [
     {
       "name": "returnDelayMs",

--- a/src/sequences/built-in/show-replay-for-driver.json
+++ b/src/sequences/built-in/show-replay-for-driver.json
@@ -3,7 +3,7 @@
   "name": "Show Replay for Driver",
   "version": "1.0.0",
   "description": "Jumps iRacing to an absolute session time for a specific driver on the replay scene, then automatically returns to live racing when the replay catches up.",
-  "category": "built-in",
+  "category": "builtin",
   "variables": [
     {
       "name": "driverNumber",

--- a/src/sequences/built-in/stream-introduction.json
+++ b/src/sequences/built-in/stream-introduction.json
@@ -3,7 +3,7 @@
   "name": "Stream Introduction",
   "version": "1.0.0",
   "description": "Opens the broadcast with driver overview and scenic cameras, then sends a welcome message to YouTube chat.",
-  "category": "built-in",
+  "category": "builtin",
   "variables": [],
   "steps": [
     {


### PR DESCRIPTION
- Update OpenAPI spec to match live API (PortableSequence, SequenceStep, SequenceVariable, intents query param, 204+Retry-After, 410 Gone)
- Fix MSAL scopes: use RC API scope (access_as_user) instead of User.Read
- Fix base URL: remove /api suffix that caused double /api in all requests
- Update director-service: send lastSequenceId+intents params, handle 410 Gone for ended sessions, parse Retry-After header, read totalDurationMs from metadata, normalize new PortableSequence format with legacy fallback
- Add getActiveIntents() for capability reporting to Race Control
- Rename category 'built-in' to 'builtin' across all files per spec
- Update SequenceVariable.type 'string'->'text', add 'cloud' source
- Harden run-electron.js: add --in-process-gpu flag, extend stderr filter for GPU/zygote/renderer_init noise in dev containers
- Remove noisy overlay server request logging
- Add rcApiScope config (env-overridable via VITE_RC_API_SCOPE)
- Update .env.example with correct base URL and RC API scope docs