### PR TITLE
feat: Remove legacy types and add cloud sequence library (#54, #55)

### DIFF
--- a/src/__tests__/contracts/portable-sequence.contract.test.ts
+++ b/src/__tests__/contracts/portable-sequence.contract.test.ts
@@ -10,10 +10,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   PortableSequence,
-  DirectorSequence,
-  normalizeApiSequence,
   SequenceStep,
 } from '../../main/director-types';
+import { normalizeApiResponse } from '../../main/normalizer';
 
 describe('PortableSequence Contract Tests', () => {
   describe('New format passthrough', () => {
@@ -79,167 +78,88 @@ describe('PortableSequence Contract Tests', () => {
     });
   });
 
-  describe('Legacy format conversion', () => {
-    it('should convert legacy commands array to PortableSequence with correct intents', () => {
-      const legacySeq: DirectorSequence = {
-        id: 'legacy-seq-1',
-        commands: [
+  describe('Normalizer passthrough for PortableSequence', () => {
+    it('should pass through a PortableSequence via normalizeApiResponse unchanged', () => {
+      const portableSeq: PortableSequence = {
+        id: 'normalizer-test-1',
+        name: 'Normalizer Test',
+        steps: [
           {
-            id: 'cmd-1',
-            type: 'WAIT',
+            id: 'step-1',
+            intent: 'system.wait',
             payload: { durationMs: 3000 },
           },
           {
-            id: 'cmd-2',
-            type: 'SWITCH_CAMERA',
-            payload: { carNumber: '5', cameraGroupNumber: 2 },
-          },
-          {
-            id: 'cmd-3',
-            type: 'SWITCH_OBS_SCENE',
-            payload: { sceneName: 'MainBroadcast' },
-          },
-          {
-            id: 'cmd-4',
-            type: 'LOG',
-            payload: { message: 'Sequence complete', level: 'INFO' },
+            id: 'step-2',
+            intent: 'broadcast.showLiveCam',
+            payload: { carNum: '5', camGroup: 2 },
           },
         ],
+        metadata: { source: 'ai-director', totalDurationMs: 15000 },
       };
 
-      const result = normalizeApiSequence(legacySeq);
+      const result = normalizeApiResponse(portableSeq);
 
-      // Verify normalized to PortableSequence format
-      expect(result.id).toBe('legacy-seq-1');
-      expect(result.steps).toBeDefined();
-      expect(Array.isArray(result.steps)).toBe(true);
-      expect(result.steps.length).toBe(4);
-
-      // Verify intents are correctly mapped
+      expect(result.id).toBe('normalizer-test-1');
+      expect(result.steps).toHaveLength(2);
       expect(result.steps[0].intent).toBe('system.wait');
       expect(result.steps[1].intent).toBe('broadcast.showLiveCam');
-      expect(result.steps[2].intent).toBe('obs.switchScene');
-      expect(result.steps[3].intent).toBe('system.log');
-
-      // Verify payloads are preserved
-      expect(result.steps[0].payload).toEqual({ durationMs: 3000 });
-      expect(result.steps[1].payload).toEqual({ carNumber: '5', cameraGroupNumber: 2 });
-      expect(result.steps[2].payload).toEqual({ sceneName: 'MainBroadcast' });
-      expect(result.steps[3].payload).toEqual({ message: 'Sequence complete', level: 'INFO' });
-    });
-
-    it('should convert DRIVER_TTS to communication.announce intent', () => {
-      const legacySeq: DirectorSequence = {
-        id: 'tts-seq',
-        commands: [
-          {
-            id: 'cmd-1',
-            type: 'DRIVER_TTS',
-            payload: { text: 'Good luck!', voiceId: 'en-US-1' },
-          },
-        ],
-      };
-
-      const result = normalizeApiSequence(legacySeq);
-
-      expect(result.steps[0].intent).toBe('communication.announce');
-      expect(result.steps[0].payload).toEqual({ text: 'Good luck!', voiceId: 'en-US-1' });
-    });
-
-    it('should convert VIEWER_CHAT to communication.talkToChat intent', () => {
-      const legacySeq: DirectorSequence = {
-        id: 'chat-seq',
-        commands: [
-          {
-            id: 'cmd-1',
-            type: 'VIEWER_CHAT',
-            payload: { platform: 'YOUTUBE', message: 'Welcome to the stream!' },
-          },
-        ],
-      };
-
-      const result = normalizeApiSequence(legacySeq);
-
-      expect(result.steps[0].intent).toBe('communication.talkToChat');
-      expect(result.steps[0].payload).toEqual({ platform: 'YOUTUBE', message: 'Welcome to the stream!' });
+      expect(result.steps[1].payload).toEqual({ carNum: '5', camGroup: 2 });
     });
   });
 
   describe('Required fields validation', () => {
-    it('should have id field after normalization', () => {
-      const legacySeq: DirectorSequence = {
+    it('should have id and steps fields on a valid PortableSequence', () => {
+      const seq: PortableSequence = {
         id: 'test-id-123',
-        commands: [
+        steps: [
           {
-            id: 'cmd-1',
-            type: 'LOG',
+            id: 'step-1',
+            intent: 'system.log',
             payload: { message: 'test', level: 'INFO' },
           },
         ],
       };
 
-      const result = normalizeApiSequence(legacySeq);
-
-      expect(result.id).toBe('test-id-123');
-      expect(typeof result.id).toBe('string');
-      expect(result.id.length).toBeGreaterThan(0);
+      expect(seq.id).toBe('test-id-123');
+      expect(typeof seq.id).toBe('string');
+      expect(seq.id.length).toBeGreaterThan(0);
+      expect(seq.steps).toBeDefined();
+      expect(Array.isArray(seq.steps)).toBe(true);
+      expect(seq.steps.length).toBeGreaterThan(0);
     });
 
-    it('should have steps field after normalization', () => {
-      const legacySeq: DirectorSequence = {
-        id: 'test-seq',
-        commands: [
-          {
-            id: 'cmd-1',
-            type: 'WAIT',
-            payload: { durationMs: 1000 },
-          },
-        ],
-      };
-
-      const result = normalizeApiSequence(legacySeq);
-
-      expect(result.steps).toBeDefined();
-      expect(Array.isArray(result.steps)).toBe(true);
-      expect(result.steps.length).toBeGreaterThan(0);
-    });
-
-    it('should preserve empty steps array', () => {
-      const legacySeq: DirectorSequence = {
+    it('should allow empty steps array', () => {
+      const seq: PortableSequence = {
         id: 'empty-seq',
-        commands: [],
+        steps: [],
       };
 
-      const result = normalizeApiSequence(legacySeq);
-
-      expect(result.steps).toBeDefined();
-      expect(Array.isArray(result.steps)).toBe(true);
-      expect(result.steps.length).toBe(0);
+      expect(seq.steps).toBeDefined();
+      expect(Array.isArray(seq.steps)).toBe(true);
+      expect(seq.steps.length).toBe(0);
     });
   });
 
   describe('Step shape validation', () => {
     it('should ensure each step has id, intent, and payload fields', () => {
-      const legacySeq: DirectorSequence = {
+      const seq: PortableSequence = {
         id: 'shape-test-seq',
-        commands: [
+        steps: [
           {
-            id: 'cmd-1',
-            type: 'WAIT',
+            id: 'step-1',
+            intent: 'system.wait',
             payload: { durationMs: 2000 },
           },
           {
-            id: 'cmd-2',
-            type: 'SWITCH_CAMERA',
-            payload: { carNumber: '3', cameraGroupNumber: 4 },
+            id: 'step-2',
+            intent: 'broadcast.showLiveCam',
+            payload: { carNum: '3', camGroup: 4 },
           },
         ],
       };
 
-      const result = normalizeApiSequence(legacySeq);
-
-      result.steps.forEach((step: SequenceStep) => {
-        // Required fields
+      seq.steps.forEach((step: SequenceStep) => {
         expect(step.id).toBeDefined();
         expect(typeof step.id).toBe('string');
 
@@ -251,70 +171,22 @@ describe('PortableSequence Contract Tests', () => {
         expect(step.payload).not.toBeNull();
       });
     });
-
-    it('should generate step IDs when missing in legacy format', () => {
-      const legacySeq: DirectorSequence = {
-        id: 'no-ids-seq',
-        commands: [
-          {
-            type: 'WAIT',
-            payload: { durationMs: 1000 },
-          } as any,
-          {
-            type: 'LOG',
-            payload: { message: 'test', level: 'INFO' },
-          } as any,
-        ],
-      };
-
-      const result = normalizeApiSequence(legacySeq);
-
-      expect(result.steps[0].id).toBe('step_0');
-      expect(result.steps[1].id).toBe('step_1');
-    });
   });
 
   describe('Canonical intent names', () => {
-    it('should resolve all standard intents correctly', () => {
-      const legacySeq: DirectorSequence = {
+    it('should use standard intent names in PortableSequence steps', () => {
+      const seq: PortableSequence = {
         id: 'intent-mapping-seq',
-        commands: [
-          {
-            id: 'cmd-1',
-            type: 'WAIT',
-            payload: { durationMs: 1000 },
-          },
-          {
-            id: 'cmd-2',
-            type: 'LOG',
-            payload: { message: 'test', level: 'INFO' },
-          },
-          {
-            id: 'cmd-3',
-            type: 'SWITCH_CAMERA',
-            payload: { carNumber: '1', cameraGroupNumber: 1 },
-          },
-          {
-            id: 'cmd-4',
-            type: 'SWITCH_OBS_SCENE',
-            payload: { sceneName: 'Scene1' },
-          },
-          {
-            id: 'cmd-5',
-            type: 'DRIVER_TTS',
-            payload: { text: 'Message', voiceId: 'voice-1' },
-          },
-          {
-            id: 'cmd-6',
-            type: 'VIEWER_CHAT',
-            payload: { platform: 'TWITCH', message: 'Hello' },
-          },
+        steps: [
+          { id: 's1', intent: 'system.wait', payload: { durationMs: 1000 } },
+          { id: 's2', intent: 'system.log', payload: { message: 'test', level: 'INFO' } },
+          { id: 's3', intent: 'broadcast.showLiveCam', payload: { carNum: '1', camGroup: 1 } },
+          { id: 's4', intent: 'obs.switchScene', payload: { sceneName: 'Scene1' } },
+          { id: 's5', intent: 'communication.announce', payload: { text: 'Message' } },
+          { id: 's6', intent: 'communication.talkToChat', payload: { platform: 'TWITCH', message: 'Hello' } },
         ],
       };
 
-      const result = normalizeApiSequence(legacySeq);
-
-      // Map of expected intent resolutions
       const expectedIntents = [
         'system.wait',
         'system.log',
@@ -324,30 +196,9 @@ describe('PortableSequence Contract Tests', () => {
         'communication.talkToChat',
       ];
 
-      result.steps.forEach((step, index) => {
+      seq.steps.forEach((step, index) => {
         expect(step.intent).toBe(expectedIntents[index]);
       });
-    });
-
-    it('should handle EXECUTE_INTENT by unwrapping to the specified intent', () => {
-      const legacySeq: DirectorSequence = {
-        id: 'execute-intent-seq',
-        commands: [
-          {
-            id: 'cmd-1',
-            type: 'EXECUTE_INTENT',
-            payload: {
-              intent: 'custom.myExtension.action',
-              payload: { customField: 'value' },
-            },
-          },
-        ],
-      };
-
-      const result = normalizeApiSequence(legacySeq);
-
-      expect(result.steps[0].intent).toBe('custom.myExtension.action');
-      expect(result.steps[0].payload).toEqual({ customField: 'value' });
     });
   });
 
@@ -424,44 +275,38 @@ describe('PortableSequence Contract Tests', () => {
       expect(portableSeq.steps[1].payload).toHaveProperty('message');
     });
 
-    it('should accept legacy field names for backward compatibility during normalization', () => {
-      // When normalizing from legacy format, the API may use old field names
-      // The normalizer should pass them through (payload transformation is executor's job)
-      const legacySeq: DirectorSequence = {
-        id: 'legacy-fields-seq',
-        commands: [
+    it('should document canonical field names for camera payloads', () => {
+      // The canonical PortableSequence format uses carNum/camGroup (not carNumber/cameraGroupNumber)
+      const seq: PortableSequence = {
+        id: 'canonical-fields-seq',
+        steps: [
           {
-            id: 'cmd-1',
-            type: 'SWITCH_CAMERA',
-            payload: { carNumber: '42', cameraGroupNumber: 2 },
+            id: 'step-1',
+            intent: 'broadcast.showLiveCam',
+            payload: { carNum: '42', camGroup: 2 },
           },
         ],
       };
 
-      const result = normalizeApiSequence(legacySeq);
-
-      // Normalizer preserves payload as-is, including legacy field names
-      expect(result.steps[0].payload).toHaveProperty('carNumber');
-      expect(result.steps[0].payload).toHaveProperty('cameraGroupNumber');
+      expect(seq.steps[0].payload).toHaveProperty('carNum');
+      expect(seq.steps[0].payload).toHaveProperty('camGroup');
+      expect(seq.steps[0].payload).not.toHaveProperty('carNumber');
+      expect(seq.steps[0].payload).not.toHaveProperty('cameraGroupNumber');
     });
   });
 
   describe('Malformed sequence rejection', () => {
-    it('should handle sequence without steps or commands gracefully', () => {
+    it('should handle sequence without steps gracefully', () => {
       const malformedSeq = {
         id: 'malformed-seq',
-        // Missing both 'steps' and 'commands'
+        // Missing 'steps'
       } as any;
 
       // The Director should detect this and handle it
-      // For now, we verify that a proper sequence has the required structure
       expect(malformedSeq.steps).toBeUndefined();
-      expect(malformedSeq.commands).toBeUndefined();
 
       // This would be caught by runtime validation before execution
-      const hasValidFormat =
-        Array.isArray(malformedSeq.steps) ||
-        Array.isArray(malformedSeq.commands);
+      const hasValidFormat = Array.isArray(malformedSeq.steps);
 
       expect(hasValidFormat).toBe(false);
     });

--- a/src/main/auth-config.ts
+++ b/src/main/auth-config.ts
@@ -43,6 +43,7 @@ export const apiConfig = {
     userProfile: '/api/auth/user',
     listSessions: '/api/director/v1/sessions',
     nextSequence: (sessionId: string) => `/api/director/v1/sessions/${sessionId}/sequences/next`,
+    listSequences: '/api/director/v1/sequences',
     getSequence: (sequenceId: string) => `/api/director/v1/sequences/${sequenceId}`,
     tts: '/api/tts',
     checkin: (sessionId: string) => `/api/director/v1/sessions/${sessionId}/checkin`,

--- a/src/main/cloud-poller.ts
+++ b/src/main/cloud-poller.ts
@@ -265,8 +265,7 @@ export class CloudPoller {
         { sessionId: this.raceSessionId }
       );
 
-      // Normalize API response — handles both new PortableSequence format (steps/intent)
-      // and legacy DirectorSequence format (commands/commandType) for backward compatibility
+      // Normalize API response — validates PortableSequence format (steps/intent)
       const portable = normalizeApiResponse(sequenceData);
 
       telemetryService.trackEvent('Sequence.Received', {

--- a/src/main/director-types.test.ts
+++ b/src/main/director-types.test.ts
@@ -1,355 +1,86 @@
 /**
- * Unit tests for director-types normalization functions
+ * Unit tests for director-types
+ *
+ * Validates the PortableSequence type structures are correct.
+ * Legacy normalization functions have been removed — see normalizer.test.ts.
  */
 import { describe, it, expect } from 'vitest';
 import {
-  normalizeApiSequence,
-  normalizeNextSequenceResponse,
-  DirectorCommand,
-  DirectorSequence,
-  GetNextSequenceResponse,
-  WaitCommand,
-  LogCommand,
-  SwitchCameraCommand,
-  SwitchObsSceneCommand,
-  DriverTtsCommand,
-  ViewerChatCommand,
-  ExecuteIntentCommand,
+  PortableSequence,
+  SequenceStep,
+  SequenceVariable,
 } from './director-types';
 
-describe('normalizeCommand', () => {
-  it('should convert WAIT command to system.wait intent', () => {
-    const legacy: DirectorSequence = {
-      id: 'seq-1',
-      commands: [
-        {
-          id: 'cmd-1',
-          type: 'WAIT',
-          payload: { durationMs: 5000 },
-        } as WaitCommand,
-      ],
-    };
-
-    const result = normalizeApiSequence(legacy);
-
-    expect(result.steps[0]).toEqual({
-      id: 'cmd-1',
-      intent: 'system.wait',
-      payload: { durationMs: 5000 },
-    });
-  });
-
-  it('should convert LOG command to system.log intent', () => {
-    const legacy: DirectorSequence = {
-      id: 'seq-2',
-      commands: [
-        {
-          id: 'cmd-2',
-          type: 'LOG',
-          payload: { message: 'Test log', level: 'INFO' },
-        } as LogCommand,
-      ],
-    };
-
-    const result = normalizeApiSequence(legacy);
-
-    expect(result.steps[0]).toEqual({
-      id: 'cmd-2',
-      intent: 'system.log',
-      payload: { message: 'Test log', level: 'INFO' },
-    });
-  });
-
-  it('should convert SWITCH_CAMERA to broadcast.showLiveCam intent', () => {
-    const legacy: DirectorSequence = {
-      id: 'seq-3',
-      commands: [
-        {
-          id: 'cmd-3',
-          type: 'SWITCH_CAMERA',
-          payload: { carNumber: '42', cameraGroupNumber: 1 },
-        } as SwitchCameraCommand,
-      ],
-    };
-
-    const result = normalizeApiSequence(legacy);
-
-    expect(result.steps[0]).toEqual({
-      id: 'cmd-3',
-      intent: 'broadcast.showLiveCam',
-      payload: { carNumber: '42', cameraGroupNumber: 1 },
-    });
-  });
-
-  it('should convert SWITCH_OBS_SCENE to obs.switchScene intent', () => {
-    const legacy: DirectorSequence = {
-      id: 'seq-4',
-      commands: [
-        {
-          id: 'cmd-4',
-          type: 'SWITCH_OBS_SCENE',
-          payload: { sceneName: 'MainScene', transition: 'Fade' },
-        } as SwitchObsSceneCommand,
-      ],
-    };
-
-    const result = normalizeApiSequence(legacy);
-
-    expect(result.steps[0]).toEqual({
-      id: 'cmd-4',
-      intent: 'obs.switchScene',
-      payload: { sceneName: 'MainScene', transition: 'Fade' },
-    });
-  });
-
-  it('should convert DRIVER_TTS to communication.announce intent', () => {
-    const legacy: DirectorSequence = {
-      id: 'seq-5',
-      commands: [
-        {
-          id: 'cmd-5',
-          type: 'DRIVER_TTS',
-          payload: { text: 'Hello driver', voiceId: 'voice-1' },
-        } as DriverTtsCommand,
-      ],
-    };
-
-    const result = normalizeApiSequence(legacy);
-
-    expect(result.steps[0]).toEqual({
-      id: 'cmd-5',
-      intent: 'communication.announce',
-      payload: { text: 'Hello driver', voiceId: 'voice-1' },
-    });
-  });
-
-  it('should convert VIEWER_CHAT to communication.talkToChat intent', () => {
-    const legacy: DirectorSequence = {
-      id: 'seq-6',
-      commands: [
-        {
-          id: 'cmd-6',
-          type: 'VIEWER_CHAT',
-          payload: { platform: 'YOUTUBE', message: 'Hello viewers!' },
-        } as ViewerChatCommand,
-      ],
-    };
-
-    const result = normalizeApiSequence(legacy);
-
-    expect(result.steps[0]).toEqual({
-      id: 'cmd-6',
-      intent: 'communication.talkToChat',
-      payload: { platform: 'YOUTUBE', message: 'Hello viewers!' },
-    });
-  });
-
-  it('should unwrap EXECUTE_INTENT and use the intent directly', () => {
-    const legacy: DirectorSequence = {
-      id: 'seq-7',
-      commands: [
-        {
-          id: 'cmd-7',
-          type: 'EXECUTE_INTENT',
-          payload: {
-            intent: 'custom.action',
-            payload: { customData: 'test' },
-          },
-        } as ExecuteIntentCommand,
-      ],
-    };
-
-    const result = normalizeApiSequence(legacy);
-
-    expect(result.steps[0]).toEqual({
-      id: 'cmd-7',
-      intent: 'custom.action',
-      payload: { customData: 'test' },
-    });
-  });
-
-  it('should handle unknown command types by creating a warning log step', () => {
-    const legacy: DirectorSequence = {
-      id: 'seq-8',
-      commands: [
-        {
-          id: 'cmd-8',
-          type: 'UNKNOWN_TYPE',
-          payload: {},
-        } as any,
-      ],
-    };
-
-    const result = normalizeApiSequence(legacy);
-
-    expect(result.steps[0]).toEqual({
-      id: 'cmd-8',
-      intent: 'system.log',
-      payload: {
-        message: 'Unknown legacy command type: UNKNOWN_TYPE',
-        level: 'WARN',
-      },
-    });
-  });
-
-  it('should generate step IDs when not provided', () => {
-    const legacy: DirectorSequence = {
-      id: 'seq-9',
-      commands: [
-        {
-          type: 'WAIT',
-          payload: { durationMs: 1000 },
-        } as any,
-      ],
-    };
-
-    const result = normalizeApiSequence(legacy);
-
-    expect(result.steps[0].id).toBe('step_0');
-  });
-});
-
-describe('normalizeApiSequence', () => {
-  it('should convert full legacy sequence to PortableSequence', () => {
-    const legacy: DirectorSequence = {
-      id: 'full-seq-1',
-      commands: [
-        {
-          id: 'cmd-1',
-          type: 'LOG',
-          payload: { message: 'Starting sequence', level: 'INFO' },
-        } as LogCommand,
-        {
-          id: 'cmd-2',
-          type: 'WAIT',
-          payload: { durationMs: 2000 },
-        } as WaitCommand,
-        {
-          id: 'cmd-3',
-          type: 'SWITCH_CAMERA',
-          payload: { carNumber: '5', cameraGroupNumber: 3 },
-        } as SwitchCameraCommand,
-      ],
-      metadata: {
-        source: 'test',
-        priority: 'NORMAL',
-      },
-    };
-
-    const result = normalizeApiSequence(legacy);
-
-    expect(result).toEqual({
-      id: 'full-seq-1',
+describe('PortableSequence type contracts', () => {
+  it('should accept a minimal PortableSequence', () => {
+    const seq: PortableSequence = {
+      id: 'test-seq-1',
       steps: [
         {
-          id: 'cmd-1',
-          intent: 'system.log',
-          payload: { message: 'Starting sequence', level: 'INFO' },
-        },
-        {
-          id: 'cmd-2',
+          id: 'step-1',
           intent: 'system.wait',
-          payload: { durationMs: 2000 },
-        },
-        {
-          id: 'cmd-3',
-          intent: 'broadcast.showLiveCam',
-          payload: { carNumber: '5', cameraGroupNumber: 3 },
+          payload: { durationMs: 1000 },
         },
       ],
-      metadata: {
-        source: 'test',
-        priority: 'NORMAL',
-      },
-    });
-  });
-
-  it('should preserve metadata when converting sequences', () => {
-    const legacy: DirectorSequence = {
-      id: 'seq-meta',
-      commands: [],
-      metadata: {
-        author: 'test-user',
-        version: 1,
-        tags: ['test', 'demo'],
-      },
     };
 
-    const result = normalizeApiSequence(legacy);
-
-    expect(result.metadata).toEqual({
-      author: 'test-user',
-      version: 1,
-      tags: ['test', 'demo'],
-    });
+    expect(seq.id).toBe('test-seq-1');
+    expect(seq.steps).toHaveLength(1);
+    expect(seq.steps[0].intent).toBe('system.wait');
   });
-});
 
-describe('normalizeNextSequenceResponse', () => {
-  it('should convert poll response to PortableSequence', () => {
-    const response: GetNextSequenceResponse = {
-      sequenceId: 'poll-seq-1',
-      createdAt: '2026-04-01T12:00:00Z',
-      priority: 'HIGH',
-      commands: [
+  it('should accept a full PortableSequence with all optional fields', () => {
+    const seq: PortableSequence = {
+      id: 'full-seq',
+      name: 'Full Sequence',
+      version: '1.0.0',
+      description: 'A fully-populated sequence',
+      category: 'builtin',
+      priority: true,
+      variables: [
         {
-          id: 'cmd-1',
-          type: 'LOG',
-          payload: { message: 'Priority sequence', level: 'INFO' },
-        } as LogCommand,
+          name: 'targetDriver',
+          label: 'Target Driver',
+          type: 'text',
+          required: true,
+        },
       ],
-      totalDurationMs: 5000,
-    };
-
-    const result = normalizeNextSequenceResponse(response);
-
-    expect(result).toEqual({
-      id: 'poll-seq-1',
       steps: [
         {
-          id: 'cmd-1',
-          intent: 'system.log',
-          payload: { message: 'Priority sequence', level: 'INFO' },
+          id: 'step-1',
+          intent: 'broadcast.showLiveCam',
+          payload: { carNum: '42', camGroup: 1 },
+          metadata: { label: 'Show driver camera', timeout: 5000 },
         },
       ],
-      metadata: { priority: 'HIGH' },
+      metadata: { source: 'ai-director', totalDurationMs: 15000 },
+    };
+
+    expect(seq.name).toBe('Full Sequence');
+    expect(seq.priority).toBe(true);
+    expect(seq.variables).toHaveLength(1);
+    expect(seq.steps[0].metadata?.label).toBe('Show driver camera');
+  });
+
+  it('should support all category values', () => {
+    const categories: PortableSequence['category'][] = ['builtin', 'cloud', 'custom'];
+    categories.forEach((cat) => {
+      const seq: PortableSequence = { id: `cat-${cat}`, steps: [], category: cat };
+      expect(seq.category).toBe(cat);
     });
   });
 
-  it('should extract priority from response into metadata', () => {
-    const response: GetNextSequenceResponse = {
-      sequenceId: 'urgent-seq',
-      createdAt: '2026-04-01T12:00:00Z',
-      priority: 'URGENT',
-      commands: [
-        {
-          id: 'cmd-1',
-          type: 'WAIT',
-          payload: { durationMs: 100 },
-        } as WaitCommand,
-      ],
+  it('should support variable types', () => {
+    const variable: SequenceVariable = {
+      name: 'delay',
+      label: 'Delay Time',
+      type: 'number',
+      required: false,
+      default: 5000,
+      constraints: { min: 1000, max: 30000 },
     };
 
-    const result = normalizeNextSequenceResponse(response);
-
-    expect(result.metadata).toEqual({ priority: 'URGENT' });
-  });
-
-  it('should handle response without priority', () => {
-    const response: GetNextSequenceResponse = {
-      sequenceId: 'no-priority-seq',
-      createdAt: '2026-04-01T12:00:00Z',
-      commands: [
-        {
-          id: 'cmd-1',
-          type: 'LOG',
-          payload: { message: 'No priority', level: 'INFO' },
-        } as LogCommand,
-      ],
-    };
-
-    const result = normalizeNextSequenceResponse(response);
-
-    expect(result.metadata).toEqual({ priority: undefined });
+    expect(variable.type).toBe('number');
+    expect(variable.constraints?.min).toBe(1000);
   });
 });

--- a/src/main/director-types.ts
+++ b/src/main/director-types.ts
@@ -136,115 +136,9 @@ export interface EventCatalogEntry {
   payloadSchema?: Record<string, unknown>;
 }
 
-// ============================================================================
-// LEGACY: API-Compatible Types
-// Kept for backward compatibility with the Race Control OpenAPI spec.
-// The normalizeApiSequence() function converts these to PortableSequence.
-// ============================================================================
-
-export type CommandType = 'WAIT' | 'LOG' | 'SWITCH_CAMERA' | 'SWITCH_OBS_SCENE' | 'DRIVER_TTS' | 'VIEWER_CHAT' | 'EXECUTE_INTENT';
-
 export type LogLevel = 'INFO' | 'WARN' | 'ERROR';
 
 export type DirectorStatus = 'IDLE' | 'BUSY' | 'ERROR';
-
-// --- Command Payloads ---
-
-export interface WaitCommandPayload {
-  durationMs: number;
-}
-
-export interface LogCommandPayload {
-  message: string;
-  level: LogLevel;
-}
-
-export interface SwitchCameraCommandPayload {
-  carNumber: string;
-  cameraGroupNumber: number;
-  cameraGroupName?: string;
-}
-
-export interface SwitchObsSceneCommandPayload {
-  sceneName: string;
-  transition?: string;
-  duration?: number;
-}
-
-export interface DriverTtsCommandPayload {
-  text: string;
-  voiceId?: string;
-  channelId?: string;
-}
-
-export interface ExecuteIntentCommandPayload {
-  intent: string;
-  payload: any;
-}
-
-export interface ViewerChatCommandPayload {
-  platform: 'YOUTUBE' | 'TWITCH';
-  message: string;
-}
-
-// --- Commands ---
-
-export interface BaseCommand {
-  id: string;
-  type: CommandType;
-}
-
-export interface WaitCommand extends BaseCommand {
-  type: 'WAIT';
-  payload: WaitCommandPayload;
-}
-
-export interface LogCommand extends BaseCommand {
-  type: 'LOG';
-  payload: LogCommandPayload;
-}
-
-export interface SwitchCameraCommand extends BaseCommand {
-  type: 'SWITCH_CAMERA';
-  payload: SwitchCameraCommandPayload;
-}
-
-export interface SwitchObsSceneCommand extends BaseCommand {
-  type: 'SWITCH_OBS_SCENE';
-  payload: SwitchObsSceneCommandPayload;
-}
-
-export interface DriverTtsCommand extends BaseCommand {
-  type: 'DRIVER_TTS';
-  payload: DriverTtsCommandPayload;
-}
-
-export interface ViewerChatCommand extends BaseCommand {
-  type: 'VIEWER_CHAT';
-  payload: ViewerChatCommandPayload;
-}
-
-export interface ExecuteIntentCommand extends BaseCommand {
-  type: 'EXECUTE_INTENT';
-  payload: ExecuteIntentCommandPayload;
-}
-
-export type DirectorCommand = 
-  | WaitCommand 
-  | LogCommand 
-  | SwitchCameraCommand 
-  | SwitchObsSceneCommand 
-  | DriverTtsCommand 
-  | ViewerChatCommand
-  | ExecuteIntentCommand;
-
-// --- Sequences ---
-
-export interface DirectorSequence {
-  id: string;
-  commands: DirectorCommand[];
-  metadata?: Record<string, unknown>;
-}
 
 // --- API Responses ---
 
@@ -309,20 +203,6 @@ export interface ActiveSessionResponse {
   name: string;
 }
 
-export type SequencePriority = 'LOW' | 'NORMAL' | 'HIGH' | 'URGENT';
-
-/**
- * @deprecated The /sequences/next endpoint now returns PortableSequence directly.
- * Kept for backward compatibility with any remaining code paths.
- */
-export interface GetNextSequenceResponse {
-  sequenceId: string;
-  createdAt: string;
-  priority?: SequencePriority;
-  commands: DirectorCommand[];
-  totalDurationMs?: number;
-}
-
 // --- Extension Protocol ---
 
 export type ExtensionMessageType = 'EXTENSION_INTENT' | 'EXTENSION_EVENT' | 'EXTENSION_STATUS';
@@ -348,82 +228,6 @@ export interface ExtensionEventMessage extends ExtensionMessage {
 export interface ExtensionStatusMessage extends ExtensionMessage {
   type: 'EXTENSION_STATUS';
   data: Record<string, { active: boolean; [key: string]: any }>;
-}
-
-// ============================================================================
-// API Normalizer
-// Converts legacy DirectorCommand[] (from Race Control API) into the
-// PortableSequence format consumed by the Sequence Executor.
-// ============================================================================
-
-/**
- * Intent mappings for legacy CommandType values.
- * Maps the old enum-based command types to the semantic intent names
- * registered by extensions in their package.json manifests.
- */
-const LEGACY_INTENT_MAP: Record<string, string> = {
-  'SWITCH_CAMERA': 'broadcast.showLiveCam',
-  'SWITCH_OBS_SCENE': 'obs.switchScene',
-  'DRIVER_TTS': 'communication.announce',
-  'VIEWER_CHAT': 'communication.talkToChat',
-};
-
-/**
- * Normalizes a single legacy DirectorCommand into a SequenceStep.
- */
-function normalizeCommand(cmd: DirectorCommand, index: number): SequenceStep {
-  const id = cmd.id || `step_${index}`;
-
-  switch (cmd.type) {
-    case 'WAIT':
-      return { id, intent: 'system.wait', payload: { ...cmd.payload } };
-    case 'LOG':
-      return { id, intent: 'system.log', payload: { ...cmd.payload } };
-    case 'EXECUTE_INTENT': {
-      // Already intent-based, unwrap
-      const intentPayload = cmd.payload as ExecuteIntentCommandPayload;
-      return {
-        id,
-        intent: intentPayload.intent,
-        payload: (intentPayload.payload ?? {}) as Record<string, unknown>,
-      };
-    }
-    default: {
-      // Map legacy command type to a semantic intent
-      const intent = LEGACY_INTENT_MAP[cmd.type];
-      if (intent) {
-        return { id, intent, payload: { ...cmd.payload } };
-      }
-      // Unknown command — log a warning step
-      return {
-        id,
-        intent: 'system.log',
-        payload: { message: `Unknown legacy command type: ${cmd.type}`, level: 'WARN' },
-      };
-    }
-  }
-}
-
-/**
- * Normalizes a legacy DirectorSequence (from API) into a PortableSequence.
- */
-export function normalizeApiSequence(legacy: DirectorSequence): PortableSequence {
-  return {
-    id: legacy.id,
-    steps: legacy.commands.map((cmd, i) => normalizeCommand(cmd, i)),
-    metadata: legacy.metadata,
-  };
-}
-
-/**
- * Normalizes a GetNextSequenceResponse (from polling API) into a PortableSequence.
- */
-export function normalizeNextSequenceResponse(response: GetNextSequenceResponse): PortableSequence {
-  return {
-    id: response.sequenceId,
-    steps: response.commands.map((cmd, i) => normalizeCommand(cmd, i)),
-    metadata: { priority: response.priority },
-  };
 }
 
 // ============================================================================

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -120,8 +120,9 @@ app.on('ready', () => {
   });
 
   // Initialize Sequence Executor & Scheduler (must be before DirectorOrchestrator)
-  sequenceExecutor = new SequenceExecutor(extensionHost);
-  sequenceLibrary = new SequenceLibraryService(capabilityCatalog);
+  sequenceExecutor = new SequenceExecutor(extensionHost, overlayBus);
+  sequenceLibrary = new SequenceLibraryService(capabilityCatalog, authService);
+  sequenceExecutor.setSequenceLibrary(sequenceLibrary);
   sequenceScheduler = new SequenceScheduler(sequenceExecutor);
 
   // Initialize Director Orchestrator — no longer depends on ObsService directly.

--- a/src/main/normalizer.test.ts
+++ b/src/main/normalizer.test.ts
@@ -94,8 +94,8 @@ describe('normalizeApiResponse', () => {
     });
   });
 
-  describe('Legacy API format (commands)', () => {
-    it('should convert WAIT command to system.wait intent', () => {
+  describe('Legacy API format rejection', () => {
+    it('should return empty steps for legacy commands format', () => {
       const apiData = {
         id: 'seq-legacy-1',
         commands: [
@@ -109,275 +109,12 @@ describe('normalizeApiResponse', () => {
 
       const result = normalizeApiResponse(apiData);
 
-      expect(result.steps[0]).toEqual({
-        id: 'cmd-1',
-        intent: 'system.wait',
-        payload: { durationMs: 5000 },
-      });
+      expect(result.id).toBe('seq-legacy-1');
+      expect(result.steps).toEqual([]);
+      expect(result.metadata).toEqual({ error: 'Legacy format not supported' });
     });
 
-    it('should convert WAIT command with durationMs at top level', () => {
-      const apiData = {
-        id: 'seq-legacy-2',
-        commands: [
-          {
-            id: 'cmd-1',
-            type: 'WAIT',
-            durationMs: 3000,
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0]).toEqual({
-        id: 'cmd-1',
-        intent: 'system.wait',
-        payload: { durationMs: 3000 },
-      });
-    });
-
-    it('should convert LOG command to system.log intent', () => {
-      const apiData = {
-        id: 'seq-legacy-3',
-        commands: [
-          {
-            id: 'cmd-2',
-            type: 'LOG',
-            payload: { message: 'Test log', level: 'WARN' },
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0]).toEqual({
-        id: 'cmd-2',
-        intent: 'system.log',
-        payload: { message: 'Test log', level: 'WARN' },
-      });
-    });
-
-    it('should convert LOG command with message/level at top level', () => {
-      const apiData = {
-        id: 'seq-legacy-4',
-        commands: [
-          {
-            id: 'cmd-2',
-            type: 'LOG',
-            message: 'Direct message',
-            level: 'ERROR',
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0].payload).toEqual({
-        message: 'Direct message',
-        level: 'ERROR',
-      });
-    });
-
-    it('should unwrap EXECUTE_INTENT command', () => {
-      const apiData = {
-        id: 'seq-legacy-5',
-        commands: [
-          {
-            id: 'cmd-3',
-            type: 'EXECUTE_INTENT',
-            payload: {
-              intent: 'custom.action',
-              payload: { foo: 'bar' },
-            },
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0]).toEqual({
-        id: 'cmd-3',
-        intent: 'custom.action',
-        payload: { foo: 'bar' },
-      });
-    });
-
-    it('should convert SWITCH_CAMERA to broadcast.showLiveCam intent', () => {
-      const apiData = {
-        id: 'seq-legacy-6',
-        commands: [
-          {
-            id: 'cmd-4',
-            type: 'SWITCH_CAMERA',
-            target: {
-              carNumber: 42,
-              cameraGroup: 3,
-            },
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0]).toEqual({
-        id: 'cmd-4',
-        intent: 'broadcast.showLiveCam',
-        payload: {
-          carNum: '42',
-          camGroup: '3',
-          carNumber: 42,
-          cameraGroup: 3,
-        },
-      });
-    });
-
-    it('should convert SWITCH_OBS_SCENE to obs.switchScene intent', () => {
-      const apiData = {
-        id: 'seq-legacy-7',
-        commands: [
-          {
-            id: 'cmd-5',
-            type: 'SWITCH_OBS_SCENE',
-            target: {
-              obsSceneId: 'MainScene',
-            },
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0]).toEqual({
-        id: 'cmd-5',
-        intent: 'obs.switchScene',
-        payload: {
-          sceneName: 'MainScene',
-          obsSceneId: 'MainScene',
-        },
-      });
-    });
-
-    it('should prefer sceneName over obsSceneId', () => {
-      const apiData = {
-        id: 'seq-legacy-8',
-        commands: [
-          {
-            id: 'cmd-5',
-            type: 'SWITCH_OBS_SCENE',
-            target: {
-              obsSceneId: 'OldName',
-              sceneName: 'NewName',
-            },
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0].payload.sceneName).toBe('NewName');
-    });
-
-    it('should convert DRIVER_TTS to communication.announce intent', () => {
-      const apiData = {
-        id: 'seq-legacy-9',
-        commands: [
-          {
-            id: 'cmd-6',
-            type: 'DRIVER_TTS',
-            payload: { text: 'Hello driver' },
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0]).toEqual({
-        id: 'cmd-6',
-        intent: 'communication.announce',
-        payload: { text: 'Hello driver' },
-      });
-    });
-
-    it('should convert VIEWER_CHAT to communication.talkToChat intent', () => {
-      const apiData = {
-        id: 'seq-legacy-10',
-        commands: [
-          {
-            id: 'cmd-7',
-            type: 'VIEWER_CHAT',
-            payload: { message: 'Hello viewers!', platform: 'YOUTUBE' },
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0]).toEqual({
-        id: 'cmd-7',
-        intent: 'communication.talkToChat',
-        payload: { message: 'Hello viewers!', platform: 'YOUTUBE' },
-      });
-    });
-
-    it('should handle unknown command types with warning log', () => {
-      const apiData = {
-        id: 'seq-legacy-11',
-        commands: [
-          {
-            id: 'cmd-8',
-            type: 'UNKNOWN_TYPE',
-            payload: {},
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0]).toEqual({
-        id: 'cmd-8',
-        intent: 'system.log',
-        payload: {
-          message: 'Unknown API command type: UNKNOWN_TYPE',
-          level: 'WARN',
-        },
-      });
-    });
-
-    it('should handle commandType field instead of type', () => {
-      const apiData = {
-        id: 'seq-legacy-12',
-        commands: [
-          {
-            id: 'cmd-9',
-            commandType: 'WAIT',
-            payload: { durationMs: 2000 },
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0].intent).toBe('system.wait');
-    });
-
-    it('should generate step IDs when missing in legacy format', () => {
-      const apiData = {
-        id: 'seq-legacy-13',
-        commands: [
-          {
-            type: 'WAIT',
-            payload: { durationMs: 1000 },
-          },
-        ],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps[0].id).toBeTruthy();
-    });
-
-    it('should use sequenceId as ID if id field is missing', () => {
+    it('should use sequenceId as ID for legacy poll responses', () => {
       const apiData = {
         sequenceId: 'from-poll-response',
         commands: [],
@@ -386,62 +123,11 @@ describe('normalizeApiResponse', () => {
       const result = normalizeApiResponse(apiData);
 
       expect(result.id).toBe('from-poll-response');
-    });
-
-    it('should extract metadata from legacy format', () => {
-      const apiData = {
-        id: 'seq-legacy-14',
-        name: 'Legacy Sequence',
-        priority: 'HIGH',
-        generatedAt: '2026-04-01T12:00:00Z',
-        totalDurationMs: 10000,
-        commands: [],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.name).toBe('Legacy Sequence');
-      expect(result.metadata).toEqual({
-        priority: 'HIGH',
-        generatedAt: '2026-04-01T12:00:00Z',
-        totalDurationMs: 10000,
-      });
-    });
-
-    it('should extract metadata from nested metadata field', () => {
-      const apiData = {
-        id: 'seq-legacy-15',
-        commands: [],
-        metadata: {
-          generatedAt: '2026-04-01T13:00:00Z',
-          totalDurationMs: 5000,
-          author: 'test',
-        },
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.metadata).toEqual({
-        priority: undefined,
-        generatedAt: '2026-04-01T13:00:00Z',
-        totalDurationMs: 5000,
-      });
+      expect(result.steps).toEqual([]);
     });
   });
 
   describe('Edge cases', () => {
-    it('should handle empty commands array', () => {
-      const apiData = {
-        id: 'seq-empty',
-        commands: [],
-      };
-
-      const result = normalizeApiResponse(apiData);
-
-      expect(result.steps).toEqual([]);
-      expect(result.id).toBe('seq-empty');
-    });
-
     it('should handle empty steps array', () => {
       const apiData = {
         id: 'seq-empty-steps',
@@ -453,9 +139,9 @@ describe('normalizeApiResponse', () => {
       expect(result.steps).toEqual([]);
     });
 
-    it('should generate ID when completely missing', () => {
+    it('should generate ID when completely missing from steps format', () => {
       const apiData = {
-        commands: [],
+        steps: [],
       };
 
       const result = normalizeApiResponse(apiData);
@@ -464,31 +150,14 @@ describe('normalizeApiResponse', () => {
       expect(typeof result.id).toBe('string');
     });
 
-    it('should handle mixed command and target fields', () => {
+    it('should return empty steps for data with no steps or commands', () => {
       const apiData = {
-        id: 'seq-mixed',
-        commands: [
-          {
-            id: 'cmd-1',
-            type: 'SWITCH_CAMERA',
-            payload: { existingField: 'value' },
-            target: {
-              carNumber: 10,
-              cameraGroup: 2,
-            },
-          },
-        ],
+        id: 'no-data',
       };
 
       const result = normalizeApiResponse(apiData);
 
-      // Target fields should be merged with payload
-      expect(result.steps[0].payload).toEqual({
-        carNum: '10',
-        camGroup: '2',
-        carNumber: 10,
-        cameraGroup: 2,
-      });
+      expect(result.steps).toEqual([]);
     });
   });
 });

--- a/src/main/normalizer.ts
+++ b/src/main/normalizer.ts
@@ -1,40 +1,18 @@
 /**
  * normalizer.ts
  *
- * Consolidates all API response normalization logic into a single function.
- * Handles both new PortableSequence format (with `steps` and semantic `intent` fields)
- * and legacy DirectorSequence format (with `commands` and `commandType` fields).
- *
- * This replaces the three separate normalization implementations:
- * 1. DirectorService.normalizeApiResponse() (private method)
- * 2. normalizeApiSequence() (in director-types.ts)
- * 3. normalizeNextSequenceResponse() (in director-types.ts)
+ * Validates and normalizes API responses into PortableSequence format.
+ * The Race Control API now returns PortableSequence directly (with `steps`).
  */
 
 import { randomUUID } from 'crypto';
 import { PortableSequence, SequenceStep } from './director-types';
 
 /**
- * Intent mappings for legacy API CommandType values.
- * Maps the old enum-based command types from the OpenAPI spec
- * to the semantic intent names registered by extensions.
- */
-const LEGACY_INTENT_MAP: Record<string, string> = {
-  'SWITCH_CAMERA': 'broadcast.showLiveCam',
-  'SWITCH_OBS_SCENE': 'obs.switchScene',
-  'DRIVER_TTS': 'communication.announce',
-  'VIEWER_CHAT': 'communication.talkToChat',
-  'PLAY_AUDIO': 'audio.play',          // Future
-  'SHOW_OVERLAY': 'overlay.show',       // Future
-  'HIDE_OVERLAY': 'overlay.hide',       // Future
-};
-
-/**
  * Normalizes a raw API response into a PortableSequence.
  *
- * Supports two formats:
- * 1. **New format**: API returns PortableSequence directly with `steps` and semantic `intent` fields
- * 2. **Legacy format**: API returns DirectorSequence/GetNextSequenceResponse with `commands` and `commandType` fields
+ * Expects the new PortableSequence format with `steps` and semantic `intent` fields.
+ * Logs an error and returns a no-op sequence if the response is in the legacy format.
  *
  * @param apiData - Raw API response (any structure)
  * @returns PortableSequence - Normalized sequence ready for execution
@@ -60,77 +38,12 @@ export function normalizeApiResponse(apiData: any): PortableSequence {
     };
   }
 
-  // Legacy format: API returned DirectorSequence/GetNextSequenceResponse with `commands`
-  console.warn('[Normalizer] Received legacy API format with commands[] — normalizing to PortableSequence');
-  const commands: any[] = apiData.commands || [];
-
-  const steps: SequenceStep[] = commands.map((cmd: any, index: number) => {
-    const type = cmd.commandType || cmd.type;
-    const id = cmd.id || randomUUID();
-
-    // Handle WAIT
-    if (type === 'WAIT') {
-      const durationMs = cmd.payload?.durationMs ?? cmd.durationMs ?? 0;
-      return { id, intent: 'system.wait', payload: { durationMs } };
-    }
-
-    // Handle LOG
-    if (type === 'LOG') {
-      const payload = cmd.payload || { message: cmd.message || '', level: cmd.level || 'INFO' };
-      return { id, intent: 'system.log', payload };
-    }
-
-    // Handle EXECUTE_INTENT (already intent-based, unwrap)
-    if (type === 'EXECUTE_INTENT') {
-      return {
-        id,
-        intent: cmd.payload?.intent || 'system.log',
-        payload: cmd.payload?.payload || {},
-      };
-    }
-
-    // Map legacy command types to semantic intents
-    const intent = LEGACY_INTENT_MAP[type];
-    if (intent) {
-      let payload = cmd.payload || {};
-
-      if (cmd.target) {
-        if (type === 'SWITCH_CAMERA') {
-          payload = {
-            carNum: cmd.target.carNumber?.toString(),
-            camGroup: cmd.target.cameraGroup?.toString(),
-            ...cmd.target,
-          };
-        } else if (type === 'SWITCH_OBS_SCENE') {
-          payload = {
-            sceneName: cmd.target.obsSceneId || cmd.target.sceneName,
-            ...cmd.target,
-          };
-        } else {
-          payload = { ...cmd.target };
-        }
-      }
-
-      return { id, intent, payload };
-    }
-
-    // Unknown command — emit a warning log step
-    console.warn(`[Normalizer] Unknown API command type: ${type}`);
-    return {
-      id,
-      intent: 'system.log',
-      payload: { message: `Unknown API command type: ${type}`, level: 'WARN' },
-    };
-  });
-
+  // Legacy format is no longer supported — log error and return empty sequence
+  console.error('[Normalizer] Received unsupported legacy API format (commands[]). Race Control should return PortableSequence with steps[].');
   return {
     id: apiData.sequenceId || apiData.id || randomUUID(),
     name: apiData.name,
-    steps,
-    metadata: {
-      priority: apiData.priority,
-      generatedAt: apiData.generatedAt || apiData.metadata?.generatedAt,
-      totalDurationMs: apiData.totalDurationMs || apiData.metadata?.totalDurationMs,
-    },
+    steps: [],
+    metadata: { error: 'Legacy format not supported' },
   };
 }

--- a/src/main/sequence-executor.test.ts
+++ b/src/main/sequence-executor.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Unit tests for SequenceExecutor
+ *
+ * Tests the built-in intent handlers:
+ * - system.wait, system.log
+ * - system.executeSequence (nested execution)
+ * - overlay.show, overlay.hide
+ * - Extension intent dispatch and soft failure
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SequenceExecutor } from './sequence-executor';
+import { PortableSequence, SequenceStep } from './director-types';
+
+// Mock ExtensionHostService
+class MockExtensionHost {
+  hasActiveHandler = vi.fn().mockReturnValue(false);
+  executeIntent = vi.fn().mockResolvedValue(undefined);
+}
+
+// Mock OverlayBus
+class MockOverlayBus {
+  showOverlay = vi.fn();
+  hideOverlay = vi.fn();
+}
+
+// Mock SequenceLibrary
+class MockSequenceLibrary {
+  getSequence = vi.fn().mockResolvedValue(null);
+}
+
+describe('SequenceExecutor', () => {
+  let executor: SequenceExecutor;
+  let mockHost: MockExtensionHost;
+  let mockOverlayBus: MockOverlayBus;
+  let mockLibrary: MockSequenceLibrary;
+
+  beforeEach(() => {
+    mockHost = new MockExtensionHost();
+    mockOverlayBus = new MockOverlayBus();
+    mockLibrary = new MockSequenceLibrary();
+    executor = new SequenceExecutor(mockHost as any, mockOverlayBus as any);
+    executor.setSequenceLibrary(mockLibrary as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  describe('system.wait', () => {
+    it('should wait for the specified duration', async () => {
+      vi.useFakeTimers();
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'system.wait',
+        payload: { durationMs: 500 },
+      };
+
+      const promise = executor.executeStep(step);
+      vi.advanceTimersByTime(500);
+      await promise;
+
+      // No extension call should be made
+      expect(mockHost.executeIntent).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+
+    it('should skip wait if durationMs is 0', async () => {
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'system.wait',
+        payload: { durationMs: 0 },
+      };
+
+      await executor.executeStep(step);
+      expect(mockHost.executeIntent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('system.log', () => {
+    it('should log message at INFO level by default', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'system.log',
+        payload: { message: 'Test message' },
+      };
+
+      await executor.executeStep(step);
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Test message'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[INFO]'));
+    });
+
+    it('should log message at ERROR level', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'system.log',
+        payload: { message: 'Error occurred', level: 'ERROR' },
+      };
+
+      await executor.executeStep(step);
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Error occurred'));
+    });
+  });
+
+  describe('system.executeSequence', () => {
+    it('should execute a nested sequence from the library', async () => {
+      const nestedSeq: PortableSequence = {
+        id: 'nested-1',
+        steps: [
+          { id: 'n1', intent: 'system.log', payload: { message: 'nested', level: 'INFO' } },
+        ],
+      };
+      mockLibrary.getSequence.mockResolvedValue(nestedSeq);
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'system.executeSequence',
+        payload: { sequenceId: 'nested-1' },
+      };
+
+      await executor.executeStep(step);
+
+      expect(mockLibrary.getSequence).toHaveBeenCalledWith('nested-1');
+    });
+
+    it('should skip if sequenceId is missing', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'system.executeSequence',
+        payload: {},
+      };
+
+      await executor.executeStep(step);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('missing sequenceId'));
+      expect(mockLibrary.getSequence).not.toHaveBeenCalled();
+    });
+
+    it('should skip if sequence is not found', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockLibrary.getSequence.mockResolvedValue(null);
+
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'system.executeSequence',
+        payload: { sequenceId: 'nonexistent' },
+      };
+
+      await executor.executeStep(step);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("'nonexistent' not found"));
+    });
+
+    it('should skip if no sequence library is configured', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const executorNoLib = new SequenceExecutor(mockHost as any);
+
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'system.executeSequence',
+        payload: { sequenceId: 'some-seq' },
+      };
+
+      await executorNoLib.executeStep(step);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no sequence library configured'));
+    });
+  });
+
+  describe('overlay.show', () => {
+    it('should call showOverlay on OverlayBus', async () => {
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'overlay.show',
+        payload: { extensionId: 'iracing', overlayId: 'standings' },
+      };
+
+      await executor.executeStep(step);
+
+      expect(mockOverlayBus.showOverlay).toHaveBeenCalledWith('iracing', 'standings');
+    });
+
+    it('should skip if extensionId or overlayId is missing', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'overlay.show',
+        payload: { extensionId: 'iracing' },
+      };
+
+      await executor.executeStep(step);
+
+      expect(mockOverlayBus.showOverlay).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('missing extensionId or overlayId'));
+    });
+
+    it('should skip if no OverlayBus is configured', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const executorNoBus = new SequenceExecutor(mockHost as any);
+
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'overlay.show',
+        payload: { extensionId: 'iracing', overlayId: 'standings' },
+      };
+
+      await executorNoBus.executeStep(step);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no OverlayBus configured'));
+    });
+  });
+
+  describe('overlay.hide', () => {
+    it('should call hideOverlay on OverlayBus', async () => {
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'overlay.hide',
+        payload: { extensionId: 'iracing', overlayId: 'standings' },
+      };
+
+      await executor.executeStep(step);
+
+      expect(mockOverlayBus.hideOverlay).toHaveBeenCalledWith('iracing', 'standings');
+    });
+
+    it('should skip if extensionId or overlayId is missing', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'overlay.hide',
+        payload: { overlayId: 'standings' },
+      };
+
+      await executor.executeStep(step);
+
+      expect(mockOverlayBus.hideOverlay).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Extension intents', () => {
+    it('should dispatch to extension host when handler is active', async () => {
+      mockHost.hasActiveHandler.mockReturnValue(true);
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'broadcast.showLiveCam',
+        payload: { carNum: '42', camGroup: 1 },
+      };
+
+      await executor.executeStep(step);
+
+      expect(mockHost.executeIntent).toHaveBeenCalledWith('broadcast.showLiveCam', { carNum: '42', camGroup: 1 });
+    });
+
+    it('should soft-fail when no handler is active', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockHost.hasActiveHandler.mockReturnValue(false);
+      const step: SequenceStep = {
+        id: 's1',
+        intent: 'broadcast.showLiveCam',
+        payload: { carNum: '42', camGroup: 1 },
+      };
+
+      await executor.executeStep(step);
+
+      expect(mockHost.executeIntent).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No active handler'));
+    });
+  });
+
+  describe('execute (full sequence)', () => {
+    it('should execute all steps in order and report progress', async () => {
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+      const progressFn = vi.fn();
+      const seq: PortableSequence = {
+        id: 'full-seq',
+        steps: [
+          { id: 's1', intent: 'system.log', payload: { message: 'A', level: 'INFO' } },
+          { id: 's2', intent: 'system.log', payload: { message: 'B', level: 'INFO' } },
+        ],
+      };
+
+      await executor.execute(seq, progressFn);
+
+      expect(progressFn).toHaveBeenCalledWith(0, 2);
+      expect(progressFn).toHaveBeenCalledWith(1, 2);
+      expect(progressFn).toHaveBeenCalledWith(2, 2);
+    });
+
+    it('should continue on error (soft failure)', async () => {
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockHost.hasActiveHandler.mockReturnValue(true);
+      mockHost.executeIntent.mockRejectedValueOnce(new Error('boom'));
+
+      const seq: PortableSequence = {
+        id: 'error-seq',
+        steps: [
+          { id: 's1', intent: 'broadcast.showLiveCam', payload: { carNum: '1', camGroup: 1 } },
+          { id: 's2', intent: 'system.log', payload: { message: 'after error', level: 'INFO' } },
+        ],
+      };
+
+      await executor.execute(seq);
+
+      // Both steps should have been attempted
+      expect(mockHost.executeIntent).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/main/sequence-executor.ts
+++ b/src/main/sequence-executor.ts
@@ -1,11 +1,14 @@
 import {
   SequenceStep,
   PortableSequence,
-  DirectorSequence,
-  normalizeApiSequence,
-  LogLevel,
 } from './director-types';
 import { ExtensionHostService } from './extension-host/extension-host';
+import { OverlayBus } from './overlay/overlay-bus';
+
+// Forward-declared to avoid circular dependency — set via setSequenceLibrary()
+interface SequenceLibraryLike {
+  getSequence(id: string): Promise<PortableSequence | null>;
+}
 
 /**
  * Sequence Executor — Intent-Driven, Headless Runtime
@@ -14,16 +17,27 @@ import { ExtensionHostService } from './extension-host/extension-host';
  * AI, API, manual JSON). It only operates on the PortableSequence format.
  *
  * Architecture:
- * - Built-in handlers for `system.*` intents (wait, log)
+ * - Built-in handlers for `system.*` intents (wait, log, executeSequence)
+ * - Built-in handlers for `overlay.*` intents (show, hide)
  * - All other intents dispatched to ExtensionHostService
  * - Soft Failure: missing handlers result in a skip + warning, not an abort
  *
  * See: documents/feature_sequence_executor.md
  */
 export class SequenceExecutor {
+  private sequenceLibrary: SequenceLibraryLike | null = null;
+
   constructor(
-    private extensionHost: ExtensionHostService
+    private extensionHost: ExtensionHostService,
+    private overlayBus?: OverlayBus,
   ) {}
+
+  /**
+   * Set the sequence library reference (avoids circular constructor dependency).
+   */
+  setSequenceLibrary(library: SequenceLibraryLike): void {
+    this.sequenceLibrary = library;
+  }
 
   /**
    * Execute a PortableSequence (the canonical format).
@@ -59,18 +73,6 @@ export class SequenceExecutor {
   }
 
   /**
-   * Execute a legacy DirectorSequence by normalizing it first.
-   * Provides backward compatibility with the Race Control API format.
-   */
-  async executeLegacy(
-    legacy: DirectorSequence,
-    onProgress?: (completed: number, total: number) => void
-  ): Promise<void> {
-    const portable = normalizeApiSequence(legacy);
-    return this.execute(portable, onProgress);
-  }
-
-  /**
    * Dispatch a single step to the appropriate handler.
    * Public so that SequenceScheduler can invoke steps individually
    * for fine-grained progress reporting and cancellation.
@@ -97,6 +99,57 @@ export class SequenceExecutor {
         case 'WARN':  console.warn(logMessage); break;
         default:      console.log(logMessage); break;
       }
+      return;
+    }
+
+    if (intent === 'system.executeSequence') {
+      const sequenceId = (payload as any).sequenceId;
+      if (!sequenceId) {
+        console.warn('[SequenceExecutor] system.executeSequence: missing sequenceId');
+        return;
+      }
+      if (!this.sequenceLibrary) {
+        console.warn('[SequenceExecutor] system.executeSequence: no sequence library configured');
+        return;
+      }
+      const nested = await this.sequenceLibrary.getSequence(sequenceId);
+      if (!nested) {
+        console.warn(`[SequenceExecutor] system.executeSequence: sequence '${sequenceId}' not found`);
+        return;
+      }
+      console.log(`[SequenceExecutor] Executing nested sequence '${sequenceId}'`);
+      await this.execute(nested);
+      return;
+    }
+
+    // --- Built-in Overlay Intents ---
+    if (intent === 'overlay.show') {
+      if (!this.overlayBus) {
+        console.warn('[SequenceExecutor] overlay.show: no OverlayBus configured');
+        return;
+      }
+      const extensionId = (payload as any).extensionId;
+      const overlayId = (payload as any).overlayId;
+      if (!extensionId || !overlayId) {
+        console.warn('[SequenceExecutor] overlay.show: missing extensionId or overlayId');
+        return;
+      }
+      this.overlayBus.showOverlay(extensionId, overlayId);
+      return;
+    }
+
+    if (intent === 'overlay.hide') {
+      if (!this.overlayBus) {
+        console.warn('[SequenceExecutor] overlay.hide: no OverlayBus configured');
+        return;
+      }
+      const extensionId = (payload as any).extensionId;
+      const overlayId = (payload as any).overlayId;
+      if (!extensionId || !overlayId) {
+        console.warn('[SequenceExecutor] overlay.hide: missing extensionId or overlayId');
+        return;
+      }
+      this.overlayBus.hideOverlay(extensionId, overlayId);
       return;
     }
 

--- a/src/main/sequence-library-service.test.ts
+++ b/src/main/sequence-library-service.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for SequenceLibraryService — Cloud Tier
+ *
+ * Tests the cloud sequence fetching, caching, and graceful offline degradation.
+ * Built-in and custom tiers are filesystem-dependent; cloud tier uses fetch.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock electron app before importing the service
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/test-userdata',
+  },
+}));
+
+// Mock fs/promises to avoid real filesystem access
+vi.mock('fs/promises', () => ({
+  default: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    readdir: vi.fn().mockResolvedValue([]),
+    readFile: vi.fn().mockResolvedValue('[]'),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    unlink: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { SequenceLibraryService } from './sequence-library-service';
+import { PortableSequence } from './director-types';
+
+// Mock AuthService
+class MockAuthService {
+  getAccessToken = vi.fn().mockResolvedValue('mock-token-123');
+}
+
+// Mock CapabilityCatalog
+class MockCapabilityCatalog {
+  getAllIntents = vi.fn().mockReturnValue([]);
+  getAllEvents = vi.fn().mockReturnValue([]);
+}
+
+// Helper to create a mock fetch response
+function mockFetchResponse(data: any, ok = true, status = 200) {
+  return Promise.resolve({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: () => Promise.resolve(data),
+  });
+}
+
+describe('SequenceLibraryService — Cloud Tier', () => {
+  let service: SequenceLibraryService;
+  let mockAuth: MockAuthService;
+  let mockCatalog: MockCapabilityCatalog;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  const cloudSequences: PortableSequence[] = [
+    {
+      id: 'cloud-seq-1',
+      name: 'Battle Cam',
+      steps: [
+        { id: 's1', intent: 'broadcast.showLiveCam', payload: { carNum: '1', camGroup: 1 } },
+      ],
+    },
+    {
+      id: 'cloud-seq-2',
+      name: 'Quick Replay',
+      steps: [
+        { id: 's1', intent: 'system.wait', payload: { durationMs: 3000 } },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    mockAuth = new MockAuthService();
+    mockCatalog = new MockCapabilityCatalog();
+    service = new SequenceLibraryService(mockCatalog as any, mockAuth as any);
+
+    // Mock global fetch
+    fetchSpy = vi.fn().mockReturnValue(mockFetchResponse(cloudSequences));
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe('loadCloud', () => {
+    it('should fetch cloud sequences with bearer token', async () => {
+      await service.loadCloud();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/api/director/v1/sequences'),
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer mock-token-123' },
+        })
+      );
+    });
+
+    it('should tag fetched sequences with category cloud', async () => {
+      await service.loadCloud();
+      const all = await service.listSequences();
+
+      const cloud = all.filter(s => s.category === 'cloud');
+      expect(cloud).toHaveLength(2);
+      expect(cloud[0].id).toBe('cloud-seq-1');
+      expect(cloud[1].id).toBe('cloud-seq-2');
+    });
+
+    it('should skip when no AuthService is provided', async () => {
+      const noAuthService = new SequenceLibraryService(mockCatalog as any);
+      await noAuthService.loadCloud();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('should skip when no access token is available', async () => {
+      mockAuth.getAccessToken.mockResolvedValue(null);
+      await service.loadCloud();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('should gracefully handle HTTP errors', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      fetchSpy.mockReturnValue(mockFetchResponse(null, false, 500));
+
+      await service.loadCloud();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Cloud fetch failed'));
+      // Should not throw
+    });
+
+    it('should gracefully handle network errors', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      fetchSpy.mockRejectedValue(new Error('Network unreachable'));
+
+      await service.loadCloud();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Cloud fetch error'),
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('Cache TTL', () => {
+    it('should not re-fetch cloud within TTL', async () => {
+      await service.loadCloud();
+      fetchSpy.mockClear();
+
+      // listSequences should not trigger another fetch
+      await service.listSequences();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('should re-fetch cloud when TTL expires', async () => {
+      await service.loadCloud();
+      fetchSpy.mockClear();
+
+      // Simulate time passing beyond TTL by manipulating the timestamp
+      // Access private field via bracket notation for testing
+      (service as any).cloudCacheTimestamp = Date.now() - 6 * 60 * 1000;
+
+      await service.listSequences();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getSequence', () => {
+    it('should find cloud sequences by ID', async () => {
+      await service.loadCloud();
+
+      const seq = await service.getSequence('cloud-seq-1');
+
+      expect(seq).not.toBeNull();
+      expect(seq!.id).toBe('cloud-seq-1');
+      expect(seq!.category).toBe('cloud');
+    });
+
+    it('should return null for unknown IDs', async () => {
+      await service.loadCloud();
+
+      const seq = await service.getSequence('nonexistent');
+
+      expect(seq).toBeNull();
+    });
+  });
+
+  describe('listSequences with filters', () => {
+    it('should filter cloud sequences by category', async () => {
+      await service.loadCloud();
+
+      const cloudOnly = await service.listSequences({ category: 'cloud' });
+
+      expect(cloudOnly).toHaveLength(2);
+      cloudOnly.forEach(s => expect(s.category).toBe('cloud'));
+    });
+
+    it('should filter by search text across cloud sequences', async () => {
+      await service.loadCloud();
+
+      const results = await service.listSequences({ search: 'Battle' });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('cloud-seq-1');
+    });
+  });
+});

--- a/src/main/sequence-library-service.ts
+++ b/src/main/sequence-library-service.ts
@@ -19,14 +19,24 @@ import {
   EventCatalogEntry,
 } from './director-types';
 import { CapabilityCatalog } from './extension-host/capability-catalog';
+import { AuthService } from './auth-service';
+import { apiConfig } from './auth-config';
+
+/** Cloud cache TTL: 5 minutes */
+const CLOUD_CACHE_TTL_MS = 5 * 60 * 1000;
 
 export class SequenceLibraryService {
   private builtInDir: string;
   private customDir: string;
   private builtInCache: PortableSequence[] = [];
+  private cloudCache: PortableSequence[] = [];
+  private cloudCacheTimestamp = 0;
   private customCache: PortableSequence[] = [];
 
-  constructor(private capabilityCatalog: CapabilityCatalog) {
+  constructor(
+    private capabilityCatalog: CapabilityCatalog,
+    private authService?: AuthService,
+  ) {
     // Built-in sequences are bundled in the app resources
     // In development: src/renderer/sequences/built-in/ compiled alongside the app
     // At runtime: relative to __dirname (dist-electron/main/) → ../sequences/built-in/
@@ -45,11 +55,12 @@ export class SequenceLibraryService {
 
     await Promise.all([
       this.loadBuiltIn(),
+      this.loadCloud(),
       this.loadCustom(),
     ]);
 
     console.log(
-      `[SequenceLibrary] Initialized: ${this.builtInCache.length} built-in, ${this.customCache.length} custom sequences`
+      `[SequenceLibrary] Initialized: ${this.builtInCache.length} built-in, ${this.cloudCache.length} cloud, ${this.customCache.length} custom sequences`
     );
   }
 
@@ -57,7 +68,12 @@ export class SequenceLibraryService {
    * List all sequences, optionally filtered by category and/or search text.
    */
   async listSequences(filter?: SequenceFilter): Promise<PortableSequence[]> {
-    let all = [...this.builtInCache, ...this.customCache];
+    // Refresh cloud cache if stale
+    if (Date.now() - this.cloudCacheTimestamp > CLOUD_CACHE_TTL_MS) {
+      await this.loadCloud();
+    }
+
+    let all = [...this.builtInCache, ...this.cloudCache, ...this.customCache];
 
     if (filter?.category) {
       all = all.filter((s) => s.category === filter.category);
@@ -80,8 +96,14 @@ export class SequenceLibraryService {
    * Get a single sequence by ID.
    */
   async getSequence(id: string): Promise<PortableSequence | null> {
+    // Refresh cloud cache if stale
+    if (Date.now() - this.cloudCacheTimestamp > CLOUD_CACHE_TTL_MS) {
+      await this.loadCloud();
+    }
+
     return (
       this.builtInCache.find((s) => s.id === id) ||
+      this.cloudCache.find((s) => s.id === id) ||
       this.customCache.find((s) => s.id === id) ||
       null
     );
@@ -249,6 +271,42 @@ export class SequenceLibraryService {
       // Built-in dir may not exist yet in dev — that's okay
       console.warn('[SequenceLibrary] No built-in sequences directory found:', this.builtInDir);
       this.builtInCache = [];
+    }
+  }
+
+  /**
+   * Fetch cloud sequences from Race Control API.
+   * Gracefully degrades when offline or unauthenticated.
+   */
+  async loadCloud(): Promise<void> {
+    if (!this.authService) {
+      return;
+    }
+
+    try {
+      const token = await this.authService.getAccessToken();
+      if (!token) {
+        console.warn('[SequenceLibrary] No access token — skipping cloud fetch');
+        return;
+      }
+
+      const url = `${apiConfig.baseUrl}${apiConfig.endpoints.listSequences}`;
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) {
+        console.warn(`[SequenceLibrary] Cloud fetch failed: ${response.status} ${response.statusText}`);
+        return;
+      }
+
+      const data: PortableSequence[] = await response.json();
+      this.cloudCache = data.map((s) => ({ ...s, category: 'cloud' as const }));
+      this.cloudCacheTimestamp = Date.now();
+      console.log(`[SequenceLibrary] Loaded ${this.cloudCache.length} cloud sequences`);
+    } catch (err) {
+      // Network failure — keep stale cache, don't crash
+      console.warn('[SequenceLibrary] Cloud fetch error (offline?):', err);
     }
   }
 


### PR DESCRIPTION
## Summary

Resolves #54 and #55.

### Issue #54 — Delete legacy normalization code

All legacy types and conversion paths have been removed. The codebase now exclusively uses `PortableSequence` as the canonical wire format.

**Removed from `director-types.ts`:**
- `CommandType` enum, all legacy payload interfaces (`WaitCommandPayload`, `LogCommandPayload`, `SwitchCameraCommandPayload`, etc.)
- All legacy command interfaces (`BaseCommand`, `WaitCommand`, `LogCommand`, etc., `DirectorCommand` union)
- `DirectorSequence`, `GetNextSequenceResponse`, `SequencePriority`
- `LEGACY_INTENT_MAP`, `normalizeCommand()`, `normalizeApiSequence()`, `normalizeNextSequenceResponse()`

**Removed from `normalizer.ts`:**
- Legacy format conversion path (LEGACY_INTENT_MAP duplicate, `commands[]` handling)
- Now returns empty sequence with error metadata for any legacy format input

**Removed from `sequence-executor.ts`:**
- `executeLegacy()` method and associated imports

**Tests rewritten:**
- `director-types.test.ts` — replaced ~350 lines of legacy tests with 4 PortableSequence type contract tests
- `normalizer.test.ts` — replaced ~15 legacy tests with rejection/edge case tests
- `portable-sequence.contract.test.ts` — all sections updated to use PortableSequence natively

**Verification:** Zero references to `DirectorSequence`, `DirectorCommand`, `CommandType`, `normalizeApiSequence` remain in `src/`.

### Issue #55 — Cloud sequence library integration

**New endpoint:** Added `listSequences: '/api/director/v1/sequences'` to `auth-config.ts` (per OpenAPI spec).

**Cloud tier in `SequenceLibraryService`:**
- Added `AuthService` as optional constructor dependency
- `loadCloud()` fetches sequences from RC API with Bearer token
- 5-minute cache TTL with automatic refresh on `listSequences()` / `getSequence()`
- Graceful degradation: network errors, HTTP errors, and missing auth all handled without crashing

**New built-in intent handlers in `SequenceExecutor`:**
- `system.executeSequence` — fetches sequence by ID from library and executes inline (nested execution)
- `overlay.show` — dispatches to `OverlayBus.showOverlay(extensionId, overlayId)`
- `overlay.hide` — dispatches to `OverlayBus.hideOverlay(extensionId, overlayId)`

**Wiring in `main.ts`:**
- `SequenceExecutor` now receives `OverlayBus` dependency
- `SequenceLibraryService` now receives `AuthService` dependency
- `sequenceExecutor.setSequenceLibrary(sequenceLibrary)` for nested execution support

**New test files:**
- `sequence-executor.test.ts` — 17 tests covering all built-in handlers and soft failure
- `sequence-library-service.test.ts` — 11 tests covering cloud fetch, caching, TTL, offline degradation

### Test Results

All **140 tests pass** across 10 test suites. Net: -398 lines (807 added, 1205 removed).