### PR TITLE
fix: crash on startup when AppInsights key is not configured in release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,9 @@ jobs:
           echo "VITE_AZURE_TENANT_ID=${{ secrets.VITE_AZURE_TENANT_ID }}" >> .env
           echo "GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env
           echo "GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}" >> .env
+          echo "VITE_APPINSIGHTS_INSTRUMENTATION_KEY=${{ secrets.VITE_APPINSIGHTS_INSTRUMENTATION_KEY }}" >> .env
+          echo "VITE_APPINSIGHTS_INGESTION_ENDPOINT=${{ secrets.VITE_APPINSIGHTS_INGESTION_ENDPOINT }}" >> .env
+          echo "VITE_APPINSIGHTS_APPLICATION_ID=${{ secrets.VITE_APPINSIGHTS_APPLICATION_ID }}" >> .env
         shell: bash
 
       - name: Build and Publish

--- a/src/main/telemetry-config.ts
+++ b/src/main/telemetry-config.ts
@@ -13,7 +13,9 @@ export const telemetryConfig = {
   ingestionEndpoint: process.env.VITE_APPINSIGHTS_INGESTION_ENDPOINT || 'https://westus3-1.in.applicationinsights.azure.com/',
   liveEndpoint: process.env.VITE_APPINSIGHTS_LIVE_ENDPOINT || 'https://westus3.livediagnostics.monitor.azure.com/',
   applicationId: process.env.VITE_APPINSIGHTS_APPLICATION_ID || '',
-  enabled: process.env.VITE_APPINSIGHTS_ENABLED !== 'false', // Default to true
+  // Disabled if explicitly set to 'false' OR if no instrumentation key is configured.
+  // An empty key causes the App Insights SDK to create a broken client that crashes at runtime.
+  enabled: process.env.VITE_APPINSIGHTS_ENABLED !== 'false' && !!process.env.VITE_APPINSIGHTS_INSTRUMENTATION_KEY,
   applicationVersion: app.getVersion(),
   get connectionString() {
     return `InstrumentationKey=${this.instrumentationKey};IngestionEndpoint=${this.ingestionEndpoint};LiveEndpoint=${this.liveEndpoint}`;


### PR DESCRIPTION
## Problem

On any machine that installs from the release package the app crashes immediately on startup with:

```
TypeError: Cannot read properties of undefined (reading 'trackEvent')
  at TelemetryClient.trackEvent
  at TelemetryService.trackEvent
  at EventEmitter.<anonymous>
  at EventEmitter.emit
```

### Root cause

The release `.env` (written by `build.yml`) did not include any `VITE_APPINSIGHTS_*` variables. So on an installed machine:

- `instrumentationKey` is `""` (empty)
- `enabled` defaulted to `true` (only checked for `=== 'false'`, not for empty key)
- `appInsights.setup("InstrumentationKey=;...")` ran and created a broken `TelemetryClient`
- `this.client = appInsights.defaultClient` was set (non-null), so our `if (!this.client) return` guard passed
- `this.client.trackEvent(...)` crashed deep inside the SDK because the internal channel was never initialised

## Fix

**1. `telemetry-config.ts`** — require a non-empty `instrumentationKey` for `enabled` to be `true`:
```ts
enabled: process.env.VITE_APPINSIGHTS_ENABLED !== 'false' && !!process.env.VITE_APPINSIGHTS_INSTRUMENTATION_KEY,
```
This disables telemetry cleanly when the key is absent rather than creating a broken client.

**2. `build.yml`** — add the three missing AppInsights secrets to the `.env` written during release builds so telemetry functions correctly when the secrets are configured in the repo.