### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "director",
-  "version": "0.1.7",
+  "version": "0.3.0",
   "description": "Sim RaceCenter Director UI App",
   "main": "dist-electron/main/main.js",
   "scripts": {


### PR DESCRIPTION
Bumps `package.json` version to `0.3.0` in preparation for the v0.3.0 release.

## What's in v0.3.0

### Features
- **YouTube extension — live chat implementation** ([#134](https://github.com/margic/director/pull/134))
  - `sendMessageToChat` now calls the YouTube Data API v3 (`liveChatMessages.insert`)
  - Dynamic OAuth redirect port (no more hardcoded 3000)
  - DOM-based `MutationObserver` chat scraper script injected into the hidden browser window
  - Real-time `youtube.auth` event plumbing for UI state sync
  - Auto-connect on startup, multi-broadcast preference (live > testing)

### Fixes
- **iRacing publisher heartbeat** — skip tick when no `raceSessionId` is bound ([#134](https://github.com/margic/director/pull/134))

### Security / Maintenance
- Electron upgraded from 39.x → 41.5.0 ([#131](https://github.com/margic/director/pull/131))
- Documents rewritten as code-grounded spec ([#133](https://github.com/margic/director/pull/133))