### PR TITLE
feat(orchestrator): class-aware battles in RaceContext (#150)

### DIFF
--- a/documents/feature_race_narrative.md
+++ b/documents/feature_race_narrative.md
@@ -282,11 +282,11 @@ Phased so each phase is independently shippable and testable.
 
 ### Phase 1 — Stop the bleeding (the bug fix)
 
-1. **Director #N1** Driver-publisher detectors: scope to `playerCarIdx` only.
-2. **Director #N2** Move `STINT_BEST_LAP` emission from
+1. **Director [#146](https://github.com/margic/director/issues/146)** Driver-publisher detectors: scope to `playerCarIdx` only.
+2. **Director [#147](https://github.com/margic/director/issues/147)** Move `STINT_BEST_LAP` emission from
    `driver-publisher/lap-performance-driver.ts` to
    `session-publisher/lap-performance-session.ts`.
-3. **Director #N3** Introduce `publisher.scope` setting and migrate the two
+3. **Director [#148](https://github.com/margic/director/issues/148)** Introduce `publisher.scope` setting and migrate the two
    legacy flags. `registerDriver()` sets `scope = 'driver'`.
 
 After Phase 1 the duplicate session events from driver rigs are gone, and
@@ -296,30 +296,30 @@ loop that was overwriting state.
 
 ### Phase 2 — Class awareness end-to-end
 
-4. **Director #N4** Make `carRefFromRoster()` always populate
+4. **Director [#149](https://github.com/margic/director/issues/149)** Make `carRefFromRoster()` always populate
    `carClassShortName` and add `carClassId` to `PublisherCarRef`.
-5. **Director #N5** Class-aware `RaceContext.battles` — pair cars by
+5. **Director [#150](https://github.com/margic/director/issues/150)** Class-aware `RaceContext.battles` — pair cars by
    class group, not just adjacent overall position.
-6. **RaceControl #R1** Accept and persist `carClassId` on event refs;
+6. **RaceControl [margic/racecontrol#324](https://github.com/margic/racecontrol/issues/324)** Accept and persist `carClassId` on event refs;
    include in raceEvents projection.
 
 ### Phase 3 — Race-state model
 
-7. **Director #N6** Extend `CarState` and `SessionState` with the trend
+7. **Director [#151](https://github.com/margic/director/issues/151)** Extend `CarState` and `SessionState` with the trend
    fields in §4. Add a `RaceStateAggregator` that updates the rolling
    series on every frame.
-8. **Director #N7** Compute and persist `racePhase` and `classGroups`.
+8. **Director [#152](https://github.com/margic/director/issues/152)** Compute and persist `racePhase` and `classGroups`.
 
 ### Phase 4 — Narrative events
 
-9. **Director #N8** Implement `GAP_CLOSING` / `GAP_OPENING` (and emit them
+9. **Director [#153](https://github.com/margic/director/issues/153)** Implement `GAP_CLOSING` / `GAP_OPENING` (and emit them
    from a new `gap-trend-detector.ts`).
-10. **Director #N9** Implement `CLASS_POSITION_GAIN` / `CLASS_POSITION_LOSS`.
-11. **Director #N10** Implement `IN_PIT_WINDOW` and `FUEL_PROJECTION` using
+10. **Director [#154](https://github.com/margic/director/issues/154)** Implement `CLASS_POSITION_GAIN` / `CLASS_POSITION_LOSS`.
+11. **Director [#155](https://github.com/margic/director/issues/155)** Implement `IN_PIT_WINDOW` and `FUEL_PROJECTION` using
     the new pit-strategy summary.
-12. **Director #N11** Implement `PACE_DROP`, `SECTOR_PERSONAL_BEST`,
+12. **Director [#156](https://github.com/margic/director/issues/156)** Implement `PACE_DROP`, `SECTOR_PERSONAL_BEST`,
     `TYRE_TEMP_DRIFT`, `ENGINE_WARNING`.
-13. **RaceControl #R2** Add the new event type literals to the OpenAPI spec
+13. **RaceControl [margic/racecontrol#325](https://github.com/margic/racecontrol/issues/325)** Add the new event type literals to the OpenAPI spec
     and the validator.
 
 Each new event type ships with detector unit tests in
@@ -359,12 +359,9 @@ These are ready-to-file. Title format follows the existing `margic/director`
 convention ("subsystem: imperative summary"). Body uses the same headings
 as recent issues in the repo.
 
-> NOTE: the agent that produced this document does **not** have a
-> `create_issue` tool available, so these are committed as drafts here.
-> The expectation is that a maintainer opens each one verbatim from the
-> blocks below.
+> NOTE: All issues below have been created. Links are included in each heading.
 
-### Issue N1 — `publisher: scope driver-rig detectors to playerCarIdx only`
+### Issue [#146](https://github.com/margic/director/issues/146) — `publisher: scope driver-rig detectors to playerCarIdx only`
 
 ```text
 ## Context
@@ -398,7 +395,7 @@ relocation (Issue N2).
 Refs: documents/feature_race_narrative.md §5.1
 ```
 
-### Issue N2 — `publisher: move STINT_BEST_LAP to session-publisher`
+### Issue [#147](https://github.com/margic/director/issues/147) — `publisher: move STINT_BEST_LAP to session-publisher`
 
 ```text
 ## Context
@@ -420,7 +417,7 @@ session publisher only.
 Refs: documents/feature_race_narrative.md §5.1, §8 Phase 1
 ```
 
-### Issue N3 — `publisher: introduce publisher.scope setting`
+### Issue [#148](https://github.com/margic/director/issues/148) — `publisher: introduce publisher.scope setting`
 
 ```text
 ## Context
@@ -456,7 +453,7 @@ scope value, asserting which sub-orchestrator is active.
 Refs: documents/feature_race_narrative.md §5
 ```
 
-### Issue N4 — `publisher: always populate carClass on PublisherCarRef`
+### Issue [#149](https://github.com/margic/director/issues/149) — `publisher: always populate carClass on PublisherCarRef`
 
 ```text
 ## Context
@@ -484,7 +481,7 @@ sees `"class": ""` in raceEvents projection.
 Refs: documents/feature_race_narrative.md §5.2, §8 Phase 2
 ```
 
-### Issue N5 — `director: class-aware battles in RaceContext`
+### Issue [#150](https://github.com/margic/director/issues/150) — `director: class-aware battles in RaceContext`
 
 ```text
 ## Context
@@ -509,7 +506,7 @@ src/main/director-orchestrator.ts (lines 230-238)
 Refs: documents/feature_race_narrative.md §8 Phase 2
 ```
 
-### Issue N6 — `publisher: extend CarState/SessionState with trend fields`
+### Issue [#151](https://github.com/margic/director/issues/151) — `publisher: extend CarState/SessionState with trend fields`
 
 ```text
 ## Context
@@ -548,10 +545,10 @@ SessionPublisherOrchestrator.onTelemetryFrame() at the top of the pipeline.
 Refs: documents/feature_race_narrative.md §4, §8 Phase 3
 ```
 
-### Issue N7 — `publisher: compute racePhase and classGroups`
+### Issue [#152](https://github.com/margic/director/issues/152) — `publisher: compute racePhase and classGroups`
 
 ```text
-Subset of N6 — split out so it can ship independently if the trend
+Subset of #151 — split out so it can ship independently if the trend
 window work blocks. racePhase derives from SessionLapsRemain/Total or
 SessionTimeRemain. classGroups recomputes per frame from
 CarIdxClassPosition + CarIdxF2Time.
@@ -559,7 +556,7 @@ CarIdxClassPosition + CarIdxF2Time.
 Refs: documents/feature_race_narrative.md §4
 ```
 
-### Issue N8 — `publisher: emit GAP_CLOSING / GAP_OPENING events`
+### Issue [#153](https://github.com/margic/director/issues/153) — `publisher: emit GAP_CLOSING / GAP_OPENING events`
 
 ```text
 ## Context
@@ -587,7 +584,7 @@ src/extensions/iracing/publisher/driver-publisher/gap-trend-detector.ts
 Refs: documents/feature_race_narrative.md §6, §8 Phase 4
 ```
 
-### Issue N9 — `publisher: emit CLASS_POSITION_GAIN / LOSS`
+### Issue [#154](https://github.com/margic/director/issues/154) — `publisher: emit CLASS_POSITION_GAIN / LOSS`
 
 ```text
 Use PlayerCarClassPosition + 2-frame hysteresis. Payload:
@@ -598,7 +595,7 @@ Wire alongside the existing POSITION_CHANGE detector but driver-scoped.
 Refs: documents/feature_race_narrative.md §6
 ```
 
-### Issue N10 — `publisher: emit IN_PIT_WINDOW and FUEL_PROJECTION`
+### Issue [#155](https://github.com/margic/director/issues/155) — `publisher: emit IN_PIT_WINDOW and FUEL_PROJECTION`
 
 ```text
 ## Context
@@ -616,7 +613,7 @@ and when fuel projection drops below their remaining stint plan.
 Refs: documents/feature_race_narrative.md §6
 ```
 
-### Issue N11 — `publisher: emit PACE_DROP, SECTOR_PERSONAL_BEST, TYRE_TEMP_DRIFT, ENGINE_WARNING`
+### Issue [#156](https://github.com/margic/director/issues/156) — `publisher: emit PACE_DROP, SECTOR_PERSONAL_BEST, TYRE_TEMP_DRIFT, ENGINE_WARNING`
 
 ```text
 Combined narrative-polish issue. Each event implemented in its own
@@ -634,7 +631,7 @@ Refs: documents/feature_race_narrative.md §6
 
 ## Appendix B — Race Control issues to create (`margic/racecontrol`)
 
-### Issue R1 — `telemetry: accept carClassId on PublisherCarRef`
+### Issue [margic/racecontrol#324](https://github.com/margic/racecontrol/issues/324) — `telemetry: accept carClassId on PublisherCarRef`
 
 ```text
 ## Context
@@ -656,7 +653,7 @@ and persist with null class.
 Refs: margic/director documents/feature_race_narrative.md §7
 ```
 
-### Issue R2 — `telemetry: register new event type literals`
+### Issue [margic/racecontrol#325](https://github.com/margic/racecontrol/issues/325) — `telemetry: register new event type literals`
 
 ```text
 ## Context

--- a/src/main/director-orchestrator.test.ts
+++ b/src/main/director-orchestrator.test.ts
@@ -510,4 +510,86 @@ describe('DirectorOrchestrator', () => {
       expect(mockSessionManager.refreshCheckin).not.toHaveBeenCalled();
     });
   });
+
+  describe('getRaceContext - class-aware battles (#150)', () => {
+    /** Helper: emit a raceStateChanged event with the given cars list. */
+    function emitRaceState(cars: any[]) {
+      mockEventBus.emit('iracing.raceStateChanged', {
+        payload: {
+          sessionFlags: 0,
+          sessionType: 'Race',
+          totalSessionLaps: 50,
+          sessionLapsRemain: 25,
+          cars,
+        },
+      });
+    }
+
+    it('does not pair a GT3 with the LMP2 directly ahead in mixed-class field', () => {
+      // 6 cars by overall position: LMP2 leads, then a GT3 0.5s back, then more.
+      // Same-class adjacency tests: GT3-GT3 close, LMP2-LMP2 close.
+      const cars = [
+        // overall pos 1: LMP2 #1 (leader, no gap)
+        { carNumber: '1',  carClass: 'LMP2', classPosition: 1, position: 1, gapToCarAhead: 0,   lapsCompleted: 10 },
+        // overall pos 2: GT3 #10, 0.5s behind LMP2 #1 — must NOT be a battle
+        { carNumber: '10', carClass: 'GT3',  classPosition: 1, position: 2, gapToCarAhead: 0.5, lapsCompleted: 10 },
+        // overall pos 3: LMP2 #2, 1.0s behind GT3 #10 (=> 1.5s behind LMP2 #1)
+        { carNumber: '2',  carClass: 'LMP2', classPosition: 2, position: 3, gapToCarAhead: 1.0, lapsCompleted: 10 },
+        // overall pos 4: GT3 #11, 0.4s behind LMP2 #2 (=> 1.4s gap to GT3 #10) — NOT a battle
+        { carNumber: '11', carClass: 'GT3',  classPosition: 2, position: 4, gapToCarAhead: 0.4, lapsCompleted: 10 },
+        // overall pos 5: GT3 #12, 0.3s behind GT3 #11 — IS a same-class battle
+        { carNumber: '12', carClass: 'GT3',  classPosition: 3, position: 5, gapToCarAhead: 0.3, lapsCompleted: 10 },
+        // overall pos 6: LMP2 #3, 4.0s back — no battles
+        { carNumber: '3',  carClass: 'LMP2', classPosition: 3, position: 6, gapToCarAhead: 4.0, lapsCompleted: 10 },
+      ];
+      emitRaceState(cars);
+
+      const ctx = (orchestrator as any).getRaceContext();
+
+      expect(ctx.battles).toBeDefined();
+      // Only the GT3 #11 vs GT3 #12 pair (gap 0.3) qualifies.
+      expect(ctx.battles).toHaveLength(1);
+      expect(ctx.battles[0]).toEqual({ cars: ['11', '12'], gapSec: 0.3 });
+    });
+
+    it('detects multiple same-class battles in different classes', () => {
+      const cars = [
+        { carNumber: '1',  carClass: 'LMP2', classPosition: 1, position: 1, gapToCarAhead: 0,   lapsCompleted: 10 },
+        { carNumber: '2',  carClass: 'LMP2', classPosition: 2, position: 2, gapToCarAhead: 0.6, lapsCompleted: 10 }, // LMP2 battle
+        { carNumber: '10', carClass: 'GT3',  classPosition: 1, position: 3, gapToCarAhead: 5.0, lapsCompleted: 10 },
+        { carNumber: '11', carClass: 'GT3',  classPosition: 2, position: 4, gapToCarAhead: 0.8, lapsCompleted: 10 }, // GT3 battle
+      ];
+      emitRaceState(cars);
+
+      const ctx = (orchestrator as any).getRaceContext();
+
+      expect(ctx.battles).toHaveLength(2);
+      expect(ctx.battles).toContainEqual({ cars: ['1', '2'], gapSec: 0.6 });
+      expect(ctx.battles).toContainEqual({ cars: ['10', '11'], gapSec: 0.8 });
+    });
+
+    it('sums the gap across other-class cars between two same-class cars', () => {
+      // LMP2 #1, GT3 #10 (0.4s back), LMP2 #2 (0.4s back) → LMP2#1↔LMP2#2 gap = 0.8s, IS battle
+      const cars = [
+        { carNumber: '1',  carClass: 'LMP2', classPosition: 1, position: 1, gapToCarAhead: 0,   lapsCompleted: 10 },
+        { carNumber: '10', carClass: 'GT3',  classPosition: 1, position: 2, gapToCarAhead: 0.4, lapsCompleted: 10 },
+        { carNumber: '2',  carClass: 'LMP2', classPosition: 2, position: 3, gapToCarAhead: 0.4, lapsCompleted: 10 },
+      ];
+      emitRaceState(cars);
+
+      const ctx = (orchestrator as any).getRaceContext();
+      expect(ctx.battles).toEqual([{ cars: ['1', '2'], gapSec: 0.8 }]);
+    });
+
+    it('returns no battles when same-class gap is >= 1.0s', () => {
+      const cars = [
+        { carNumber: '1',  carClass: 'LMP2', classPosition: 1, position: 1, gapToCarAhead: 0,   lapsCompleted: 10 },
+        { carNumber: '2',  carClass: 'LMP2', classPosition: 2, position: 2, gapToCarAhead: 1.5, lapsCompleted: 10 },
+      ];
+      emitRaceState(cars);
+
+      const ctx = (orchestrator as any).getRaceContext();
+      expect(ctx.battles).toBeUndefined();
+    });
+  });
 });

--- a/src/main/director-orchestrator.ts
+++ b/src/main/director-orchestrator.ts
@@ -226,15 +226,39 @@ export class DirectorOrchestrator extends EventEmitter {
       .filter((c: any) => c.onPitRoad)
       .map((c: any) => String(c.carNumber ?? ''));
 
-    // Active battles: pairs of cars within 1.0s of each other
+    // Active battles: same-class adjacent pairs within 1.0s.
+    // Issue #150 — group cars by class first; in multi-class sessions a GT3
+    // sitting 0.5s behind an LMP2 is not a real battle. We sum the
+    // overall-order `gapToCarAhead` values between two same-class cars to
+    // get the inter-class gap (cars[] is already overall-position sorted).
     const battles: Array<{ cars: string[]; gapSec: number }> = [];
-    for (let i = 1; i < cars.length; i++) {
-      const gap = cars[i].gapToCarAhead ?? 0;
-      if (gap > 0 && gap < 1.0) {
-        battles.push({
-          cars: [String(cars[i - 1].carNumber ?? ''), String(cars[i].carNumber ?? '')],
-          gapSec: Math.round(gap * 1000) / 1000,
-        });
+    const carsByClass = new Map<string, number[]>(); // carClass → indices into cars[] (overall order)
+    for (let i = 0; i < cars.length; i++) {
+      const cls = String(cars[i].carClass ?? '');
+      if (!carsByClass.has(cls)) carsByClass.set(cls, []);
+      carsByClass.get(cls)!.push(i);
+    }
+    for (const indices of carsByClass.values()) {
+      // indices are already in overall-position order, which matches classPosition order
+      // for cars within the same class.
+      for (let k = 1; k < indices.length; k++) {
+        const aheadIdx = indices[k - 1];
+        const behindIdx = indices[k];
+        // Sum gap-to-ahead from aheadIdx+1 through behindIdx (inclusive) to get
+        // the cumulative gap across any other-class cars between them.
+        let gap = 0;
+        let valid = true;
+        for (let j = aheadIdx + 1; j <= behindIdx; j++) {
+          const g = cars[j].gapToCarAhead ?? 0;
+          if (g <= 0) { valid = false; break; }
+          gap += g;
+        }
+        if (valid && gap < 1.0) {
+          battles.push({
+            cars: [String(cars[aheadIdx].carNumber ?? ''), String(cars[behindIdx].carNumber ?? '')],
+            gapSec: Math.round(gap * 1000) / 1000,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
Closes #150 — Phase 2 of the [race narrative plan](../blob/main/documents/feature_race_narrative.md).

## Problem
`DirectorOrchestrator.getRaceContext()` walked `cars[]` in overall position order and emitted a battle whenever two adjacent cars were within 1.0s. In multi-class sessions this produced false positives — e.g. a GT3 sitting 0.5s behind an LMP2 was reported as a "battle" even though the cars are racing in different classes.

## Fix
Group cars by `carClass` first, then walk same-class adjacent pairs:

1. Bucket `cars[]` by `carClass` (preserves overall-position order, which matches `classPosition` order within each class).
2. For each adjacent same-class pair, sum `gapToCarAhead` across any other-class cars between them to get the true inter-class gap.
3. Emit a battle only if that cumulative gap is `> 0 && < 1.0`.

## Tests
4 new unit tests in `director-orchestrator.test.ts` covering:
- Mixed-class field where a GT3 is 0.5s behind an LMP2 → no battle for that pair, but a same-class GT3 pair at 0.3s is a battle.
- Multiple same-class battles in different classes detected independently.
- Gap correctly summed across an interleaved other-class car (LMP2 → GT3 → LMP2 with 0.4s + 0.4s = 0.8s LMP2-LMP2 battle).
- No battles emitted when same-class gap ≥ 1.0s.

All 707 tests pass (was 703 before; +4 new).

## Race narrative plan tracking
- ✅ Phase 1 (#146, #147, #148)
- ✅ Phase 2: #149, **this PR (#150)**, racecontrol#324 still open cloud-side
- ⏭ Phase 3 (#151, #152) and Phase 4 (#153–#156) remain unchanged and still apply.