### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/margic/director/security/code-scanning/2](https://github.com/margic/director/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is minimally scoped.  
Best fix here: add workflow-level permissions directly under `on:` (or before `jobs:`) with `contents: read`, which is sufficient for checkout and read operations in this pipeline. This keeps existing functionality unchanged while satisfying CodeQL and documenting intent.

File/region to change:
- `.github/workflows/test.yml`
- Insert a root-level `permissions:` block between the trigger section and `jobs:`.

No imports, methods, or extra definitions are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
