### PR TITLE
fix: always send raceContext on check-in POST and PATCH (fixes #142)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -393,10 +393,22 @@ components:
           maxItems: 50
           items:
             $ref: '#/components/schemas/PortableSequence'
+        raceContext:
+          $ref: '#/components/schemas/RaceContext'
+          description: |
+            Live race context snapshot from the Director's simulator at check-in time.
+            The AI Planner uses this to generate phase-appropriate templates:
+            - `sessionType` suppresses irrelevant categories (e.g. no opening/closing
+              templates during Practice or Qualify). Optional — if omitted or empty
+              (e.g. iRacing not yet running), the Planner generates a full template set.
+            - `cautionType` controls whether caution/pace-car templates are generated
+            - `totalLaps` and `lapsRemain` tune lap-phase weighting (early / mid / late race)
+            - `trackName` and `seriesName` personalise template names and descriptions
       required:
         - directorId
         - version
         - capabilities
+        - raceContext
     SessionCheckinResponse:
       type: object
       properties:
@@ -969,6 +981,96 @@ paths:
             Another Director owns this session.
         '404':
           description: No active check-in exists for this session.
+    patch:
+      summary: Refresh Check-In (Update Capabilities)
+      description: >
+        Updates the Director's capabilities on an active check-in and triggers
+        a template re-plan. Use this when the Director gains new features,
+        connects new hardware, updates extensions, or wants to force a refresh
+        of the AI-generated sequence templates mid-session — without wrapping
+        and re-checking-in.
+
+        The check-in TTL is refreshed. Existing templates are replaced by the
+        Planner using the updated capabilities. The current templates continue
+        serving requests while the re-plan runs in the background.
+
+        When `raceContext` is supplied, the Planner uses it to scope the
+        re-generated templates to the correct session type (Practice / Qualify /
+        Race). If omitted, the Planner falls back to the `raceContext` captured
+        at the original POST check-in. The Director **should** include
+        `raceContext` whenever it has live iRacing session data — this enables
+        session-type-scoped re-plans when iRacing connects after check-in.
+      tags:
+        - Director
+      parameters:
+        - in: path
+          name: raceSessionId
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: The ID of the active race session.
+        - in: header
+          name: X-Checkin-Id
+          schema:
+            type: string
+          required: true
+          description: The check-in ID received from the POST checkin response.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - capabilities
+              properties:
+                capabilities:
+                  $ref: '#/components/schemas/DirectorCapabilities'
+                raceContext:
+                  $ref: '#/components/schemas/RaceContext'
+                  description: >
+                    Optional live race context at refresh time. When provided,
+                    the Planner uses it to scope the re-generated templates to
+                    the correct session type (Practice / Qualify / Race).
+                    If omitted, the Planner re-plans using the raceContext
+                    captured at the original POST check-in.
+                sequences:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/PortableSequence'
+                  description: >
+                    Optional updated local sequence library. If provided, these
+                    are used as training examples for the re-plan.
+      responses:
+        '200':
+          description: Capabilities updated and template re-plan triggered.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [refreshed]
+                  checkinId:
+                    type: string
+                  sessionConfig:
+                    $ref: '#/components/schemas/SessionOperationalConfig'
+                  warnings:
+                    type: array
+                    items:
+                      type: string
+        '400':
+          description: Invalid request body or missing X-Checkin-Id.
+        '401':
+          description: Not authenticated.
+        '403':
+          description: >
+            RaceDirector role required, or X-Checkin-Id does not match
+            the active check-in.
+        '404':
+          description: No active check-in or session not found.
   /api/director/v1/sessions:
     get:
       summary: List Active Sessions for Director

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "director",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Sim RaceCenter Director UI App",
   "main": "dist-electron/main/main.js",
   "scripts": {

--- a/src/main/director-types.ts
+++ b/src/main/director-types.ts
@@ -288,8 +288,13 @@ export interface SessionCheckinRequest {
   capabilities: DirectorCapabilities;
   /** Optional: local sequence library for Planner training (max 50, 100KB) */
   sequences?: PortableSequence[];
-  /** Optional: live simulator snapshot at check-in time (issue #114). Enables Planner phase-weighting. */
-  raceContext?: RaceContext;
+  /**
+   * Live simulator snapshot at check-in time. Required by live spec (issue #142).
+   * Send sessionType='' / sessionFlags='disconnected' when iRacing is not yet running —
+   * the Planner will generate a full template set and re-plan when PATCH /checkin is called
+   * after iRacing connects.
+   */
+  raceContext: RaceContext;
 }
 
 export interface SessionCheckinResponse {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -347,17 +347,28 @@ export class SessionManager extends EventEmitter {
       }
     }
 
-    // Include live race context snapshot for Planner phase-weighting (issue #114)
-    if (this.getRaceContext) {
-      try {
-        const raceContext = this.getRaceContext();
-        if (raceContext) {
-          body.raceContext = raceContext;
-          console.log(`[SessionManager] Including raceContext in check-in (sessionType=${raceContext.sessionType})`);
+    // Always include raceContext — live spec requires it (issue #142).
+    // When iRacing is not yet running, send a disconnected snapshot so the Planner
+    // generates a full template set; the PATCH /checkin triggered on iRacing connect
+    // will carry updated capabilities so the Planner re-plans with real session data.
+    {
+      let raceContext: import('./director-types').RaceContext | null = null;
+      if (this.getRaceContext) {
+        try {
+          raceContext = this.getRaceContext();
+        } catch (err) {
+          console.warn('[SessionManager] Failed to get raceContext for check-in:', err);
         }
-      } catch (err) {
-        console.warn('[SessionManager] Failed to get raceContext for check-in:', err);
       }
+      body.raceContext = raceContext ?? {
+        sessionType: '',
+        sessionFlags: 'disconnected',
+        lapsRemain: -1,
+        carCount: 0,
+        drivers: [],
+        contextTimestamp: new Date().toISOString(),
+      };
+      console.log(`[SessionManager] Including raceContext in check-in (sessionType=${body.raceContext.sessionType || '(disconnected)'})`);
     }
 
     const url = `${apiConfig.baseUrl}${apiConfig.endpoints.checkin(raceSessionId)}`;
@@ -516,6 +527,26 @@ export class SessionManager extends EventEmitter {
     }
 
     const capabilities = this.buildCapabilities?.() ?? { intents: [], connections: {} };
+
+    // Include raceContext when available so the Planner can scope re-generated
+    // templates to the correct session type (issue #142 / racecontrol#319).
+    // The PATCH spec now accepts raceContext as optional; if omitted, Race Control
+    // falls back to the raceContext captured at original POST check-in.
+    let raceContext: import('./director-types').RaceContext | undefined;
+    if (this.getRaceContext) {
+      try {
+        raceContext = this.getRaceContext() ?? undefined;
+      } catch {
+        // Non-fatal — PATCH without raceContext is valid; RC uses POST-time fallback.
+      }
+    }
+
+    const patchBody: Record<string, unknown> = { capabilities };
+    if (raceContext) {
+      patchBody.raceContext = raceContext;
+      console.log(`[SessionManager] Refreshing check-in with raceContext (sessionType=${raceContext.sessionType})`);
+    }
+
     const url = `${apiConfig.baseUrl}${apiConfig.endpoints.refreshCheckin(raceSessionId)}`;
 
     try {
@@ -527,7 +558,7 @@ export class SessionManager extends EventEmitter {
           'Content-Type': 'application/json',
           'X-Checkin-Id': this.checkinId,
         },
-        body: JSON.stringify({ capabilities }),
+        body: JSON.stringify(patchBody),
       });
 
       const duration = Date.now() - startTime;

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -328,10 +328,33 @@ export class SessionManager extends EventEmitter {
     const capabilities = this.buildCapabilities?.() ?? { intents: [], connections: {} };
     const directorId = configService.getOrCreateDirectorId();
 
+    // Always include raceContext — live spec requires it (issue #142).
+    // When iRacing is not yet running, send a disconnected snapshot so the Planner
+    // generates a full template set; the PATCH /checkin triggered on iRacing connect
+    // will carry updated capabilities so the Planner re-plans with real session data.
+    let raceContextValue: import('./director-types').RaceContext | null = null;
+    if (this.getRaceContext) {
+      try {
+        raceContextValue = this.getRaceContext();
+      } catch (err) {
+        console.warn('[SessionManager] Failed to get raceContext for check-in:', err);
+      }
+    }
+    const raceContext: import('./director-types').RaceContext = raceContextValue ?? {
+      sessionType: '',
+      sessionFlags: 'disconnected',
+      lapsRemain: -1,
+      carCount: 0,
+      drivers: [],
+      contextTimestamp: new Date().toISOString(),
+    };
+    console.log(`[SessionManager] Including raceContext in check-in (sessionType=${raceContext.sessionType || '(disconnected)'})`);
+
     const body: SessionCheckinRequest = {
       directorId,
       version: app.getVersion(),
       capabilities,
+      raceContext,
     };
 
     // Include local sequences for Planner training
@@ -345,30 +368,6 @@ export class SessionManager extends EventEmitter {
       } catch (err) {
         console.warn('[SessionManager] Failed to gather local sequences:', err);
       }
-    }
-
-    // Always include raceContext — live spec requires it (issue #142).
-    // When iRacing is not yet running, send a disconnected snapshot so the Planner
-    // generates a full template set; the PATCH /checkin triggered on iRacing connect
-    // will carry updated capabilities so the Planner re-plans with real session data.
-    {
-      let raceContext: import('./director-types').RaceContext | null = null;
-      if (this.getRaceContext) {
-        try {
-          raceContext = this.getRaceContext();
-        } catch (err) {
-          console.warn('[SessionManager] Failed to get raceContext for check-in:', err);
-        }
-      }
-      body.raceContext = raceContext ?? {
-        sessionType: '',
-        sessionFlags: 'disconnected',
-        lapsRemain: -1,
-        carCount: 0,
-        drivers: [],
-        contextTimestamp: new Date().toISOString(),
-      };
-      console.log(`[SessionManager] Including raceContext in check-in (sessionType=${body.raceContext.sessionType || '(disconnected)'})`);
     }
 
     const url = `${apiConfig.baseUrl}${apiConfig.endpoints.checkin(raceSessionId)}`;


### PR DESCRIPTION
## Summary

Fixes #142 — Director was not sending `raceContext` on the PATCH `/checkin` call when iRacing connected, causing the Planner to re-generate templates without session type context (Practice/Qualify sessions got Race templates).

## Changes

### `src/main/session-manager.ts`
- **`checkinSession()` (POST):** Always sends `raceContext`. When iRacing is not yet running at check-in time, a disconnected sentinel is sent (`sessionType: '', sessionFlags: 'disconnected', lapsRemain: -1, carCount: 0, drivers: []`) so the Planner generates a full template set and can re-plan correctly when iRacing connects.
- **`refreshCheckin()` (PATCH):** Now includes `raceContext` in the PATCH body when live iRacing session data is available. This allows the Planner to scope re-generated templates to the correct session type when iRacing connects after check-in.

### `src/main/director-types.ts`
- `SessionCheckinRequest.raceContext` changed from optional (`raceContext?: RaceContext`) to required (`raceContext: RaceContext`), matching the live spec (racecontrol PR #318).

### `openapi.yaml`
- Synced with the deployed live spec:
  - `raceContext` added as **required** on `SessionCheckinRequest`
  - PATCH `/checkin` endpoint added with `raceContext` as an **optional** field

## Race Control dependency

Race Control shipped the server-side changes in `margic/racecontrol#318` — PATCH `/checkin` now accepts optional `raceContext` and falls back to the POST-time context if omitted.

## Testing

28/28 tests pass across `checkin-acceptance.test.ts` and `session-manager.test.ts`.

## Version

Bumped `0.3.0` → `0.3.1` (patch release).
