### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/margic/director/security/code-scanning/1](https://github.com/margic/director/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root so it applies to all jobs by default.  
For this CI workflow (checkout + install + build), the least-privilege baseline is:

- `contents: read`

This preserves existing functionality while ensuring the token cannot write by default. No imports, methods, or extra definitions are needed—just YAML configuration update near the top-level keys (after `on:` and before `jobs:` is a clean placement).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
