### PR TITLE
fix: lapping detection, 30s heartbeat, and publisher page state persistence

### DIFF
--- a/src/extensions/iracing/publisher/__tests__/lifecycle-event-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/lifecycle-event-detector.test.ts
@@ -120,55 +120,55 @@ describe('onConnectionChange', () => {
 // ---------------------------------------------------------------------------
 
 describe('checkHeartbeat', () => {
-  it('fires PUBLISHER_HEARTBEAT when no event has been emitted (starts at time 0, check at 1001)', () => {
+  it('fires PUBLISHER_HEARTBEAT when no event has been emitted (starts at time 0, check at 30001)', () => {
     let now = 0;
     const detector = new LifecycleEventDetector(() => now);
-    now = 1001;
+    now = 30001;
     const events = detector.checkHeartbeat(CTX);
     expect(events).toHaveLength(1);
     expect(events[0].type).toBe('PUBLISHER_HEARTBEAT');
   });
 
-  it('fires exactly at the 1000ms boundary', () => {
+  it('fires exactly at the 30000ms boundary', () => {
     let now = 0;
     const detector = new LifecycleEventDetector(() => now);
-    now = 999;
+    now = 29999;
     expect(detector.checkHeartbeat(CTX)).toHaveLength(0);
-    now = 1000;
+    now = 30000;
     expect(detector.checkHeartbeat(CTX)).toHaveLength(1);
   });
 
-  it('returns empty array when another event was emitted less than 1s ago', () => {
-    let now = 500;
+  it('returns empty array when another event was emitted less than 30s ago', () => {
+    let now = 15000;
     const detector = new LifecycleEventDetector(() => now);
-    detector.notifyEventEmitted(); // last event at 500ms
-    now = 1000; // only 500ms since last event
+    detector.notifyEventEmitted(); // last event at 15s
+    now = 20000; // only 5s since last event
     expect(detector.checkHeartbeat(CTX)).toHaveLength(0);
   });
 
   it('notifyEventEmitted from external detector suppresses heartbeat', () => {
     let now = 0;
     const detector = new LifecycleEventDetector(() => now);
-    now = 1500;
-    detector.notifyEventEmitted(); // some other event fired at 1500ms
-    now = 2000; // only 500ms since last
+    now = 15000;
+    detector.notifyEventEmitted(); // some other event fired at 15s
+    now = 20000; // only 5s since last
     expect(detector.checkHeartbeat(CTX)).toHaveLength(0);
   });
 
-  it('heartbeat fires again after a second interval has elapsed', () => {
+  it('heartbeat fires again after a second 30s interval has elapsed', () => {
     let now = 0;
     const detector = new LifecycleEventDetector(() => now);
-    now = 1001;
-    detector.checkHeartbeat(CTX); // fires; updates lastEventAt to 1001
-    now = 2002;
-    const events = detector.checkHeartbeat(CTX); // 1001ms since last
+    now = 30001;
+    detector.checkHeartbeat(CTX); // fires; updates lastEventAt to 30001
+    now = 60002;
+    const events = detector.checkHeartbeat(CTX); // 30001ms since last
     expect(events).toHaveLength(1);
   });
 
   it('heartbeat does NOT fire twice in rapid succession', () => {
     let now = 0;
     const detector = new LifecycleEventDetector(() => now);
-    now = 1001;
+    now = 30001;
     detector.checkHeartbeat(CTX); // fires
     const second = detector.checkHeartbeat(CTX); // same ms → no fire
     expect(second).toHaveLength(0);
@@ -177,7 +177,7 @@ describe('checkHeartbeat', () => {
   it('heartbeat carries publisherCode and raceSessionId', () => {
     let now = 0;
     const detector = new LifecycleEventDetector(() => now);
-    now = 2000;
+    now = 31000;
     const [ev] = detector.checkHeartbeat(CTX);
     expect(ev.rigId).toBe('rig-01');
     expect(ev.raceSessionId).toBe('session-abc');
@@ -194,10 +194,10 @@ describe('notifyEventEmitted', () => {
     const detector = new LifecycleEventDetector(() => now);
     now = 5000;
     detector.notifyEventEmitted();
-    now = 5500;
-    expect(detector.checkHeartbeat(CTX)).toHaveLength(0); // still within window
-    now = 6001;
-    expect(detector.checkHeartbeat(CTX)).toHaveLength(1); // now past 1s
+    now = 5500;                    // only 500ms since last event
+    expect(detector.checkHeartbeat(CTX)).toHaveLength(0); // still within 30s window
+    now = 35001;                   // 30001ms since last event
+    expect(detector.checkHeartbeat(CTX)).toHaveLength(1); // now past 30s
   });
 });
 

--- a/src/extensions/iracing/publisher/__tests__/orchestrator.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/orchestrator.test.ts
@@ -393,12 +393,12 @@ describe('iracing.publisherStateChanged', () => {
 // ---------------------------------------------------------------------------
 
 describe('heartbeat', () => {
-  it('fires PUBLISHER_HEARTBEAT after 1s of inactivity', () => {
+  it('fires PUBLISHER_HEARTBEAT after 30s of inactivity', () => {
     const { orch, director } = makeActiveOrchestrator();
     director.emittedEvents.length = 0;
 
     // Advance time so heartbeat detector considers it idle, then tick
-    vi.advanceTimersByTime(1500);
+    vi.advanceTimersByTime(31000);
     orch.tickHeartbeat();
 
     const beat = director.emittedEvents.find(
@@ -425,12 +425,12 @@ describe('heartbeat', () => {
     expect(beat).toBeUndefined();
   });
 
-  it('automatic 1Hz timer drives heartbeats while running', async () => {
+  it('automatic 30s timer drives heartbeats while running', async () => {
     const { orch, director } = makeActiveOrchestrator();
     director.emittedEvents.length = 0;
 
-    // Advance fake time by 3s — should produce ~3 heartbeats
-    await vi.advanceTimersByTimeAsync(3500);
+    // Advance fake time by 65s — should produce 2 heartbeats (at ~30s and ~60s)
+    await vi.advanceTimersByTimeAsync(65_000);
 
     const beats = director.emittedEvents.filter(
       (e) => e.event === 'iracing.publisherEventEmitted' && e.payload?.type === 'PUBLISHER_HEARTBEAT',

--- a/src/extensions/iracing/publisher/__tests__/overtake-battle-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/overtake-battle-detector.test.ts
@@ -651,22 +651,24 @@ describe('LAPPED_TRAFFIC_AHEAD', () => {
   });
 
   it('re-fires after the pair separates and re-closes', () => {
+    // Both cars start at the same physical track position (lapDistPct = 0).
     const base = makeFrame({ cars: [
-      { carIdx: 0, position: 1, lapsCompleted: 10, f2Time: 0 },
-      { carIdx: 1, position: 2, lapsCompleted: 11, f2Time: 1.5 },
+      { carIdx: 0, position: 1, lapsCompleted: 10, lapDistPct: 0 },
+      { carIdx: 1, position: 2, lapsCompleted: 11, lapDistPct: 0 },
     ] });
     const state = prime(base);
-    detect(base, cloneFrame(base), state);
+    detect(base, cloneFrame(base), state);  // first fire, latches la:0-1 / bl:0-1
 
-    // Gap widens past threshold → announcement cleared
+    // Car 0 moves to 50% of the lap — physGap 0.5 × 90 s = 45 s >> 2 s threshold.
     const wide = cloneFrame(base);
-    wide.carIdxF2Time[1] = 5;
+    wide.carIdxLapDistPct[0] = 0.5;
     detect(base, wide, state);
-    expect(state.trafficAnnouncements.has('0-1')).toBe(false);
+    expect(state.trafficAnnouncements.has('la:0-1')).toBe(false); // latch cleared
+    expect(state.trafficAnnouncements.has('bl:0-1')).toBe(false);
 
-    // Close again
+    // Car 0 moves back close to car 1 (1% of lap ≈ 0.9 s gap).
     const close = cloneFrame(wide);
-    close.carIdxF2Time[1] = 1.2;
+    close.carIdxLapDistPct[0] = 0.01;
     const events = detect(wide, close, state);
     expect(events.find(e => e.type === 'LAPPED_TRAFFIC_AHEAD')).toBeDefined();
   });
@@ -695,11 +697,116 @@ describe('BEING_LAPPED', () => {
     expect((ev.payload as any).lappingCar.carIdx).toBe(0); // the lapping car is carIdx 0
     expect((ev.payload as any).lappedCar).toBeUndefined(); // not present on this event
   });
+
+  it('does NOT fire twice while the lapping car remains close', () => {
+    const base = makeFrame({ cars: [
+      { carIdx: 0, position: 1, lapsCompleted: 11, lapDistPct: 0 },
+      { carIdx: 1, position: 2, lapsCompleted: 10, lapDistPct: 0 },
+    ] });
+    const state = prime(base);
+    detect(base, cloneFrame(base), state);                      // first fire
+    const events = detect(base, cloneFrame(base), state);       // same proximity
+    expect(events.filter(e => e.type === 'BEING_LAPPED')).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------
-// Tier 2 (#97): STOPPED_ON_TRACK
+// Tier 2 (#97): LAPPED_TRAFFIC_AHEAD + BEING_LAPPED — real-world scenarios
+//
+// These tests cover the scenario that originally failed: a car parked on
+// track gets lapped but NO events are produced.  The old code relied on
+// carIdxF2Time which equals ≈ lap_time × lap_delta (~80–90 s) and always
+// exceeded the 2 s threshold.  The new code uses carIdxLapDistPct.
 // ---------------------------------------------------------------------------
+
+describe('lapping detection — real-world physical-proximity scenarios', () => {
+  it('fires BEING_LAPPED when lapping car is physically close (approaching from behind)', () => {
+    // Lapping car (idx 1, 5 laps) is approaching the parked user car (idx 0,
+    // 0 laps) from behind.  Both are near the start/finish straight.
+    const base = makeFrame({ cars: [
+      { carIdx: 0, position: 20, lapsCompleted: 0, lapDistPct: 0.05, lastLapTime: 90 },
+      { carIdx: 1, position: 10, lapsCompleted: 5, lapDistPct: 0.97, lastLapTime: 90 },
+    ] });
+    const state = prime(base);
+    // physDiff = 0.97 - 0.05 = 0.92; normalise: 0.92 - 1.0 = -0.08
+    // gapSec = 0.08 * 90 = 7.2 s  — just beyond the default 2 s threshold.
+    // Let's tighten the approach: lapping car at 0.99.
+    const f1 = cloneFrame(base);
+    f1.carIdxLapDistPct[1] = 0.99;
+    // physDiff = 0.99 - 0.05 = 0.94; normalise: 0.94 - 1.0 = -0.06; gapSec = 5.4 s — still wide.
+    // Move parked car further into the lap so approaching gap is < 2 s.
+    f1.carIdxLapDistPct[0] = 0.02;
+    // physDiff = 0.99 - 0.02 = 0.97; normalise: 0.97 - 1.0 = -0.03; gapSec = 0.03*90 = 2.7 s — still wide.
+    // Tighten further: lapping car at 0.995, parked at 0.005.
+    f1.carIdxLapDistPct[0] = 0.005;
+    f1.carIdxLapDistPct[1] = 0.995;
+    // physDiff = 0.995 - 0.005 = 0.99; normalise: 0.99 - 1.0 = -0.01; gapSec = 0.01*90 = 0.9 s ✓
+    const events = detect(base, f1, state);
+    expect(events.find(e => e.type === 'BEING_LAPPED')).toBeDefined();
+    const ev = events.find(e => e.type === 'BEING_LAPPED')!;
+    expect((ev.payload as any).lappingCar.carIdx).toBe(1);
+  });
+
+  it('fires LAPPED_TRAFFIC_AHEAD simultaneously with BEING_LAPPED', () => {
+    // Same pair — both events should fire on the first proximity frame.
+    const base = makeFrame({ cars: [
+      { carIdx: 0, position: 20, lapsCompleted: 0, lapDistPct: 0.005, lastLapTime: 90 },
+      { carIdx: 1, position: 10, lapsCompleted: 5, lapDistPct: 0.995, lastLapTime: 90 },
+    ] });
+    const state = prime(base);
+    const events = detect(base, cloneFrame(base), state);
+    expect(events.find(e => e.type === 'BEING_LAPPED')).toBeDefined();
+    expect(events.find(e => e.type === 'LAPPED_TRAFFIC_AHEAD')).toBeDefined();
+    // BEING_LAPPED from parked car's perspective
+    const bl = events.find(e => e.type === 'BEING_LAPPED')!;
+    expect((bl.payload as any).lappingCar.carIdx).toBe(1);
+    // LAPPED_TRAFFIC_AHEAD from lapping car's perspective
+    const la = events.find(e => e.type === 'LAPPED_TRAFFIC_AHEAD')!;
+    expect((la.payload as any).lappedCar.carIdx).toBe(0);
+  });
+
+  it('fires BEING_LAPPED after lapping car crosses start/finish just ahead', () => {
+    // Lapping car has just crossed start/finish; parked car is a tiny fraction behind.
+    const base = makeFrame({ cars: [
+      { carIdx: 0, position: 15, lapsCompleted: 3, lapDistPct: 0.998, lastLapTime: 90 },
+      { carIdx: 1, position: 5,  lapsCompleted: 4, lapDistPct: 0.01,  lastLapTime: 90 },
+    ] });
+    const state = prime(base);
+    // physDiff = 0.01 - 0.998 = -0.988; normalise: -0.988 + 1.0 = 0.012; gapSec = 0.012*90 = 1.08 s ✓
+    const events = detect(base, cloneFrame(base), state);
+    expect(events.find(e => e.type === 'BEING_LAPPED')).toBeDefined();
+  });
+
+  it('does NOT fire BEING_LAPPED when lapping car is far away physically', () => {
+    // Lapping car is at 50% of the track, parked car is at 5% — 45 s apart.
+    const base = makeFrame({ cars: [
+      { carIdx: 0, position: 20, lapsCompleted: 0, lapDistPct: 0.05, lastLapTime: 90 },
+      { carIdx: 1, position: 5,  lapsCompleted: 5, lapDistPct: 0.50, lastLapTime: 90 },
+    ] });
+    const state = prime(base);
+    const events = detect(base, cloneFrame(base), state);
+    expect(events.find(e => e.type === 'BEING_LAPPED')).toBeUndefined();
+  });
+
+  it('fires BEING_LAPPED for a parked car lapped by multiple cars simultaneously', () => {
+    // Parked car at 0.01 lapDistPct; two lapping cars both physically close.
+    // car 1 at 0.995: physDiff = 0.995−0.01 = 0.985 → normalise = −0.015 → 0.015×90 = 1.35 s ✓
+    // car 2 at 0.990: physDiff = 0.990−0.01 = 0.980 → normalise = −0.020 → 0.020×90 = 1.80 s ✓
+    const base = makeFrame({ cars: [
+      { carIdx: 0, position: 20, lapsCompleted: 0, lapDistPct: 0.01,  lastLapTime: 90 },
+      { carIdx: 1, position: 5,  lapsCompleted: 5, lapDistPct: 0.995, lastLapTime: 90 },
+      { carIdx: 2, position: 6,  lapsCompleted: 5, lapDistPct: 0.990, lastLapTime: 90 },
+    ] });
+    const state = prime(base);
+    const events = detect(base, cloneFrame(base), state);
+    // Two BEING_LAPPED events — one for each lapping car
+    const beingLapped = events.filter(e => e.type === 'BEING_LAPPED');
+    expect(beingLapped).toHaveLength(2);
+    // Two LAPPED_TRAFFIC_AHEAD events — from each lapper's perspective
+    const lappedAhead = events.filter(e => e.type === 'LAPPED_TRAFFIC_AHEAD');
+    expect(lappedAhead).toHaveLength(2);
+  });
+});
 
 describe('STOPPED_ON_TRACK', () => {
   it('fires after ≥ 2s with no lapDistPct movement while off pit road', () => {

--- a/src/extensions/iracing/publisher/orchestrator.ts
+++ b/src/extensions/iracing/publisher/orchestrator.ts
@@ -73,7 +73,7 @@ export interface PublisherOrchestratorConfig {
 
 const DEFAULT_RC_BASE_URL       = 'https://simracecenter.com';
 const DEFAULT_BATCH_INTERVAL_MS = 2000;
-const HEARTBEAT_INTERVAL_MS     = 1_000;
+const HEARTBEAT_INTERVAL_MS     = 30_000;
 
 /** Legacy config keys removed in DIR-2 and DIR-3 (S3 migration). */
 const LEGACY_KEYS = [
@@ -522,7 +522,7 @@ export class PublisherOrchestrator {
       );
     }
 
-    // 1Hz heartbeat
+    // 30s heartbeat
     this.heartbeatTimer = setInterval(() => this.tickHeartbeat(), HEARTBEAT_INTERVAL_MS);
 
     this.cfg.director.log('info', 'Publisher infrastructure started');

--- a/src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts
+++ b/src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts
@@ -289,78 +289,112 @@ export function detectOvertakeAndBattle(
   }
 
   // -------------------------------------------------------------------------
-  // Step 4: Lapped-traffic detection (#97)
+  // Step 4: Cross-lap physical proximity — LAPPED_TRAFFIC_AHEAD / BEING_LAPPED
   //
-  // For each car i with a car immediately ahead (leaderIdx), compare
-  // carIdxLapCompleted. If i is within TRAFFIC_PROXIMITY_GAP_SEC of leaderIdx:
-  //   - leaderIdx has fewer laps → LAPPED_TRAFFIC_AHEAD (i catching slower car)
-  //   - leaderIdx has more laps   → BEING_LAPPED (i is about to be lapped)
-  // Latched per pair via state.trafficAnnouncements; cleared when gap grows
-  // past threshold or laps equalise.
+  // carIdxF2Time cannot be used here: for cars on different laps it equals
+  // ≈ lap_difference × lap_time (80–90 s), always above any reasonable
+  // proximity threshold.  Instead we compare carIdxLapDistPct positions
+  // directly and convert the fractional-track gap to seconds via the last
+  // known lap time (FALLBACK_LAP_TIME_SEC when unavailable).
+  //
+  // The position-adjacent scan (currPos − 1) also cannot work: when being
+  // lapped the lapping car is many positions ahead in race order, not just
+  // one.  An O(n²) scan over all on-track pairs finds every cross-lap pair.
+  //
+  // For each qualifying pair we fire:
+  //   LAPPED_TRAFFIC_AHEAD — from the lapper's perspective (more laps)
+  //   BEING_LAPPED         — from the lapped car's perspective (fewer laps)
+  //
+  // Latched per pair via state.trafficAnnouncements using prefixed keys:
+  //   'la:<pairKey>'  — LAPPED_TRAFFIC_AHEAD announced
+  //   'bl:<pairKey>'  — BEING_LAPPED announced
+  // Both are cleared when the cars move more than TRAFFIC_PROXIMITY_GAP_SEC
+  // apart physically.
   // -------------------------------------------------------------------------
   const seenTrafficPairs = new Set<string>();
+
   for (let i = 0; i < CAR_COUNT; i++) {
-    const currPos = curr.carIdxPosition[i];
-    if (currPos <= 1) continue;
+    if (curr.carIdxPosition[i] <= 0) continue;
     if (curr.carIdxOnPitRoad[i] !== 0) continue;
+    const lapI = curr.carIdxLapCompleted[i];
+    const pctI = curr.carIdxLapDistPct[i];
 
-    const leaderIdx = currPosMap.get(currPos - 1);
-    if (leaderIdx === undefined) continue;
-    if (curr.carIdxOnPitRoad[leaderIdx] !== 0) continue;
+    for (let j = i + 1; j < CAR_COUNT; j++) {
+      if (curr.carIdxPosition[j] <= 0) continue;
+      if (curr.carIdxOnPitRoad[j] !== 0) continue;
+      const lapJ = curr.carIdxLapCompleted[j];
 
-    const gap = curr.carIdxF2Time[i];
-    if (gap < 0 || gap > TRAFFIC_PROXIMITY_GAP_SEC) continue;
+      // Only interested in cars on different laps.
+      if (lapI === lapJ) continue;
 
-    const chaserLap = curr.carIdxLapCompleted[i];
-    const leaderLap = curr.carIdxLapCompleted[leaderIdx];
-    if (chaserLap === leaderLap) continue;
+      const pctJ = curr.carIdxLapDistPct[j];
 
-    const pairKey = battleKey(i, leaderIdx);
-    seenTrafficPairs.add(pairKey);
-    const existing = state.trafficAnnouncements.get(pairKey);
+      // Physical track gap as a fraction of the lap, normalised to [−0.5, 0.5]
+      // so that the start/finish line wrap-around is handled correctly.
+      let physDiff = pctI - pctJ;
+      if (physDiff >  0.5) physDiff -= 1.0;
+      if (physDiff < -0.5) physDiff += 1.0;
 
-    // Approximate distance in metres from F2Time. We don't have vehicle speed
-    // in the frame, so we report a rough figure based on a nominal 50 m/s
-    // racing pace. Good enough for highlights/UI.
-    const approxDistanceMeters = Math.round(gap * 50);
+      // Convert fractional gap to approximate seconds using the last known
+      // lap time (fall back to FALLBACK_LAP_TIME_SEC when unavailable).
+      const lapRef =
+        curr.carIdxLastLapTime[i] > 0 ? curr.carIdxLastLapTime[i] :
+        curr.carIdxLastLapTime[j] > 0 ? curr.carIdxLastLapTime[j] :
+        FALLBACK_LAP_TIME_SEC;
+      const gapSec = Math.abs(physDiff) * lapRef;
 
-    if (leaderLap < chaserLap) {
-      // The car ahead is a lapped car — chaser is catching lapped traffic.
-      if (existing !== 'LAPPED_AHEAD') {
-        const car = carRefFromRoster(state, i);
+      if (gapSec > TRAFFIC_PROXIMITY_GAP_SEC) continue;
+
+      // Determine which car is lapping (more completed laps) and which is
+      // being lapped (fewer completed laps).
+      const lapperIdx = lapI > lapJ ? i : j;
+      const lappedIdx  = lapI > lapJ ? j : i;
+
+      const pairKey = battleKey(lapperIdx, lappedIdx);
+      const laKey   = `la:${pairKey}`;
+      const blKey   = `bl:${pairKey}`;
+      seenTrafficPairs.add(laKey);
+      seenTrafficPairs.add(blKey);
+
+      // Approximate distance in metres at a nominal 50 m/s racing pace.
+      const approxDistanceMeters = Math.round(gapSec * 50);
+
+      // LAPPED_TRAFFIC_AHEAD — fired from the lapper's perspective.
+      if (!state.trafficAnnouncements.has(laKey)) {
+        const lapperCar = carRefFromRoster(state, lapperIdx);
         events.push(buildEvent(
           'LAPPED_TRAFFIC_AHEAD',
-          car,
+          lapperCar,
           {
-            lappedCar:      carRefFromRoster(state, leaderIdx),
+            lappedCar:      carRefFromRoster(state, lappedIdx),
             distanceMeters: approxDistanceMeters,
           },
           opts,
         ));
-        state.trafficAnnouncements.set(pairKey, 'LAPPED_AHEAD');
+        state.trafficAnnouncements.set(laKey, 'LAPPED_AHEAD');
       }
-    } else if (leaderLap > chaserLap) {
-      // The car ahead has MORE laps — chaser is about to be lapped.
-      if (existing !== 'BEING_LAPPED') {
-        const car = carRefFromRoster(state, i);
+
+      // BEING_LAPPED — fired from the lapped car's perspective.
+      if (!state.trafficAnnouncements.has(blKey)) {
+        const lappedCar = carRefFromRoster(state, lappedIdx);
         events.push(buildEvent(
           'BEING_LAPPED',
-          car,
+          lappedCar,
           {
-            lappingCar:     carRefFromRoster(state, leaderIdx),
+            lappingCar:     carRefFromRoster(state, lapperIdx),
             distanceMeters: approxDistanceMeters,
           },
           opts,
         ));
-        state.trafficAnnouncements.set(pairKey, 'BEING_LAPPED');
+        state.trafficAnnouncements.set(blKey, 'BEING_LAPPED');
       }
     }
   }
 
-  // Clear traffic announcements for pairs that are no longer close/out-of-lap.
-  for (const pairKey of Array.from(state.trafficAnnouncements.keys())) {
-    if (!seenTrafficPairs.has(pairKey)) {
-      state.trafficAnnouncements.delete(pairKey);
+  // Clear traffic announcements for pairs that are no longer physically close.
+  for (const key of Array.from(state.trafficAnnouncements.keys())) {
+    if (!seenTrafficPairs.has(key)) {
+      state.trafficAnnouncements.delete(key);
     }
   }
 

--- a/src/extensions/iracing/publisher/shared/lifecycle-event-detector.ts
+++ b/src/extensions/iracing/publisher/shared/lifecycle-event-detector.ts
@@ -31,7 +31,7 @@ export interface LifecycleDetectorContext {
 // Constants
 // ---------------------------------------------------------------------------
 
-const HEARTBEAT_INTERVAL_MS = 1_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
 const CAPABILITIES = ['telemetry-v1'];
 const NOCAR = { carIdx: -1, carNumber: '', driverName: '' };
 

--- a/src/extensions/iracing/renderer/PublisherSettings.tsx
+++ b/src/extensions/iracing/renderer/PublisherSettings.tsx
@@ -72,6 +72,7 @@ export const PublisherSettings = () => {
   const [driverEnabled, setDriverEnabled]           = useState(false);
   const [rigId, setRigId]                           = useState('');
   const [driverSessionId, setDriverSessionId]       = useState('');
+  const [registeredDriverName, setRegisteredDriverName] = useState('');
 
   // Live status
   const [publisherStatus, setPublisherStatus]       = useState<PublisherStatus | null>(null);
@@ -109,16 +110,18 @@ export const PublisherSettings = () => {
     const load = async () => {
       if (!window.electronAPI?.config) return;
       try {
-        const [sessEnabled, drvEnabled, id, sessId] = await Promise.all([
+        const [sessEnabled, drvEnabled, id, sessId, driverDisplayName] = await Promise.all([
           window.electronAPI.config.get('publisher.session.enabled'),
           window.electronAPI.config.get('publisher.driver.enabled'),
           window.electronAPI.config.get('publisher.rigId'),
           window.electronAPI.config.get('publisher.driver.sessionId'),
+          window.electronAPI.config.get('publisher.driver.displayName'),
         ]);
         setSessionEnabled(sessEnabled !== false);
         setDriverEnabled(drvEnabled ?? false);
         setRigId(id ?? '');
         setDriverSessionId(sessId ?? '');
+        if (driverDisplayName) setRegisteredDriverName(driverDisplayName);
       } catch (e) {
         console.error('Failed to load publisher config', e);
       }
@@ -186,6 +189,7 @@ export const PublisherSettings = () => {
           setRegistering(false);
           setRegisterResult(r);
           if (r.success) {
+            setRegisteredDriverName(selectedDriverName);
             window.electronAPI?.config?.get('publisher.driver.sessionId').then((v) => {
               if (v) setDriverSessionId(v);
             }).catch(() => {});
@@ -608,10 +612,15 @@ export const PublisherSettings = () => {
                 {registering ? 'Registering…' : 'Register'}
               </Button>
 
-              {/* Current bound session */}
+              {/* Current registration */}
               {driverSessionId && !registerResult?.success && (
                 <p className="text-xs text-muted-foreground font-jetbrains">
-                  Registered: <span className="text-foreground">{driverSessionId}</span>
+                  Registered:{' '}
+                  {registeredDriverName && (
+                    <span className="text-foreground">{registeredDriverName}</span>
+                  )}
+                  {registeredDriverName && ' — '}
+                  <span className="text-foreground">{driverSessionId}</span>
                 </p>
               )}
 

--- a/src/extensions/iracing/renderer/PublisherSettings.tsx
+++ b/src/extensions/iracing/renderer/PublisherSettings.tsx
@@ -277,7 +277,18 @@ export const PublisherSettings = () => {
     setLoadingDrivers(true);
     try {
       const list = await window.electronAPI?.publisher?.listDrivers();
-      if (list) setDrivers(list.map((d) => ({ driverId: d.driverId, displayName: d.displayName, nickname: d.nickname })));
+      if (!list) return;
+      const mapped = list.map((d) => ({ driverId: d.driverId, displayName: d.displayName, nickname: d.nickname }));
+      setDrivers(mapped);
+      // Restore previously selected driver if config has one
+      const savedId = await window.electronAPI?.config?.get('publisher.driver.driverId').catch(() => null);
+      if (savedId) {
+        const found = mapped.find((d) => d.driverId === savedId);
+        if (found) {
+          setSelectedDriverId(found.driverId);
+          setSelectedDriverName(found.displayName);
+        }
+      }
     } catch (e) {
       console.error('Failed to load drivers', e);
     } finally {
@@ -285,10 +296,14 @@ export const PublisherSettings = () => {
     }
   }, []);
 
+  // Auto-load driver list on mount so the previously selected driver is restored
+  useEffect(() => { void loadDrivers(); }, [loadDrivers]);
+
   const handleSelectDriver = useCallback((driverId: string) => {
     setSelectedDriverId(driverId);
     const found = drivers.find((d) => d.driverId === driverId);
     setSelectedDriverName(found?.displayName ?? '');
+    window.electronAPI?.config?.set('publisher.driver.driverId', driverId).catch(() => {});
   }, [drivers]);
 
   const handleRegister = useCallback(async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    exclude: [
+      'node_modules/**',
+      'dist/**',
+      'dist-electron/**',
+      'release/**',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Changes

### 1. BEING_LAPPED / LAPPED_TRAFFIC_AHEAD never fired

**Root cause (two bugs in Step 4 of `detectOvertakeAndBattle`)**

**Bug 1 — Wrong proximity metric (`carIdxF2Time`)**  
`CarIdxF2Time` is a race-position-based time gap. For cars on different laps it equals approximately `lap_delta × lap_time` (~80–90 s), which always exceeds the 2 s threshold. Neither event ever fired in a real race.

**Bug 2 — Only looked one position ahead**  
The scan only examined the car directly ahead in race position, missing the lapping car entirely.

**Fix:** O(n²) scan over all pairs using `carIdxLapDistPct` physical proximity with S/F wrap-around handling. Both `LAPPED_TRAFFIC_AHEAD` and `BEING_LAPPED` fire simultaneously for the same pair with independent latch keys (`la:` / `bl:`).

---

### 2. Publisher heartbeat firing every 1 s (should be 30 s)

`HEARTBEAT_INTERVAL_MS` was incorrectly set to `1_000` in a previous session. Corrected to `30_000` in both `lifecycle-event-detector.ts` and `orchestrator.ts`. Tests updated to use 30 s time offsets.

---

### 3. Publisher page forgets driver selection and registered driver on navigation

Three independent state-loss bugs:

- **Driver list not auto-loaded**: The drivers dropdown was always empty on mount; user had to click "Load Drivers" every time. Fixed by calling `loadDrivers()` automatically via `useEffect` on mount.
- **Selected driver not persisted**: `selectedDriverId` / `selectedDriverName` were pure React state. Fixed by persisting `publisher.driver.driverId` to config on select, and restoring it after `loadDrivers()` fetches the list.
- **Registered driver name not shown**: Only `driverSessionId` was loaded from config on mount; the display name was lost. Fixed by also loading `publisher.driver.displayName` from config and showing `"<Name> — <sessionId>"` in the registration status line.

---

## Tests

All 683 source tests pass. New test suite: `lapping detection — real-world physical-proximity scenarios` (5 tests). Heartbeat tests updated to 30 s timing in both `lifecycle-event-detector.test.ts` and `orchestrator.test.ts`.