### PR TITLE
fix: replace flat intents[] with extensions[] in DirectorCapabilities

### DIFF
--- a/documents/feature_race_narrative.md
+++ b/documents/feature_race_narrative.md
@@ -282,11 +282,11 @@ Phased so each phase is independently shippable and testable.
 
 ### Phase 1 — Stop the bleeding (the bug fix)
 
-1. **Director #N1** Driver-publisher detectors: scope to `playerCarIdx` only.
-2. **Director #N2** Move `STINT_BEST_LAP` emission from
+1. **Director [#146](https://github.com/margic/director/issues/146)** Driver-publisher detectors: scope to `playerCarIdx` only.
+2. **Director [#147](https://github.com/margic/director/issues/147)** Move `STINT_BEST_LAP` emission from
    `driver-publisher/lap-performance-driver.ts` to
    `session-publisher/lap-performance-session.ts`.
-3. **Director #N3** Introduce `publisher.scope` setting and migrate the two
+3. **Director [#148](https://github.com/margic/director/issues/148)** Introduce `publisher.scope` setting and migrate the two
    legacy flags. `registerDriver()` sets `scope = 'driver'`.
 
 After Phase 1 the duplicate session events from driver rigs are gone, and
@@ -296,30 +296,30 @@ loop that was overwriting state.
 
 ### Phase 2 — Class awareness end-to-end
 
-4. **Director #N4** Make `carRefFromRoster()` always populate
+4. **Director [#149](https://github.com/margic/director/issues/149)** Make `carRefFromRoster()` always populate
    `carClassShortName` and add `carClassId` to `PublisherCarRef`.
-5. **Director #N5** Class-aware `RaceContext.battles` — pair cars by
+5. **Director [#150](https://github.com/margic/director/issues/150)** Class-aware `RaceContext.battles` — pair cars by
    class group, not just adjacent overall position.
-6. **RaceControl #R1** Accept and persist `carClassId` on event refs;
+6. **RaceControl [margic/racecontrol#324](https://github.com/margic/racecontrol/issues/324)** Accept and persist `carClassId` on event refs;
    include in raceEvents projection.
 
 ### Phase 3 — Race-state model
 
-7. **Director #N6** Extend `CarState` and `SessionState` with the trend
+7. **Director [#151](https://github.com/margic/director/issues/151)** Extend `CarState` and `SessionState` with the trend
    fields in §4. Add a `RaceStateAggregator` that updates the rolling
    series on every frame.
-8. **Director #N7** Compute and persist `racePhase` and `classGroups`.
+8. **Director [#152](https://github.com/margic/director/issues/152)** Compute and persist `racePhase` and `classGroups`.
 
 ### Phase 4 — Narrative events
 
-9. **Director #N8** Implement `GAP_CLOSING` / `GAP_OPENING` (and emit them
+9. **Director [#153](https://github.com/margic/director/issues/153)** Implement `GAP_CLOSING` / `GAP_OPENING` (and emit them
    from a new `gap-trend-detector.ts`).
-10. **Director #N9** Implement `CLASS_POSITION_GAIN` / `CLASS_POSITION_LOSS`.
-11. **Director #N10** Implement `IN_PIT_WINDOW` and `FUEL_PROJECTION` using
+10. **Director [#154](https://github.com/margic/director/issues/154)** Implement `CLASS_POSITION_GAIN` / `CLASS_POSITION_LOSS`.
+11. **Director [#155](https://github.com/margic/director/issues/155)** Implement `IN_PIT_WINDOW` and `FUEL_PROJECTION` using
     the new pit-strategy summary.
-12. **Director #N11** Implement `PACE_DROP`, `SECTOR_PERSONAL_BEST`,
+12. **Director [#156](https://github.com/margic/director/issues/156)** Implement `PACE_DROP`, `SECTOR_PERSONAL_BEST`,
     `TYRE_TEMP_DRIFT`, `ENGINE_WARNING`.
-13. **RaceControl #R2** Add the new event type literals to the OpenAPI spec
+13. **RaceControl [margic/racecontrol#325](https://github.com/margic/racecontrol/issues/325)** Add the new event type literals to the OpenAPI spec
     and the validator.
 
 Each new event type ships with detector unit tests in
@@ -359,12 +359,9 @@ These are ready-to-file. Title format follows the existing `margic/director`
 convention ("subsystem: imperative summary"). Body uses the same headings
 as recent issues in the repo.
 
-> NOTE: the agent that produced this document does **not** have a
-> `create_issue` tool available, so these are committed as drafts here.
-> The expectation is that a maintainer opens each one verbatim from the
-> blocks below.
+> NOTE: All issues below have been created. Links are included in each heading.
 
-### Issue N1 — `publisher: scope driver-rig detectors to playerCarIdx only`
+### Issue [#146](https://github.com/margic/director/issues/146) — `publisher: scope driver-rig detectors to playerCarIdx only`
 
 ```text
 ## Context
@@ -398,7 +395,7 @@ relocation (Issue N2).
 Refs: documents/feature_race_narrative.md §5.1
 ```
 
-### Issue N2 — `publisher: move STINT_BEST_LAP to session-publisher`
+### Issue [#147](https://github.com/margic/director/issues/147) — `publisher: move STINT_BEST_LAP to session-publisher`
 
 ```text
 ## Context
@@ -420,7 +417,7 @@ session publisher only.
 Refs: documents/feature_race_narrative.md §5.1, §8 Phase 1
 ```
 
-### Issue N3 — `publisher: introduce publisher.scope setting`
+### Issue [#148](https://github.com/margic/director/issues/148) — `publisher: introduce publisher.scope setting`
 
 ```text
 ## Context
@@ -456,7 +453,7 @@ scope value, asserting which sub-orchestrator is active.
 Refs: documents/feature_race_narrative.md §5
 ```
 
-### Issue N4 — `publisher: always populate carClass on PublisherCarRef`
+### Issue [#149](https://github.com/margic/director/issues/149) — `publisher: always populate carClass on PublisherCarRef`
 
 ```text
 ## Context
@@ -484,7 +481,7 @@ sees `"class": ""` in raceEvents projection.
 Refs: documents/feature_race_narrative.md §5.2, §8 Phase 2
 ```
 
-### Issue N5 — `director: class-aware battles in RaceContext`
+### Issue [#150](https://github.com/margic/director/issues/150) — `director: class-aware battles in RaceContext`
 
 ```text
 ## Context
@@ -509,7 +506,7 @@ src/main/director-orchestrator.ts (lines 230-238)
 Refs: documents/feature_race_narrative.md §8 Phase 2
 ```
 
-### Issue N6 — `publisher: extend CarState/SessionState with trend fields`
+### Issue [#151](https://github.com/margic/director/issues/151) — `publisher: extend CarState/SessionState with trend fields`
 
 ```text
 ## Context
@@ -548,10 +545,10 @@ SessionPublisherOrchestrator.onTelemetryFrame() at the top of the pipeline.
 Refs: documents/feature_race_narrative.md §4, §8 Phase 3
 ```
 
-### Issue N7 — `publisher: compute racePhase and classGroups`
+### Issue [#152](https://github.com/margic/director/issues/152) — `publisher: compute racePhase and classGroups`
 
 ```text
-Subset of N6 — split out so it can ship independently if the trend
+Subset of #151 — split out so it can ship independently if the trend
 window work blocks. racePhase derives from SessionLapsRemain/Total or
 SessionTimeRemain. classGroups recomputes per frame from
 CarIdxClassPosition + CarIdxF2Time.
@@ -559,7 +556,7 @@ CarIdxClassPosition + CarIdxF2Time.
 Refs: documents/feature_race_narrative.md §4
 ```
 
-### Issue N8 — `publisher: emit GAP_CLOSING / GAP_OPENING events`
+### Issue [#153](https://github.com/margic/director/issues/153) — `publisher: emit GAP_CLOSING / GAP_OPENING events`
 
 ```text
 ## Context
@@ -587,7 +584,7 @@ src/extensions/iracing/publisher/driver-publisher/gap-trend-detector.ts
 Refs: documents/feature_race_narrative.md §6, §8 Phase 4
 ```
 
-### Issue N9 — `publisher: emit CLASS_POSITION_GAIN / LOSS`
+### Issue [#154](https://github.com/margic/director/issues/154) — `publisher: emit CLASS_POSITION_GAIN / LOSS`
 
 ```text
 Use PlayerCarClassPosition + 2-frame hysteresis. Payload:
@@ -598,7 +595,7 @@ Wire alongside the existing POSITION_CHANGE detector but driver-scoped.
 Refs: documents/feature_race_narrative.md §6
 ```
 
-### Issue N10 — `publisher: emit IN_PIT_WINDOW and FUEL_PROJECTION`
+### Issue [#155](https://github.com/margic/director/issues/155) — `publisher: emit IN_PIT_WINDOW and FUEL_PROJECTION`
 
 ```text
 ## Context
@@ -616,7 +613,7 @@ and when fuel projection drops below their remaining stint plan.
 Refs: documents/feature_race_narrative.md §6
 ```
 
-### Issue N11 — `publisher: emit PACE_DROP, SECTOR_PERSONAL_BEST, TYRE_TEMP_DRIFT, ENGINE_WARNING`
+### Issue [#156](https://github.com/margic/director/issues/156) — `publisher: emit PACE_DROP, SECTOR_PERSONAL_BEST, TYRE_TEMP_DRIFT, ENGINE_WARNING`
 
 ```text
 Combined narrative-polish issue. Each event implemented in its own
@@ -634,7 +631,7 @@ Refs: documents/feature_race_narrative.md §6
 
 ## Appendix B — Race Control issues to create (`margic/racecontrol`)
 
-### Issue R1 — `telemetry: accept carClassId on PublisherCarRef`
+### Issue [margic/racecontrol#324](https://github.com/margic/racecontrol/issues/324) — `telemetry: accept carClassId on PublisherCarRef`
 
 ```text
 ## Context
@@ -656,7 +653,7 @@ and persist with null class.
 Refs: margic/director documents/feature_race_narrative.md §7
 ```
 
-### Issue R2 — `telemetry: register new event type literals`
+### Issue [margic/racecontrol#325](https://github.com/margic/racecontrol/issues/325) — `telemetry: register new event type literals`
 
 ```text
 ## Context

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -272,10 +272,13 @@ components:
     DirectorCapabilities:
       type: object
       properties:
-        intents:
+        extensions:
           type: array
+          description: |
+            Per-extension capability grouping. Replaces the flat intents[] array
+            (Race Control breaking change, racecontrol#299 / director#163).
           items:
-            $ref: '#/components/schemas/IntentCapability'
+            $ref: '#/components/schemas/DirectorExtensionCapabilities'
         connections:
           type: object
           additionalProperties:
@@ -305,8 +308,47 @@ components:
           items:
             $ref: '#/components/schemas/CapabilityDriver'
       required:
-        - intents
+        - extensions
         - connections
+    DirectorExtensionCapabilities:
+      type: object
+      description: Per-extension capability grouping sent in the check-in payload.
+      properties:
+        extensionId:
+          type: string
+          description: Extension identifier (e.g., "director-iracing")
+        intents:
+          type: array
+          items:
+            $ref: '#/components/schemas/DirectorIntentRegistration'
+        aiContext:
+          type: string
+          description: |
+            Optional prose description of this extension's capabilities,
+            injected verbatim into the AI Planner prompt under EXTENSION CONTEXT.
+      required:
+        - extensionId
+        - intents
+    DirectorIntentRegistration:
+      type: object
+      description: A single intent registration within an extension's capability entry.
+      properties:
+        intent:
+          type: string
+          description: Intent identifier (e.g., "broadcast.showLiveCam")
+        active:
+          type: boolean
+          description: Whether the handler is currently registered and executable
+        schema:
+          type: object
+          additionalProperties: true
+          description: Optional JSON Schema for the intent's payload
+        description:
+          type: string
+          description: Optional per-intent description for AI prompts
+      required:
+        - intent
+        - active
     CameraGroup:
       type: object
       description: An iRacing camera group entry mapping a human-readable name to its numeric SDK ID.
@@ -336,26 +378,6 @@ components:
       required:
         - carNumber
         - userName
-    IntentCapability:
-      type: object
-      properties:
-        intent:
-          type: string
-          description: Intent identifier (e.g., "broadcast.showLiveCam")
-        extensionId:
-          type: string
-          description: Extension providing this intent
-        active:
-          type: boolean
-          description: Whether the handler is currently registered and executable
-        schema:
-          type: object
-          additionalProperties: true
-          description: Optional JSON Schema for the intent's payload
-      required:
-        - intent
-        - extensionId
-        - active
     ConnectionHealth:
       type: object
       properties:

--- a/scripts/test-director-loop.ts
+++ b/scripts/test-director-loop.ts
@@ -95,15 +95,44 @@ async function testCheckIn(): Promise<string | null> {
 
   const url = `${CONFIG.apiBaseUrl}/api/director/v1/sessions/${CONFIG.testSessionId}/checkin`;
 
-  // Build realistic capabilities payload
+  // Build realistic capabilities payload (#163: extensions[] replaces flat intents[])
   const capabilities = {
-    intents: [
-      { intent: 'system.wait', extensionId: 'builtin', active: true },
-      { intent: 'system.log', extensionId: 'builtin', active: true },
-      { intent: 'broadcast.showLiveCam', extensionId: 'iracing-extension', active: true },
-      { intent: 'obs.switchScene', extensionId: 'obs-extension', active: true },
-      { intent: 'communication.announce', extensionId: 'discord-extension', active: true },
-      { intent: 'communication.talkToChat', extensionId: 'youtube-extension', active: true },
+    extensions: [
+      {
+        extensionId: 'builtin',
+        intents: [
+          { intent: 'system.wait', active: true },
+          { intent: 'system.log', active: true },
+        ],
+      },
+      {
+        extensionId: 'iracing-extension',
+        intents: [
+          { intent: 'broadcast.showLiveCam', active: true },
+        ],
+        aiContext: 'The iRacing extension controls Race Director cameras and instant replay playback.',
+      },
+      {
+        extensionId: 'obs-extension',
+        intents: [
+          { intent: 'obs.switchScene', active: true },
+        ],
+        aiContext: 'The OBS extension switches the active OBS Studio video scene.',
+      },
+      {
+        extensionId: 'discord-extension',
+        intents: [
+          { intent: 'communication.announce', active: true },
+        ],
+        aiContext: 'The Discord extension announces messages via text-to-speech in the race team voice channel.',
+      },
+      {
+        extensionId: 'youtube-extension',
+        intents: [
+          { intent: 'communication.talkToChat', active: true },
+        ],
+        aiContext: 'The YouTube extension posts messages to the live stream chat.',
+      },
     ],
     connections: {
       obs: { connected: true, version: '30.0.0' },

--- a/src/main/director-types.ts
+++ b/src/main/director-types.ts
@@ -243,13 +243,21 @@ export interface ConnectionHealth {
   metadata?: Record<string, unknown>;
 }
 
-export interface IntentCapability {
+/** A single intent registration within an extension's capability entry (issue #163). */
+export interface DirectorIntentRegistration {
   intent: string;
-  extensionId: string;
   active: boolean;
   schema?: Record<string, unknown>;
   /** Human-readable description passed verbatim to the Planner LLM (issue #112). */
   description?: string;
+}
+
+/** Per-extension capability grouping — replaces the flat IntentCapability[] (issue #163). */
+export interface DirectorExtensionCapabilities {
+  extensionId: string;
+  intents: DirectorIntentRegistration[];
+  /** Optional prose injected into the AI Planner prompt under EXTENSION CONTEXT (issue #113). */
+  aiContext?: string;
 }
 
 /** iRacing camera group — maps a human-readable name to its numeric SDK ID. */
@@ -266,7 +274,8 @@ export interface CapabilityDriver {
 }
 
 export interface DirectorCapabilities {
-  intents: IntentCapability[];
+  /** Per-extension capability grouping — replaces the flat intents[] (issue #163). */
+  extensions: DirectorExtensionCapabilities[];
   connections: Record<string, ConnectionHealth>;
   /** iRacing camera groups cached from the SDK at check-in time. */
   cameraGroups?: CameraGroup[];
@@ -274,12 +283,6 @@ export interface DirectorCapabilities {
   scenes?: string[];
   /** Drivers in the current simulator session at check-in time. */
   drivers?: CapabilityDriver[];
-  /**
-   * Per-extension AI context prose blocks (issue #113).
-   * Race Control injects these verbatim into the Planner prompt
-   * under a dedicated EXTENSION CONTEXT section.
-   */
-  extensionContexts?: Array<{ extensionId: string; aiContext: string }>;
 }
 
 export interface SessionCheckinRequest {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -227,27 +227,36 @@ app.on('ready', () => {
 
     const scenes: string[] = obsPayload?.scenes ?? [];
 
-    // #112: only include broadcast intents in capabilities — exclude operational/query
-    const broadcastIntents = allIntents
-      .filter(entry => (entry.intent.category ?? 'broadcast') === 'broadcast')
-      .map(entry => ({
+    // #112: only include broadcast intents — exclude operational/query
+    // #163: group by extensionId into extensions[] (replaces flat intents[])
+    const broadcastIntents = allIntents.filter(entry => (entry.intent.category ?? 'broadcast') === 'broadcast');
+
+    const extensionMap = new Map<string, import('./director-types').DirectorExtensionCapabilities>();
+    for (const entry of broadcastIntents) {
+      if (!extensionMap.has(entry.extensionId)) {
+        extensionMap.set(entry.extensionId, { extensionId: entry.extensionId, intents: [] });
+      }
+      extensionMap.get(entry.extensionId)!.intents.push({
         intent: entry.intent.intent,
-        extensionId: entry.extensionId,
         active: entry.enabled,
         schema: entry.intent.schema as Record<string, unknown> | undefined,
         description: entry.intent.description,
-      }));
+      });
+    }
 
-    // #113: collect per-extension aiContext prose for the Planner
-    const extensionContexts = catalog.getExtensionAiContexts();
+    // #113: attach per-extension aiContext prose for the Planner
+    for (const { extensionId, aiContext } of catalog.getExtensionAiContexts()) {
+      if (extensionMap.has(extensionId)) {
+        extensionMap.get(extensionId)!.aiContext = aiContext;
+      }
+    }
 
     return {
-      intents: broadcastIntents,
+      extensions: Array.from(extensionMap.values()),
       connections,
       ...(cameraGroups.length > 0 && { cameraGroups }),
       ...(scenes.length > 0 && { scenes }),
       ...(drivers.length > 0 && { drivers }),
-      ...(extensionContexts.length > 0 && { extensionContexts }),
     };
   });
   sessionManager.setLocalSequencesGetter(async () => {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -325,7 +325,7 @@ export class SessionManager extends EventEmitter {
       return this.getState();
     }
 
-    const capabilities = this.buildCapabilities?.() ?? { intents: [], connections: {} };
+    const capabilities = this.buildCapabilities?.() ?? { extensions: [], connections: {} };
     const directorId = configService.getOrCreateDirectorId();
 
     // Always include raceContext — live spec requires it (issue #142).
@@ -525,7 +525,7 @@ export class SessionManager extends EventEmitter {
       return this.getState();
     }
 
-    const capabilities = this.buildCapabilities?.() ?? { intents: [], connections: {} };
+    const capabilities = this.buildCapabilities?.() ?? { extensions: [], connections: {} };
 
     // Include raceContext when available so the Planner can scope re-generated
     // templates to the correct session type (issue #142 / racecontrol#319).


### PR DESCRIPTION
Closes #163

## Summary

Implements the breaking change from Race Control ([racecontrol#299](https://github.com/margic/racecontrol/issues/299)) — the flat `capabilities.intents[]` array has been replaced with a per-extension grouping `capabilities.extensions[]`.

## Changes

### `src/main/director-types.ts`
- Removed `IntentCapability` interface
- Added `DirectorIntentRegistration` — intent/active/schema/description (no `extensionId`)
- Added `DirectorExtensionCapabilities` — extensionId + intents[] + optional `aiContext`
- Updated `DirectorCapabilities` — `extensions: DirectorExtensionCapabilities[]` replaces `intents[]`; `extensionContexts` removed (folded into `aiContext` on each extension entry)

### `src/main/main.ts`
- Updated capabilities builder to group broadcast intents by `extensionId` and attach `aiContext` from the catalog, returning `extensions[]`

### `src/main/session-manager.ts`
- Updated both fallback capability objects from `{ intents: [] }` to `{ extensions: [] }`

### `scripts/test-director-loop.ts`
- Updated hardcoded check-in payload to the new grouped format with `aiContext` per extension

### `openapi.yaml`
- `DirectorCapabilities` updated: `extensions` required, `intents` removed
- `IntentCapability` schema removed
- `DirectorExtensionCapabilities` and `DirectorIntentRegistration` schemas added

## Verification

- Schemas verified against the official spec at https://simracecenter.com/api/openapi.yaml — exact match
- All 703 tests pass