### PR TITLE
feat(publisher): race narrative state aggregator + 4 new detectors (#151–#156)

### DIFF
--- a/src/extensions/iracing/index.ts
+++ b/src/extensions/iracing/index.ts
@@ -755,6 +755,21 @@ function buildTelemetryFrame(): TelemetryFrame | null {
         steeringWheelPctTorque: readVarFloat('SteeringWheelPctTorque', buf.offset),
         solarAltitude:          readVarFloat('SolarAltitude',          buf.offset),
         carIdxSpeed:            readVarFloat('CarIdxSpeed',            buf.offset),
+
+        // Race-narrative additions (#151–#156). Each may be missing on
+        // older iRacing builds — assembleTelemetryFrame defaults to 0/-1.
+        sessionLapsRemain:   readVarInt('SessionLapsRemainEx', buf.offset)
+                          ?? readVarInt('SessionLapsRemain',   buf.offset),
+        sessionLapsTotal:    readVarInt('SessionLapsTotal',    buf.offset),
+        sessionTimeRemain:   readVarFloat('SessionTimeRemain', buf.offset),
+        lapDeltaToBestLap:   readVarFloat('LapDeltaToBestLap', buf.offset),
+        lapDeltaToBestLapOk: readVarInt('LapDeltaToBestLap_OK', buf.offset),
+        engineWarnings:      readVarInt('EngineWarnings',      buf.offset),
+        fuelUsePerHour:      readVarFloat('FuelUsePerHour',    buf.offset),
+        lfTempCM:            readVarFloat('LFtempCM',          buf.offset),
+        rfTempCM:            readVarFloat('RFtempCM',          buf.offset),
+        lrTempCM:            readVarFloat('LRtempCM',          buf.offset),
+        rrTempCM:            readVarFloat('RRtempCM',          buf.offset),
     };
 
     return assembleTelemetryFrame(reads);

--- a/src/extensions/iracing/publisher/__tests__/class-position-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/class-position-detector.test.ts
@@ -1,0 +1,47 @@
+/**
+ * class-position-detector.test.ts — Issue #154
+ */
+import { describe, it, expect } from 'vitest';
+import { detectClassPositionChange } from '../driver-publisher/class-position-detector';
+import { aggregateRaceState } from '../shared/race-state-aggregator';
+import { createSessionState } from '../session-state';
+import { makeFrame, seedRoster } from './frame-fixtures';
+import type { TelemetryFrame } from '../session-state';
+
+const PLAYER = 0;
+const ctx = { rigId: 'r1', raceSessionId: 's1', playerCarIdx: PLAYER };
+
+describe('detectClassPositionChange (#154)', () => {
+  it('emits CLASS_POSITION_GAIN after 2-frame hysteresis', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    let prev: TelemetryFrame | null = null;
+    let allEvents: any[] = [];
+    // Sequence: cp=3, cp=3, cp=2, cp=2, cp=2 (must see cp=2 twice in history before emit)
+    for (const cp of [3, 3, 2, 2, 2]) {
+      const frame = makeFrame({ cars: [{ carIdx: PLAYER, classPosition: cp }] });
+      aggregateRaceState(prev, frame, state, { playerCarIdx: PLAYER });
+      allEvents = allEvents.concat(detectClassPositionChange(prev, frame, state, ctx));
+      prev = frame;
+    }
+    const gains = allEvents.filter((e) => e.type === 'CLASS_POSITION_GAIN');
+    expect(gains.length).toBe(1);
+    expect(gains[0].payload.previousClassPos).toBe(3);
+    expect(gains[0].payload.newClassPos).toBe(2);
+  });
+
+  it('emits CLASS_POSITION_LOSS when classPosition increases', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    let prev: TelemetryFrame | null = null;
+    let allEvents: any[] = [];
+    for (const cp of [2, 2, 3, 3, 3]) {
+      const frame = makeFrame({ cars: [{ carIdx: PLAYER, classPosition: cp }] });
+      aggregateRaceState(prev, frame, state, { playerCarIdx: PLAYER });
+      allEvents = allEvents.concat(detectClassPositionChange(prev, frame, state, ctx));
+      prev = frame;
+    }
+    const losses = allEvents.filter((e) => e.type === 'CLASS_POSITION_LOSS');
+    expect(losses.length).toBe(1);
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/frame-fixtures.ts
+++ b/src/extensions/iracing/publisher/__tests__/frame-fixtures.ts
@@ -141,6 +141,18 @@ export interface FrameOptions {
   steeringWheelAngle?: number;
   steeringWheelPctTorque?: number;
   solarAltitude?: number;
+  // Race-narrative additions (#151–#156)
+  sessionLapsRemain?: number;
+  sessionLapsTotal?: number;
+  sessionTimeRemain?: number;
+  lapDeltaToBestLap?: number;
+  lapDeltaToBestLapOk?: number;
+  engineWarnings?: number;
+  fuelUsePerHour?: number;
+  lfTempCM?: number;
+  rfTempCM?: number;
+  lrTempCM?: number;
+  rrTempCM?: number;
   // Per-car slot overrides
   cars?: CarSlotOverride[];
 }
@@ -205,6 +217,17 @@ export function makeFrame(opts: FrameOptions = {}): TelemetryFrame {
     steeringWheelAngle:       opts.steeringWheelAngle       ?? 0,
     steeringWheelPctTorque:   opts.steeringWheelPctTorque   ?? 0,
     solarAltitude:            opts.solarAltitude            ?? 0.3, // midday
+    sessionLapsRemain:        opts.sessionLapsRemain        ?? -1,
+    sessionLapsTotal:         opts.sessionLapsTotal         ?? -1,
+    sessionTimeRemain:        opts.sessionTimeRemain        ?? -1,
+    lapDeltaToBestLap:        opts.lapDeltaToBestLap        ?? 0,
+    lapDeltaToBestLapOk:      opts.lapDeltaToBestLapOk      ?? 0,
+    engineWarnings:           opts.engineWarnings           ?? 0,
+    fuelUsePerHour:           opts.fuelUsePerHour           ?? 0,
+    lfTempCM:                 opts.lfTempCM                 ?? 0,
+    rfTempCM:                 opts.rfTempCM                 ?? 0,
+    lrTempCM:                 opts.lrTempCM                 ?? 0,
+    rrTempCM:                 opts.rrTempCM                 ?? 0,
   };
 }
 

--- a/src/extensions/iracing/publisher/__tests__/gap-trend-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/gap-trend-detector.test.ts
@@ -1,0 +1,79 @@
+/**
+ * gap-trend-detector.test.ts — Issue #153
+ */
+import { describe, it, expect } from 'vitest';
+import { detectGapTrend } from '../driver-publisher/gap-trend-detector';
+import { aggregateRaceState } from '../shared/race-state-aggregator';
+import { createSessionState } from '../session-state';
+import { makeFrame, seedRoster } from './frame-fixtures';
+import type { TelemetryFrame } from '../session-state';
+
+const PLAYER = 0;
+const AHEAD = 1;
+const ctx = { rigId: 'r1', raceSessionId: 's1', playerCarIdx: PLAYER };
+
+describe('detectGapTrend (#153)', () => {
+  it('emits GAP_CLOSING when gap shrinks 2.8 → 1.4 within 3.0s', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER, AHEAD]);
+    let prev: TelemetryFrame | null = null;
+    let allEvents: any[] = [];
+    for (const [t, gap] of [[0, 2.8], [1, 2.4], [2, 2.0], [3, 1.5]] as Array<[number, number]>) {
+      const frame = makeFrame({
+        sessionTime: t,
+        cars: [
+          { carIdx: PLAYER, position: 2, f2Time: gap },
+          { carIdx: AHEAD,  position: 1, f2Time: 0 },
+        ],
+      });
+      aggregateRaceState(prev, frame, state, { playerCarIdx: PLAYER });
+      const events = detectGapTrend(prev, frame, state, ctx);
+      allEvents = allEvents.concat(events);
+      prev = frame;
+    }
+    const closing = allEvents.filter((e) => e.type === 'GAP_CLOSING');
+    expect(closing.length).toBeGreaterThanOrEqual(1);
+    expect(closing[0].payload.direction).toBe('ahead');
+    expect(closing[0].payload.closingRateSecPerLap).toBeGreaterThan(0);
+  });
+
+  it('does not emit when the gap is already > 3.0s', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER, AHEAD]);
+    let prev: TelemetryFrame | null = null;
+    let allEvents: any[] = [];
+    for (const [t, gap] of [[0, 5.0], [1, 4.5], [2, 4.0], [3, 3.5]] as Array<[number, number]>) {
+      const frame = makeFrame({
+        sessionTime: t,
+        cars: [
+          { carIdx: PLAYER, position: 2, f2Time: gap },
+          { carIdx: AHEAD,  position: 1, f2Time: 0 },
+        ],
+      });
+      aggregateRaceState(prev, frame, state, { playerCarIdx: PLAYER });
+      allEvents = allEvents.concat(detectGapTrend(prev, frame, state, ctx));
+      prev = frame;
+    }
+    expect(allEvents.filter((e) => e.type === 'GAP_CLOSING')).toHaveLength(0);
+  });
+
+  it('emits GAP_OPENING when gap grows', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER, AHEAD]);
+    let prev: TelemetryFrame | null = null;
+    let allEvents: any[] = [];
+    for (const [t, gap] of [[0, 1.0], [1, 1.4], [2, 1.8], [3, 2.4]] as Array<[number, number]>) {
+      const frame = makeFrame({
+        sessionTime: t,
+        cars: [
+          { carIdx: PLAYER, position: 2, f2Time: gap },
+          { carIdx: AHEAD,  position: 1, f2Time: 0 },
+        ],
+      });
+      aggregateRaceState(prev, frame, state, { playerCarIdx: PLAYER });
+      allEvents = allEvents.concat(detectGapTrend(prev, frame, state, ctx));
+      prev = frame;
+    }
+    expect(allEvents.some((e) => e.type === 'GAP_OPENING')).toBe(true);
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/incident-stint-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/incident-stint-detector.test.ts
@@ -234,6 +234,10 @@ describe('STINT_MILESTONE', () => {
       stoppedFrames: 0, isStoppedOnTrack: false, stoppedStartSessionTime: null,
       pitStallArrivalFuelLevel: null, onOutLap: false, pitExitLapsCompleted: null,
       stintStartLap: 0, firedStintMilestones: new Set([25, 50, 75]),
+      recentGapToAhead: [], closingRateToAhead: 0,
+      recentGapToBehind: [], closingRateToBehind: 0,
+      lapsSinceLastPit: 0, estimatedFuelLapsRemaining: 0, inPitWindow: false,
+      classPositionHistory: [], stintLapTimes: [],
     });
 
     // Pit exit frame

--- a/src/extensions/iracing/publisher/__tests__/narrative-polish-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/narrative-polish-detector.test.ts
@@ -1,0 +1,112 @@
+/**
+ * narrative-polish-detector.test.ts — Issue #156
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  detectPaceDrop,
+  detectSectorPersonalBest,
+  detectTyreTempDrift,
+  detectEngineWarning,
+} from '../driver-publisher/narrative-polish-detector';
+import { createSessionState, getOrCreateCarState } from '../session-state';
+import { makeFrame, seedRoster } from './frame-fixtures';
+
+const PLAYER = 0;
+const ctx = { rigId: 'r1', raceSessionId: 's1', playerCarIdx: PLAYER };
+
+describe('detectPaceDrop (#156)', () => {
+  it('emits PACE_DROP after 2 consecutive laps ≥ 1.5% slower than stint best', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    const cs = getOrCreateCarState(state, PLAYER);
+    cs.stintBestLapTime = 90.0;
+    cs.stintLapTimes = [91.5, 91.6]; // both ≥ 1.5% over 90.0
+    const frame = makeFrame();
+    const events = detectPaceDrop(frame, frame, state, ctx);
+    expect(events.filter((e) => e.type === 'PACE_DROP').length).toBe(1);
+  });
+
+  it('does not emit when only one slow lap', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    const cs = getOrCreateCarState(state, PLAYER);
+    cs.stintBestLapTime = 90.0;
+    cs.stintLapTimes = [90.2, 92.0];
+    const frame = makeFrame();
+    const events = detectPaceDrop(frame, frame, state, ctx);
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe('detectSectorPersonalBest (#156)', () => {
+  it('emits when LapDeltaToBestLap crosses below zero', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    const prev = makeFrame({ lapDeltaToBestLap: 0.05, lapDeltaToBestLapOk: 1 });
+    const curr = makeFrame({
+      lapDeltaToBestLap: -0.12, lapDeltaToBestLapOk: 1,
+      cars: [{ carIdx: PLAYER, lapDistPct: 0.5, lapsCompleted: 5 }],
+    });
+    const events = detectSectorPersonalBest(prev, curr, state, ctx);
+    expect(events.length).toBe(1);
+    const payload = events[0].payload as { sector: number; deltaSec: number };
+    expect(payload.sector).toBe(2);
+    expect(payload.deltaSec).toBeCloseTo(0.12, 3);
+  });
+
+  it('does not emit when delta is positive', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    const prev = makeFrame({ lapDeltaToBestLap: 0.1, lapDeltaToBestLapOk: 1 });
+    const curr = makeFrame({ lapDeltaToBestLap: 0.05, lapDeltaToBestLapOk: 1 });
+    expect(detectSectorPersonalBest(prev, curr, state, ctx)).toHaveLength(0);
+  });
+});
+
+describe('detectTyreTempDrift (#156)', () => {
+  it('emits TYRE_TEMP_DRIFT after baseline forms and tyre rises > 15 °C', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    // Seed baseline of 5 samples at 80 °C
+    for (let i = 0; i < 5; i++) {
+      const f = makeFrame({ sessionTime: i, lfTempCM: 80 });
+      detectTyreTempDrift(f, f, state, ctx);
+    }
+    // Now spike to 100 °C → delta 20 above baseline 80
+    const spike = makeFrame({ sessionTime: 100, lfTempCM: 100 });
+    const events = detectTyreTempDrift(spike, spike, state, ctx);
+    const drift = events.filter((e) => e.type === 'TYRE_TEMP_DRIFT');
+    expect(drift.length).toBe(1);
+    const driftPayload = drift[0].payload as { tyre: string; deltaC: number };
+    expect(driftPayload.tyre).toBe('LF');
+    expect(driftPayload.deltaC).toBeGreaterThanOrEqual(15);
+  });
+});
+
+describe('detectEngineWarning (#156)', () => {
+  it('emits when a new warning bit is set', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    const prev = makeFrame({ engineWarnings: 0 });
+    const curr = makeFrame({ engineWarnings: 0x04 }); // OilPressure
+    const events = detectEngineWarning(prev, curr, state, ctx);
+    expect(events).toHaveLength(1);
+    expect((events[0].payload as { warningNames: string[] }).warningNames).toContain('OilPressureWarning');
+  });
+
+  it('does not re-emit while bitmask is unchanged', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    state.lastEngineWarnings = 0x04;
+    const f = makeFrame({ engineWarnings: 0x04 });
+    expect(detectEngineWarning(f, f, state, ctx)).toHaveLength(0);
+  });
+
+  it('does not emit when warnings clear (good news is not a story)', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    state.lastEngineWarnings = 0x04;
+    const f = makeFrame({ engineWarnings: 0 });
+    expect(detectEngineWarning(f, f, state, ctx)).toHaveLength(0);
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/pit-window-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/pit-window-detector.test.ts
@@ -1,0 +1,50 @@
+/**
+ * pit-window-detector.test.ts — Issue #155
+ */
+import { describe, it, expect } from 'vitest';
+import { detectPitWindow } from '../driver-publisher/pit-window-detector';
+import { aggregateRaceState } from '../shared/race-state-aggregator';
+import { createSessionState, getOrCreateCarState } from '../session-state';
+import { makeFrame, seedRoster } from './frame-fixtures';
+
+const PLAYER = 0;
+const ctx = { rigId: 'r1', raceSessionId: 's1', playerCarIdx: PLAYER };
+
+describe('detectPitWindow (#155)', () => {
+  it('emits IN_PIT_WINDOW once when within last 5 laps of the stint', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    state.estimatedStintLaps = 30;
+    // Simulate 26 laps in the stint — within the 5-lap window.
+    const cs = getOrCreateCarState(state, PLAYER);
+    cs.stintStartLap = 0;
+    cs.lapsSinceLastPit = 26;
+    cs.inPitWindow = true;
+
+    const frame = makeFrame({ cars: [{ carIdx: PLAYER, lapsCompleted: 26 }] });
+    const ev1 = detectPitWindow(frame, frame, state, ctx);
+    const ev2 = detectPitWindow(frame, frame, state, ctx);
+    expect(ev1.filter((e) => e.type === 'IN_PIT_WINDOW').length).toBe(1);
+    expect(ev2.filter((e) => e.type === 'IN_PIT_WINDOW').length).toBe(0);
+  });
+
+  it('emits FUEL_PROJECTION at most once per lap when projection ≤ threshold', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [PLAYER]);
+    state.estimatedStintLaps = 30;
+    state.playerFuelPerLap = 2.5;
+    const cs = getOrCreateCarState(state, PLAYER);
+    cs.estimatedFuelLapsRemaining = 5; // ≤ 30
+
+    const frameLap10 = makeFrame({ fuelLevel: 12.5, cars: [{ carIdx: PLAYER, lapsCompleted: 10 }] });
+    const ev1 = detectPitWindow(frameLap10, frameLap10, state, ctx);
+    const ev2 = detectPitWindow(frameLap10, frameLap10, state, ctx);
+    expect(ev1.filter((e) => e.type === 'FUEL_PROJECTION').length).toBe(1);
+    expect(ev2.filter((e) => e.type === 'FUEL_PROJECTION').length).toBe(0);
+
+    // New lap → can fire again.
+    const frameLap11 = makeFrame({ fuelLevel: 10.0, cars: [{ carIdx: PLAYER, lapsCompleted: 11 }] });
+    const ev3 = detectPitWindow(frameLap11, frameLap11, state, ctx);
+    expect(ev3.filter((e) => e.type === 'FUEL_PROJECTION').length).toBe(1);
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/race-state-aggregator.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/race-state-aggregator.test.ts
@@ -1,0 +1,73 @@
+/**
+ * race-state-aggregator.test.ts — #151 / #152
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  aggregateRaceState,
+  GAP_WINDOW_SIZE,
+  CLASS_POSITION_HISTORY_SIZE,
+} from '../shared/race-state-aggregator';
+import { createSessionState, getOrCreateCarState } from '../session-state';
+import { makeFrame, seedRoster } from './frame-fixtures';
+
+describe('RaceStateAggregator (#151 / #152)', () => {
+  it('rolls a 5-sample CarIdxF2Time window and computes a closing rate', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [0, 1, 2]);
+    let prev = makeFrame({ cars: [{ carIdx: 0, f2Time: 2.5, position: 2 }] });
+    aggregateRaceState(null, prev, state, { playerCarIdx: 0 });
+    for (const gap of [2.4, 2.3, 2.1, 1.8, 1.4]) {
+      const next = makeFrame({ sessionTime: 1, cars: [{ carIdx: 0, f2Time: gap, position: 2 }] });
+      aggregateRaceState(prev, next, state, { playerCarIdx: 0 });
+      prev = next;
+    }
+    const cs = getOrCreateCarState(state, 0);
+    expect(cs.recentGapToAhead.length).toBeLessThanOrEqual(GAP_WINDOW_SIZE);
+    expect(cs.recentGapToAhead[cs.recentGapToAhead.length - 1]).toBeCloseTo(1.4, 5);
+    // Window slope: oldest is 2.4 (fell out 2.5), newest is 1.4 → closing
+    expect(cs.closingRateToAhead).toBeGreaterThan(0);
+  });
+
+  it('caps classPositionHistory to CLASS_POSITION_HISTORY_SIZE', () => {
+    const state = createSessionState('s1', 1);
+    seedRoster(state, [0]);
+    let prev = makeFrame({ cars: [{ carIdx: 0, classPosition: 5 }] });
+    aggregateRaceState(null, prev, state, { playerCarIdx: 0 });
+    for (const cp of [4, 3, 2, 1]) {
+      const next = makeFrame({ cars: [{ carIdx: 0, classPosition: cp }] });
+      aggregateRaceState(prev, next, state, { playerCarIdx: 0 });
+      prev = next;
+    }
+    const cs = getOrCreateCarState(state, 0);
+    expect(cs.classPositionHistory.length).toBe(CLASS_POSITION_HISTORY_SIZE);
+  });
+
+  it('derives racePhase from sessionLapsTotal/Remain', () => {
+    const state = createSessionState('s1', 1);
+    aggregateRaceState(null, makeFrame({ sessionLapsTotal: 50, sessionLapsRemain: 45 }), state, { playerCarIdx: 0 });
+    expect(state.racePhase).toBe('opening');
+    aggregateRaceState(null, makeFrame({ sessionLapsTotal: 50, sessionLapsRemain: 25 }), state, { playerCarIdx: 0 });
+    expect(state.racePhase).toBe('midrace');
+    aggregateRaceState(null, makeFrame({ sessionLapsTotal: 50, sessionLapsRemain: 10 }), state, { playerCarIdx: 0 });
+    expect(state.racePhase).toBe('endgame');
+    aggregateRaceState(null, makeFrame({ sessionLapsTotal: 50, sessionLapsRemain: 3 }), state, { playerCarIdx: 0 });
+    expect(state.racePhase).toBe('final-laps');
+  });
+
+  it('forms classGroups for same-class cars within 1.0s', () => {
+    const state = createSessionState('s1', 1);
+    // Two GT3 cars 0.6s apart, plus a third GT3 4s back (excluded).
+    seedRoster(state, [0, 1, 2], { carClassId: 100, carClassShortName: 'GT3' });
+    const frame = makeFrame({
+      cars: [
+        { carIdx: 0, position: 1, classPosition: 1, f2Time: 0 },
+        { carIdx: 1, position: 2, classPosition: 2, f2Time: 0.6 },
+        { carIdx: 2, position: 3, classPosition: 3, f2Time: 4.0 },
+      ],
+    });
+    aggregateRaceState(null, frame, state, { playerCarIdx: 0 });
+    const groups = state.classGroups.get(100) ?? [];
+    expect(groups.length).toBe(1);
+    expect(groups[0]).toEqual([0, 1]);
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/session-state.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/session-state.test.ts
@@ -45,6 +45,17 @@ function makeFrame(overrides: Partial<TelemetryFrame> = {}): TelemetryFrame {
     steeringWheelPctTorque: 0,
     solarAltitude: 0.3,
     carIdxSpeed: new Float32Array(64).fill(40),
+    sessionLapsRemain: -1,
+    sessionLapsTotal: -1,
+    sessionTimeRemain: -1,
+    lapDeltaToBestLap: 0,
+    lapDeltaToBestLapOk: 0,
+    engineWarnings: 0,
+    fuelUsePerHour: 0,
+    lfTempCM: 0,
+    rfTempCM: 0,
+    lrTempCM: 0,
+    rrTempCM: 0,
     ...overrides,
   };
 }

--- a/src/extensions/iracing/publisher/driver-publisher/class-position-detector.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/class-position-detector.ts
@@ -1,0 +1,84 @@
+/**
+ * class-position-detector.ts — Issue #154
+ *
+ * Emits CLASS_POSITION_GAIN / CLASS_POSITION_LOSS for the player car when
+ * the iRacing CarIdxClassPosition value changes, with 2-frame hysteresis
+ * via the classPositionHistory window populated by RaceStateAggregator.
+ */
+
+import type { TelemetryFrame, SessionState } from '../session-state';
+import { buildEvent, carRefFromRoster, getOrCreateCarState } from '../session-state';
+import type { PublisherEvent } from '../event-types';
+
+export interface ClassPositionContext {
+  rigId: string;
+  raceSessionId: string;
+  playerCarIdx: number;
+}
+
+let unsetPlayerCarIdxWarned = false;
+
+export function detectClassPositionChange(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: ClassPositionContext,
+): PublisherEvent[] {
+  const events: PublisherEvent[] = [];
+  if (ctx.playerCarIdx < 0) {
+    if (!unsetPlayerCarIdxWarned) {
+      unsetPlayerCarIdxWarned = true;
+      // eslint-disable-next-line no-console
+      console.warn('[class-position-detector] playerCarIdx unset; skipping');
+    }
+    return events;
+  }
+  if (prev === null) return events;
+
+  const cs = getOrCreateCarState(state, ctx.playerCarIdx);
+  const newPos = curr.carIdxClassPosition[ctx.playerCarIdx];
+  if (newPos <= 0) return events;
+
+  // Hysteresis — require the new position observed for the last 2 samples.
+  const hist = cs.classPositionHistory;
+  if (hist.length < 2) return events;
+  const lastTwo = hist.slice(-2);
+  if (lastTwo[0] !== newPos || lastTwo[1] !== newPos) return events;
+
+  const previousEmitted =
+    state.lastEmittedClassPosition > 0
+      ? state.lastEmittedClassPosition
+      : prev.carIdxClassPosition[ctx.playerCarIdx];
+
+  if (previousEmitted === newPos || previousEmitted <= 0) {
+    if (state.lastEmittedClassPosition === 0) state.lastEmittedClassPosition = newPos;
+    return events;
+  }
+
+  const playerRef = carRefFromRoster(state, ctx.playerCarIdx);
+  if (!playerRef) return events;
+
+  // Pit-cycle reason heuristic: position changed while the player or the
+  // displaced car was on pit road within the last frame.
+  const reason: 'overtake' | 'pit_cycle' | 'other' =
+    prev.carIdxOnPitRoad[ctx.playerCarIdx] !== curr.carIdxOnPitRoad[ctx.playerCarIdx]
+      ? 'pit_cycle'
+      : 'overtake';
+
+  const type = newPos < previousEmitted ? 'CLASS_POSITION_GAIN' : 'CLASS_POSITION_LOSS';
+  events.push(buildEvent(
+    type,
+    playerRef,
+    {
+      previousClassPos: previousEmitted,
+      newClassPos: newPos,
+      carClassId: playerRef.carClassId ?? 0,
+      carClassShortName: playerRef.carClassShortName ?? '',
+      reason,
+    },
+    { raceSessionId: ctx.raceSessionId, rigId: ctx.rigId, frame: curr },
+  ));
+  state.lastEmittedClassPosition = newPos;
+
+  return events;
+}

--- a/src/extensions/iracing/publisher/driver-publisher/gap-trend-detector.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/gap-trend-detector.ts
@@ -1,0 +1,138 @@
+/**
+ * gap-trend-detector.ts — Issue #153
+ *
+ * Emits GAP_CLOSING / GAP_OPENING for the player car based on the rolling
+ * gap windows maintained by RaceStateAggregator.
+ *
+ * Trigger:
+ *   - GAP_CLOSING: gap < 3.0s AND closingRate >= 0.3 s/lap, sustained 2 frames
+ *   - GAP_OPENING: gap < 3.0s AND closingRate <= -0.3 s/lap, sustained 2 frames
+ *   - Cooldown 30 s per direction before re-emitting in the same direction.
+ */
+
+import type { TelemetryFrame, SessionState } from '../session-state';
+import { buildEvent, carRefFromRoster, getOrCreateCarState } from '../session-state';
+import type { PublisherEvent } from '../event-types';
+
+export const GAP_TREND_GAP_THRESHOLD_SEC = 3.0;
+export const GAP_TREND_RATE_THRESHOLD_SEC_PER_LAP = 0.3;
+export const GAP_TREND_COOLDOWN_SEC = 30;
+
+let unsetPlayerCarIdxWarned = false;
+
+export interface GapTrendContext {
+  rigId: string;
+  raceSessionId: string;
+  /** Required — driver-pipeline detectors are scoped to the player car only. */
+  playerCarIdx: number;
+}
+
+export function detectGapTrend(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: GapTrendContext,
+): PublisherEvent[] {
+  const events: PublisherEvent[] = [];
+  if (ctx.playerCarIdx < 0) {
+    if (!unsetPlayerCarIdxWarned) {
+      unsetPlayerCarIdxWarned = true;
+      // eslint-disable-next-line no-console
+      console.warn('[gap-trend-detector] playerCarIdx unset; skipping');
+    }
+    return events;
+  }
+  if (prev === null) return events;
+
+  const cs = getOrCreateCarState(state, ctx.playerCarIdx);
+  const opts = { raceSessionId: ctx.raceSessionId, rigId: ctx.rigId, frame: curr };
+
+  // ---- Ahead ----
+  const gapAhead = curr.carIdxF2Time[ctx.playerCarIdx];
+  if (
+    gapAhead > 0
+    && gapAhead < GAP_TREND_GAP_THRESHOLD_SEC
+    && cs.recentGapToAhead.length >= 2
+  ) {
+    const rate = cs.closingRateToAhead;
+    const direction =
+      rate >= GAP_TREND_RATE_THRESHOLD_SEC_PER_LAP ? 'closing'
+      : rate <= -GAP_TREND_RATE_THRESHOLD_SEC_PER_LAP ? 'opening'
+      : 'none';
+    if (direction !== 'none') {
+      const cooldownOk =
+        curr.sessionTime - state.lastGapTrendEmittedAt.ahead >= GAP_TREND_COOLDOWN_SEC
+        || state.lastGapTrendDirection.ahead !== direction;
+      if (cooldownOk) {
+        const targetCarIdx = findCarAhead(curr, ctx.playerCarIdx);
+        const playerRef = carRefFromRoster(state, ctx.playerCarIdx);
+        const targetRef = targetCarIdx >= 0 ? carRefFromRoster(state, targetCarIdx) : undefined;
+        if (playerRef && targetRef) {
+          const type = direction === 'closing' ? 'GAP_CLOSING' : 'GAP_OPENING';
+          events.push(buildEvent(
+            type,
+            playerRef,
+            { targetCar: targetRef, gapSec: round3(gapAhead), closingRateSecPerLap: round3(rate), direction: 'ahead' },
+            opts,
+          ));
+          state.lastGapTrendEmittedAt.ahead = curr.sessionTime;
+          state.lastGapTrendDirection.ahead = direction;
+        }
+      }
+    }
+  }
+
+  // ---- Behind ----
+  const gapBehindWindow = cs.recentGapToBehind;
+  if (gapBehindWindow.length >= 2) {
+    const gapBehind = gapBehindWindow[gapBehindWindow.length - 1];
+    if (gapBehind > 0 && gapBehind < GAP_TREND_GAP_THRESHOLD_SEC) {
+      const rate = cs.closingRateToBehind;
+      const direction =
+        rate >= GAP_TREND_RATE_THRESHOLD_SEC_PER_LAP ? 'closing'
+        : rate <= -GAP_TREND_RATE_THRESHOLD_SEC_PER_LAP ? 'opening'
+        : 'none';
+      if (direction !== 'none') {
+        const cooldownOk =
+          curr.sessionTime - state.lastGapTrendEmittedAt.behind >= GAP_TREND_COOLDOWN_SEC
+          || state.lastGapTrendDirection.behind !== direction;
+        if (cooldownOk) {
+          const playerPos = curr.carIdxPosition[ctx.playerCarIdx];
+          const targetCarIdx = findCarAtPosition(curr, playerPos + 1);
+          const playerRef = carRefFromRoster(state, ctx.playerCarIdx);
+          const targetRef = targetCarIdx >= 0 ? carRefFromRoster(state, targetCarIdx) : undefined;
+          if (playerRef && targetRef) {
+            const type = direction === 'closing' ? 'GAP_CLOSING' : 'GAP_OPENING';
+            events.push(buildEvent(
+              type,
+              playerRef,
+              { targetCar: targetRef, gapSec: round3(gapBehind), closingRateSecPerLap: round3(rate), direction: 'behind' },
+              opts,
+            ));
+            state.lastGapTrendEmittedAt.behind = curr.sessionTime;
+            state.lastGapTrendDirection.behind = direction;
+          }
+        }
+      }
+    }
+  }
+
+  return events;
+}
+
+function findCarAhead(frame: TelemetryFrame, playerCarIdx: number): number {
+  const playerPos = frame.carIdxPosition[playerCarIdx];
+  if (playerPos <= 1) return -1;
+  return findCarAtPosition(frame, playerPos - 1);
+}
+
+function findCarAtPosition(frame: TelemetryFrame, position: number): number {
+  for (let i = 0; i < frame.carIdxPosition.length; i++) {
+    if (frame.carIdxPosition[i] === position) return i;
+  }
+  return -1;
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/src/extensions/iracing/publisher/driver-publisher/narrative-polish-detector.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/narrative-polish-detector.ts
@@ -1,0 +1,212 @@
+/**
+ * narrative-polish-detector.ts — Issue #156
+ *
+ * Bundles four small player-scoped detectors into one module to keep the
+ * orchestrator wiring simple. Each detector has its own export and tests.
+ *
+ *   - PACE_DROP             — 2 consecutive laps ≥ 1.5% slower than stint best
+ *   - SECTOR_PERSONAL_BEST  — LapDeltaToBestLap crosses < 0 at a sector boundary
+ *   - TYRE_TEMP_DRIFT       — any tyre middle temp rises > 15 °C above 5-sample baseline
+ *   - ENGINE_WARNING        — EngineWarnings bitmask change
+ */
+
+import type { TelemetryFrame, SessionState } from '../session-state';
+import { buildEvent, carRefFromRoster, getOrCreateCarState } from '../session-state';
+import type { PublisherEvent, TyreId } from '../event-types';
+
+export const PACE_DROP_THRESHOLD_PCT = 0.015; // 1.5 %
+export const TYRE_TEMP_DRIFT_DELTA_C = 15;
+export const TYRE_TEMP_DRIFT_BASELINE_SIZE = 5;
+export const TYRE_TEMP_DRIFT_COOLDOWN_SEC = 60;
+export const SECTOR_BOUNDARIES = [0.333, 0.667];
+
+let unsetPlayerCarIdxWarned = false;
+
+export interface NarrativePolishContext {
+  rigId: string;
+  raceSessionId: string;
+  playerCarIdx: number;
+}
+
+export function detectNarrativePolish(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: NarrativePolishContext,
+): PublisherEvent[] {
+  const events: PublisherEvent[] = [];
+  if (ctx.playerCarIdx < 0) {
+    if (!unsetPlayerCarIdxWarned) {
+      unsetPlayerCarIdxWarned = true;
+      // eslint-disable-next-line no-console
+      console.warn('[narrative-polish-detector] playerCarIdx unset; skipping');
+    }
+    return events;
+  }
+  if (prev === null) return events;
+
+  events.push(...detectPaceDrop(prev, curr, state, ctx));
+  events.push(...detectSectorPersonalBest(prev, curr, state, ctx));
+  events.push(...detectTyreTempDrift(prev, curr, state, ctx));
+  events.push(...detectEngineWarning(prev, curr, state, ctx));
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+
+export function detectPaceDrop(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: NarrativePolishContext,
+): PublisherEvent[] {
+  const events: PublisherEvent[] = [];
+  if (!prev) return events;
+  const cs = getOrCreateCarState(state, ctx.playerCarIdx);
+  if (cs.inPitWindow) return events;
+  if (cs.stintBestLapTime <= 0) return events;
+  if (cs.stintLapTimes.length < 2) return events;
+  if (state.paceDropFired) return events;
+
+  const lastTwo = cs.stintLapTimes.slice(-2);
+  const slowestPct = Math.max(...lastTwo.map((t) => (t - cs.stintBestLapTime) / cs.stintBestLapTime));
+  const allOver = lastTwo.every((t) => (t - cs.stintBestLapTime) / cs.stintBestLapTime >= PACE_DROP_THRESHOLD_PCT);
+  if (!allOver) return events;
+
+  const playerRef = carRefFromRoster(state, ctx.playerCarIdx);
+  if (!playerRef) return events;
+  events.push(buildEvent(
+    'PACE_DROP',
+    playerRef,
+    { deltaPct: round4(slowestPct), lapTimes: lastTwo.map((t) => round3(t)), stintBestSec: round3(cs.stintBestLapTime) },
+    { raceSessionId: ctx.raceSessionId, rigId: ctx.rigId, frame: curr },
+  ));
+  state.paceDropFired = true;
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+
+export function detectSectorPersonalBest(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: NarrativePolishContext,
+): PublisherEvent[] {
+  const events: PublisherEvent[] = [];
+  if (!prev) return events;
+  if (curr.lapDeltaToBestLapOk === 0) return events;
+  if (curr.lapDeltaToBestLap >= 0) return events; // not improving
+  if (prev.lapDeltaToBestLap >= 0) {
+    // Just crossed below zero — qualifies as a sector PB.
+  } else {
+    return events;
+  }
+  const lapDist = curr.carIdxLapDistPct[ctx.playerCarIdx];
+  const sector: 1 | 2 | 3 = lapDist < SECTOR_BOUNDARIES[0] ? 1 : lapDist < SECTOR_BOUNDARIES[1] ? 2 : 3;
+  const lap = curr.carIdxLapCompleted[ctx.playerCarIdx];
+
+  if (state.sectorPersonalBestLastLap === lap && state.sectorPersonalBestLastSector === sector) {
+    return events;
+  }
+  const playerRef = carRefFromRoster(state, ctx.playerCarIdx);
+  if (!playerRef) return events;
+  events.push(buildEvent(
+    'SECTOR_PERSONAL_BEST',
+    playerRef,
+    { sector, deltaSec: round3(Math.abs(curr.lapDeltaToBestLap)) },
+    { raceSessionId: ctx.raceSessionId, rigId: ctx.rigId, frame: curr },
+  ));
+  state.sectorPersonalBestLastSector = sector;
+  state.sectorPersonalBestLastLap = lap;
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+
+export function detectTyreTempDrift(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: NarrativePolishContext,
+): PublisherEvent[] {
+  const events: PublisherEvent[] = [];
+  const tyres: Array<{ id: TyreId; temp: number }> = [
+    { id: 'LF', temp: curr.lfTempCM },
+    { id: 'RF', temp: curr.rfTempCM },
+    { id: 'LR', temp: curr.lrTempCM },
+    { id: 'RR', temp: curr.rrTempCM },
+  ];
+
+  for (const t of tyres) {
+    if (t.temp <= 0) continue;
+    const baseline = state.tyreTempBaseline[t.id];
+    if (baseline.length >= TYRE_TEMP_DRIFT_BASELINE_SIZE) {
+      const avg = baseline.reduce((a, b) => a + b, 0) / baseline.length;
+      const delta = t.temp - avg;
+      if (delta > TYRE_TEMP_DRIFT_DELTA_C) {
+        const lastEmit = state.tyreTempDriftLastEmit[t.id];
+        if (curr.sessionTime - lastEmit >= TYRE_TEMP_DRIFT_COOLDOWN_SEC) {
+          const playerRef = carRefFromRoster(state, ctx.playerCarIdx);
+          if (playerRef) {
+            events.push(buildEvent(
+              'TYRE_TEMP_DRIFT',
+              playerRef,
+              { tyre: t.id, tempC: round1(t.temp), baselineC: round1(avg), deltaC: round1(delta) },
+              { raceSessionId: ctx.raceSessionId, rigId: ctx.rigId, frame: curr },
+            ));
+            state.tyreTempDriftLastEmit[t.id] = curr.sessionTime;
+          }
+        }
+      }
+    }
+    // Update rolling baseline AFTER comparing — keeps detection responsive.
+    baseline.push(t.temp);
+    while (baseline.length > TYRE_TEMP_DRIFT_BASELINE_SIZE) baseline.shift();
+  }
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+
+const ENGINE_WARNING_FLAGS: Array<{ bit: number; name: string }> = [
+  { bit: 0x01, name: 'WaterTempWarning' },
+  { bit: 0x02, name: 'FuelPressureWarning' },
+  { bit: 0x04, name: 'OilPressureWarning' },
+  { bit: 0x08, name: 'EngineStalled' },
+  { bit: 0x10, name: 'PitSpeedLimiter' },
+  { bit: 0x20, name: 'RevLimiterActive' },
+  { bit: 0x40, name: 'OilTempWarning' },
+];
+
+export function detectEngineWarning(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: NarrativePolishContext,
+): PublisherEvent[] {
+  const events: PublisherEvent[] = [];
+  const flags = curr.engineWarnings;
+  if (flags === state.lastEngineWarnings) return events;
+  // Only emit on transitions that ADD a warning (clearing is not a story).
+  const newlySet = flags & ~state.lastEngineWarnings;
+  state.lastEngineWarnings = flags;
+  if (newlySet === 0) return events;
+  const names = ENGINE_WARNING_FLAGS.filter((f) => (newlySet & f.bit) !== 0).map((f) => f.name);
+  if (names.length === 0) return events;
+  const playerRef = carRefFromRoster(state, ctx.playerCarIdx);
+  if (!playerRef) return events;
+  events.push(buildEvent(
+    'ENGINE_WARNING',
+    playerRef,
+    { warningFlags: flags, warningNames: names },
+    { raceSessionId: ctx.raceSessionId, rigId: ctx.rigId, frame: curr },
+  ));
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+
+function round1(n: number): number { return Math.round(n * 10) / 10; }
+function round3(n: number): number { return Math.round(n * 1000) / 1000; }
+function round4(n: number): number { return Math.round(n * 10000) / 10000; }

--- a/src/extensions/iracing/publisher/driver-publisher/orchestrator.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/orchestrator.ts
@@ -31,6 +31,11 @@ import { detectDriverLapPerformance } from './lap-performance-driver';
 import { detectPlayerPhysics } from './player-physics-detector';
 import { buildIdentityEvents } from './identity-event-builder';
 import { IdentityOverrideService } from './identity-override';
+import { aggregateRaceState } from '../shared/race-state-aggregator';
+import { detectGapTrend } from './gap-trend-detector';
+import { detectClassPositionChange } from './class-position-detector';
+import { detectPitWindow } from './pit-window-detector';
+import { detectNarrativePolish } from './narrative-polish-detector';
 import {
   createSessionState,
   buildEvent,
@@ -143,6 +148,15 @@ export class DriverPublisherOrchestrator {
     const playerCarIdx = this.playerCarIdx ?? -1;
     const events: PublisherEvent[] = [];
 
+    // Race-narrative state aggregator (#151–#152) — must run BEFORE
+    // detectors so they can consume the rolling windows / derived state.
+    if (playerCarIdx >= 0) {
+      aggregateRaceState(this.prevFrame, frame, this.state, {
+        playerCarIdx,
+        estimatedStintLaps: this.estimatedStintLaps,
+      });
+    }
+
     // Identity — resolve on every frame; only emits on first resolve or change.
     if (this.iracingUserName) {
       const identityResult = this.identity.resolve(this.iracingUserName, this.identityDisplayName);
@@ -180,6 +194,12 @@ export class DriverPublisherOrchestrator {
       playerCarIdx,
       carNumberByCarIdx: this.carNumberByCarIdx.size > 0 ? this.carNumberByCarIdx : undefined,
     }));
+
+    // Race-narrative detectors (#153–#156) — all gated on playerCarIdx.
+    events.push(...detectGapTrend(this.prevFrame, frame, this.state, { ...ctx, playerCarIdx }));
+    events.push(...detectClassPositionChange(this.prevFrame, frame, this.state, { ...ctx, playerCarIdx }));
+    events.push(...detectPitWindow(this.prevFrame, frame, this.state, { ...ctx, playerCarIdx }));
+    events.push(...detectNarrativePolish(this.prevFrame, frame, this.state, { ...ctx, playerCarIdx }));
 
     this.dispatchEvents(events);
 

--- a/src/extensions/iracing/publisher/driver-publisher/pit-window-detector.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/pit-window-detector.ts
@@ -1,0 +1,91 @@
+/**
+ * pit-window-detector.ts — Issue #155
+ *
+ * Emits IN_PIT_WINDOW (once per stint) and FUEL_PROJECTION (at most once
+ * per lap) for the player car. Reads the trend fields populated by the
+ * RaceStateAggregator — does not maintain its own state.
+ */
+
+import type { TelemetryFrame, SessionState } from '../session-state';
+import { buildEvent, carRefFromRoster, getOrCreateCarState } from '../session-state';
+import type { PublisherEvent } from '../event-types';
+
+let unsetPlayerCarIdxWarned = false;
+
+export interface PitWindowContext {
+  rigId: string;
+  raceSessionId: string;
+  playerCarIdx: number;
+  /** Optional override; defaults to estimatedStintLaps from session state. */
+  fuelProjectionThresholdLaps?: number;
+}
+
+export function detectPitWindow(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: PitWindowContext,
+): PublisherEvent[] {
+  const events: PublisherEvent[] = [];
+  if (ctx.playerCarIdx < 0) {
+    if (!unsetPlayerCarIdxWarned) {
+      unsetPlayerCarIdxWarned = true;
+      // eslint-disable-next-line no-console
+      console.warn('[pit-window-detector] playerCarIdx unset; skipping');
+    }
+    return events;
+  }
+
+  const cs = getOrCreateCarState(state, ctx.playerCarIdx);
+  const opts = { raceSessionId: ctx.raceSessionId, rigId: ctx.rigId, frame: curr };
+  const playerRef = carRefFromRoster(state, ctx.playerCarIdx);
+  if (!playerRef) return events;
+
+  // ---- IN_PIT_WINDOW — fires once when inPitWindow flips false → true ----
+  if (cs.inPitWindow && !state.inPitWindowFired) {
+    const stintLen = state.estimatedStintLaps;
+    const lapsRemaining = Math.max(0, stintLen - cs.lapsSinceLastPit);
+    events.push(buildEvent(
+      'IN_PIT_WINDOW',
+      playerRef,
+      { lapsRemainingInStint: lapsRemaining, estimatedStintLaps: stintLen },
+      opts,
+    ));
+    state.inPitWindowFired = true;
+  }
+  // Reset the latch when the stint resets (lapsSinceLastPit goes back to 0
+  // after a pit exit handled elsewhere) — keyed off inPitWindow being false.
+  if (!cs.inPitWindow) state.inPitWindowFired = false;
+
+  // ---- FUEL_PROJECTION — at most once per lap when projection is low ----
+  const lapNumber = curr.carIdxLapCompleted[ctx.playerCarIdx];
+  const fuelPerLap = state.playerFuelPerLap;
+  const projected = cs.estimatedFuelLapsRemaining;
+  if (
+    fuelPerLap > 0
+    && projected > 0
+    && state.fuelProjectionLastLap !== lapNumber
+  ) {
+    const threshold = ctx.fuelProjectionThresholdLaps ?? state.estimatedStintLaps;
+    if (threshold > 0 && projected <= threshold) {
+      events.push(buildEvent(
+        'FUEL_PROJECTION',
+        playerRef,
+        {
+          projectedLaps: round2(projected),
+          fuelLevel: round2(curr.fuelLevel),
+          fuelPerLap: round2(fuelPerLap),
+          thresholdLaps: threshold,
+        },
+        opts,
+      ));
+      state.fuelProjectionLastLap = lapNumber;
+    }
+  }
+
+  return events;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/extensions/iracing/publisher/event-types.ts
+++ b/src/extensions/iracing/publisher/event-types.ts
@@ -136,7 +136,19 @@ export type PublisherEventType =
   | 'WEATHER_CHANGE'
   | 'TRACK_TEMP_DRIFT'
   | 'WIND_SHIFT'
-  | 'TIME_OF_DAY_PHASE';
+  | 'TIME_OF_DAY_PHASE'
+  // §9 Race-narrative additions (#151–#156). All driver-pipeline events,
+  // gated on playerCarIdx. Backward-compatible — additive only.
+  | 'GAP_CLOSING'
+  | 'GAP_OPENING'
+  | 'CLASS_POSITION_GAIN'
+  | 'CLASS_POSITION_LOSS'
+  | 'IN_PIT_WINDOW'
+  | 'FUEL_PROJECTION'
+  | 'PACE_DROP'
+  | 'SECTOR_PERSONAL_BEST'
+  | 'TYRE_TEMP_DRIFT'
+  | 'ENGINE_WARNING';
 
 // CLOUD-EMITTED — publisher never produces these. Listed here for documentation only.
 // 'FOCUS_VS_FOCUS_BATTLE' | 'FOCUS_GROUP_ON_TRACK' | 'FOCUS_GROUP_SPLIT'
@@ -252,6 +264,18 @@ export interface EventPayloadMap {
   TRACK_TEMP_DRIFT: TrackTempDriftPayload;
   WIND_SHIFT: WindShiftPayload;
   TIME_OF_DAY_PHASE: TimeOfDayPhasePayload;
+
+  // §9 Race-narrative (#151–#156)
+  GAP_CLOSING: GapTrendPayload;
+  GAP_OPENING: GapTrendPayload;
+  CLASS_POSITION_GAIN: ClassPositionChangePayload;
+  CLASS_POSITION_LOSS: ClassPositionChangePayload;
+  IN_PIT_WINDOW: InPitWindowPayload;
+  FUEL_PROJECTION: FuelProjectionPayload;
+  PACE_DROP: PaceDropPayload;
+  SECTOR_PERSONAL_BEST: SectorPersonalBestPayload;
+  TYRE_TEMP_DRIFT: TyreTempDriftPayload;
+  ENGINE_WARNING: EngineWarningPayload;
 }
 
 // ---------------------------------------------------------------------------
@@ -545,4 +569,69 @@ export interface TimeOfDayPhasePayload {
   phase: TimeOfDayPhase;
   /** Solar altitude in radians (positive = above horizon) */
   solarAltitudeRad: number;
+}
+
+// ---------------------------------------------------------------------------
+// §9 Race-narrative payloads (#151–#156)
+// ---------------------------------------------------------------------------
+
+export interface GapTrendPayload {
+  /** Self-describing ref for the target car (the one being closed on / opening). */
+  targetCar: PublisherCarRef;
+  /** Current gap in seconds. */
+  gapSec: number;
+  /** Closing rate in seconds per lap (positive = closing). */
+  closingRateSecPerLap: number;
+  /** Direction of the trend relative to the player car. */
+  direction: 'ahead' | 'behind';
+}
+
+export interface ClassPositionChangePayload {
+  previousClassPos: number;
+  newClassPos: number;
+  carClassId: number;
+  carClassShortName: string;
+  reason: 'overtake' | 'pit_cycle' | 'other';
+}
+
+export interface InPitWindowPayload {
+  lapsRemainingInStint: number;
+  estimatedStintLaps: number;
+}
+
+export interface FuelProjectionPayload {
+  projectedLaps: number;
+  fuelLevel: number;
+  fuelPerLap: number;
+  /** Threshold (laps) below which projection alerts. */
+  thresholdLaps: number;
+}
+
+export interface PaceDropPayload {
+  /** % drop vs stint best of the slowest sample lap (positive). */
+  deltaPct: number;
+  /** Last 2 lap times (seconds). */
+  lapTimes: number[];
+  stintBestSec: number;
+}
+
+export interface SectorPersonalBestPayload {
+  sector: 1 | 2 | 3;
+  deltaSec: number;
+}
+
+export type TyreId = 'LF' | 'RF' | 'LR' | 'RR';
+
+export interface TyreTempDriftPayload {
+  tyre: TyreId;
+  tempC: number;
+  baselineC: number;
+  deltaC: number;
+}
+
+export interface EngineWarningPayload {
+  /** Raw EngineWarnings bitmask. */
+  warningFlags: number;
+  /** Decoded warning names (e.g. 'WaterTempWarning', 'OilPressureWarning'). */
+  warningNames: string[];
 }

--- a/src/extensions/iracing/publisher/session-state.ts
+++ b/src/extensions/iracing/publisher/session-state.ts
@@ -77,6 +77,32 @@ export interface TelemetryFrame {
   solarAltitude: number;
   /** iRacing: CarIdxSpeed (m/s) per car */
   carIdxSpeed: Float32Array;
+
+  // Race-narrative additions (#151–#156). All default to 0 / -1 when the
+  // raw read is missing so existing fixtures and the koffi reader stay
+  // backwards compatible.
+  /** iRacing: SessionLapsRemainEx (or SessionLapsRemain) — laps left in session, -1 = unknown/unlimited */
+  sessionLapsRemain: number;
+  /** iRacing: SessionLapsTotal — total laps for the session, -1 = unknown/timed */
+  sessionLapsTotal: number;
+  /** iRacing: SessionTimeRemain (seconds) — -1 = unknown/lap-limited */
+  sessionTimeRemain: number;
+  /** iRacing: LapDeltaToBestLap (seconds, signed) — current vs personal best, mid-lap */
+  lapDeltaToBestLap: number;
+  /** iRacing: LapDeltaToBestLap_OK (bool/int) — whether the delta is valid */
+  lapDeltaToBestLapOk: number;
+  /** iRacing: EngineWarnings bitmask */
+  engineWarnings: number;
+  /** iRacing: FuelUsePerHour (litres/hour) */
+  fuelUsePerHour: number;
+  /** iRacing: LFtempCM (left front centre tyre temperature, Celsius) */
+  lfTempCM: number;
+  /** iRacing: RFtempCM (right front centre tyre temperature, Celsius) */
+  rfTempCM: number;
+  /** iRacing: LRtempCM (left rear centre tyre temperature, Celsius) */
+  lrTempCM: number;
+  /** iRacing: RRtempCM (right rear centre tyre temperature, Celsius) */
+  rrTempCM: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +149,26 @@ export interface CarState {
   stintStartLap: number;
   /** Stint milestone percents (25 / 50 / 75) already fired this stint. */
   firedStintMilestones: Set<number>;
+
+  // ---- Race-narrative trend fields (#151) ----
+  /** Rolling window (last 5) of CarIdxF2Time samples (gap to car ahead). */
+  recentGapToAhead: number[];
+  /** Closing rate vs car ahead in seconds-per-lap (positive = closing). */
+  closingRateToAhead: number;
+  /** Rolling window (last 5) of gap-to-car-behind samples. */
+  recentGapToBehind: number[];
+  /** Closing rate vs car behind in seconds-per-lap (positive = behind closing on us). */
+  closingRateToBehind: number;
+  /** Laps completed since the most recent pit exit. */
+  lapsSinceLastPit: number;
+  /** Estimated number of laps remaining in the current fuel load (player only). */
+  estimatedFuelLapsRemaining: number;
+  /** True when the player is within the last 5 laps of the estimated stint. */
+  inPitWindow: boolean;
+  /** Last 3 sampled classPosition values for hysteresis on CLASS_POSITION_GAIN/LOSS. */
+  classPositionHistory: number[];
+  /** Stint lap times (seconds) — accumulated since the start of the current stint. */
+  stintLapTimes: number[];
 }
 
 // ---------------------------------------------------------------------------
@@ -228,6 +274,41 @@ export interface SessionState {
   spinDetectedCooldownUntilTick: number;
   /** Emit BIG_HIT at most once per this many ticks. */
   bigHitCooldownUntilTick: number;
+
+  // ---- Race-narrative additions (#151–#156) ----
+  /** Race phase derived from SessionLapsRemain/Total or SessionTimeRemain. */
+  racePhase: 'unknown' | 'opening' | 'midrace' | 'endgame' | 'final-laps';
+  /** Cars within 1.0 s of each other, grouped by carClassId. Rebuilt per frame. */
+  classGroups: Map<number, number[][]>;
+  /** Per-car pit strategy summary keyed by carIdx. */
+  pitStrategySummary: Map<number, {
+    estStintLaps: number;
+    lapsRemainingInStint: number;
+    undercutOpportunityAgainst: number | null;
+  }>;
+  /** Estimated player stint length in laps (from setSessionMetadata). */
+  estimatedStintLaps: number;
+  /** Whether IN_PIT_WINDOW has fired for the current stint. */
+  inPitWindowFired: boolean;
+  /** SessionTime of the last GAP_CLOSING/GAP_OPENING emission per direction. */
+  lastGapTrendEmittedAt: { ahead: number; behind: number };
+  /** Direction of the last GAP_CLOSING/GAP_OPENING emission per direction. */
+  lastGapTrendDirection: { ahead: 'closing' | 'opening' | 'none'; behind: 'closing' | 'opening' | 'none' };
+  /** Last classPosition value emitted for CLASS_POSITION_GAIN/LOSS gating. */
+  lastEmittedClassPosition: number;
+  /** Lap number on which FUEL_PROJECTION last fired (one per lap cap). */
+  fuelProjectionLastLap: number;
+  /** Latch — PACE_DROP fired this stint (cleared on stint reset). */
+  paceDropFired: boolean;
+  /** Last sectorIdx in which SECTOR_PERSONAL_BEST fired (for cooldown). */
+  sectorPersonalBestLastSector: number;
+  /** Last lap on which SECTOR_PERSONAL_BEST fired. */
+  sectorPersonalBestLastLap: number;
+  /** Rolling 5-sample baselines per tyre and last emit times for TYRE_TEMP_DRIFT. */
+  tyreTempBaseline: { LF: number[]; RF: number[]; LR: number[]; RR: number[] };
+  tyreTempDriftLastEmit: { LF: number; RF: number; LR: number; RR: number };
+  /** Last EngineWarnings bitmask seen — change-detection for ENGINE_WARNING. */
+  lastEngineWarnings: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -259,6 +340,15 @@ function makeDefaultCarState(): CarState {
     pitExitLapsCompleted: null,
     stintStartLap: 0,
     firedStintMilestones: new Set(),
+    recentGapToAhead: [],
+    closingRateToAhead: 0,
+    recentGapToBehind: [],
+    closingRateToBehind: 0,
+    lapsSinceLastPit: 0,
+    estimatedFuelLapsRemaining: 0,
+    inPitWindow: false,
+    classPositionHistory: [],
+    stintLapTimes: [],
   };
 }
 
@@ -299,6 +389,21 @@ export function createSessionState(raceSessionId: string, sessionUniqueId: numbe
     slowCarAheadCooldownUntilTick: 0,
     spinDetectedCooldownUntilTick: 0,
     bigHitCooldownUntilTick: 0,
+    racePhase: 'unknown',
+    classGroups: new Map(),
+    pitStrategySummary: new Map(),
+    estimatedStintLaps: 0,
+    inPitWindowFired: false,
+    lastGapTrendEmittedAt: { ahead: -Infinity, behind: -Infinity },
+    lastGapTrendDirection: { ahead: 'none', behind: 'none' },
+    lastEmittedClassPosition: 0,
+    fuelProjectionLastLap: -1,
+    paceDropFired: false,
+    sectorPersonalBestLastSector: -1,
+    sectorPersonalBestLastLap: -1,
+    tyreTempBaseline: { LF: [], RF: [], LR: [], RR: [] },
+    tyreTempDriftLastEmit: { LF: 0, RF: 0, LR: 0, RR: 0 },
+    lastEngineWarnings: 0,
   };
 }
 

--- a/src/extensions/iracing/publisher/shared/race-state-aggregator.ts
+++ b/src/extensions/iracing/publisher/shared/race-state-aggregator.ts
@@ -1,0 +1,227 @@
+/**
+ * race-state-aggregator.ts — #151 / #152
+ *
+ * Updates the rolling per-car and session-level trend fields on every
+ * telemetry frame BEFORE the narrative detectors run. The detectors are
+ * pure observers of this state — they do not maintain their own windows.
+ *
+ * Cheap to run: O(N) where N = number of resolved cars in the session.
+ *
+ * No events emitted from this module — it only mutates state.
+ */
+
+import type { TelemetryFrame, SessionState, CarState } from '../session-state';
+import { getOrCreateCarState } from '../session-state';
+
+/** Maximum samples kept in a rolling gap window. */
+export const GAP_WINDOW_SIZE = 5;
+/** Maximum samples kept for class-position hysteresis. */
+export const CLASS_POSITION_HISTORY_SIZE = 3;
+/** Distance from end of stint considered the "pit window" (laps). */
+export const PIT_WINDOW_LAPS = 5;
+/** Battle gap threshold for class-group formation (seconds). */
+export const CLASS_GROUP_GAP_SEC = 1.0;
+
+export interface AggregatorContext {
+  /** iRacing DriverInfo.DriverCarIdx — required to compute player-relative state. */
+  playerCarIdx: number;
+  /** Estimated player stint length in laps (from setSessionMetadata). */
+  estimatedStintLaps?: number;
+  /** Per-car class id (carIdx → CarClassID) — used for classGroups. */
+  carClassByCarIdx?: Map<number, number>;
+}
+
+/**
+ * Updates SessionState + per-car CarState rolling windows and derived fields
+ * for the current frame. Must be called BEFORE narrative detectors.
+ */
+export function aggregateRaceState(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: AggregatorContext,
+): void {
+  const playerCarIdx = ctx.playerCarIdx;
+
+  if (ctx.estimatedStintLaps !== undefined) {
+    state.estimatedStintLaps = ctx.estimatedStintLaps;
+  }
+
+  // ---- 1. Per-car gap windows + closing rates ----
+  // We only maintain the window for cars currently in the roster — keeps
+  // memory bounded and matches detector visibility.
+  const carCount = curr.carIdxPosition.length;
+  const playerPosition =
+    playerCarIdx >= 0 && playerCarIdx < carCount ? curr.carIdxPosition[playerCarIdx] : 0;
+
+  for (const [carIdx] of state.knownRoster) {
+    if (carIdx < 0 || carIdx >= carCount) continue;
+    const cs = getOrCreateCarState(state, carIdx);
+
+    // Gap to car ahead — CarIdxF2Time. iRacing reports 0 for the leader.
+    const gapAhead = curr.carIdxF2Time[carIdx];
+    if (Number.isFinite(gapAhead) && gapAhead > 0) {
+      pushWindow(cs.recentGapToAhead, gapAhead);
+      cs.closingRateToAhead = computeClosingRate(cs.recentGapToAhead);
+    }
+
+    // Gap-to-car-behind for the player only (we don't have CarIdxF2Time
+    // for "behind us" — derive from the car-behind's gapToCarAhead).
+    if (carIdx === playerCarIdx) {
+      const carBehindIdx = findCarBehind(curr, playerPosition);
+      if (carBehindIdx >= 0) {
+        const gapBehind = curr.carIdxF2Time[carBehindIdx];
+        if (Number.isFinite(gapBehind) && gapBehind > 0) {
+          pushWindow(cs.recentGapToBehind, gapBehind);
+          cs.closingRateToBehind = computeClosingRate(cs.recentGapToBehind);
+        }
+      }
+    }
+
+    // ---- 2. Class-position history (hysteresis source for #154) ----
+    const classPos = curr.carIdxClassPosition[carIdx];
+    if (classPos > 0) {
+      pushWindow(cs.classPositionHistory, classPos, CLASS_POSITION_HISTORY_SIZE);
+    }
+
+    // ---- 3. Lap completion → stint laps + lapsSinceLastPit ----
+    const prevLaps = prev ? prev.carIdxLapCompleted[carIdx] : cs.lapsCompleted;
+    const currLaps = curr.carIdxLapCompleted[carIdx];
+    if (prev && currLaps > prevLaps && currLaps > 0) {
+      // New lap started. Stint accounting.
+      const lastLap = curr.carIdxLastLapTime[carIdx];
+      if (lastLap > 0) cs.stintLapTimes.push(lastLap);
+      cs.lapsSinceLastPit = Math.max(0, currLaps - cs.stintStartLap);
+    }
+  }
+
+  // ---- 4. Player fuel projection ----
+  if (playerCarIdx >= 0) {
+    const cs = getOrCreateCarState(state, playerCarIdx);
+    const fuelPerLap = state.playerFuelPerLap;
+    if (fuelPerLap > 0 && curr.fuelLevel > 0) {
+      cs.estimatedFuelLapsRemaining = curr.fuelLevel / fuelPerLap;
+    }
+    // inPitWindow — within the last PIT_WINDOW_LAPS of the stint length.
+    const stintLen = state.estimatedStintLaps;
+    if (stintLen > 0 && cs.lapsSinceLastPit > 0) {
+      const lapsRemaining = stintLen - cs.lapsSinceLastPit;
+      cs.inPitWindow = lapsRemaining >= 0 && lapsRemaining <= PIT_WINDOW_LAPS;
+
+      // pitStrategySummary
+      state.pitStrategySummary.set(playerCarIdx, {
+        estStintLaps: stintLen,
+        lapsRemainingInStint: lapsRemaining,
+        undercutOpportunityAgainst: null,
+      });
+    } else {
+      cs.inPitWindow = false;
+    }
+  }
+
+  // ---- 5. Race phase ----
+  state.racePhase = computeRacePhase(curr);
+
+  // ---- 6. Class groups — cars within CLASS_GROUP_GAP_SEC by class ----
+  state.classGroups = computeClassGroups(curr, state, ctx.carClassByCarIdx);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pushWindow(arr: number[], value: number, max = GAP_WINDOW_SIZE): void {
+  arr.push(value);
+  while (arr.length > max) arr.shift();
+}
+
+/**
+ * Closing rate in seconds-per-lap, derived from the slope of the rolling
+ * gap window. Positive means the gap is shrinking (closing).
+ *
+ * We assume each window sample is ~1 lap apart on average (the publisher
+ * frame cadence is sub-second but lap-to-lap deltas dominate the signal).
+ * The detectors use this as a directional indicator, not a precise rate.
+ */
+function computeClosingRate(window: number[]): number {
+  const n = window.length;
+  if (n < 2) return 0;
+  // Simple delta over the window length.
+  return (window[0] - window[n - 1]) / Math.max(1, n - 1);
+}
+
+/** Returns the carIdx immediately behind `playerPosition` in overall order, or -1. */
+function findCarBehind(frame: TelemetryFrame, playerPosition: number): number {
+  if (playerPosition <= 0) return -1;
+  const target = playerPosition + 1;
+  for (let i = 0; i < frame.carIdxPosition.length; i++) {
+    if (frame.carIdxPosition[i] === target) return i;
+  }
+  return -1;
+}
+
+function computeRacePhase(frame: TelemetryFrame): SessionState['racePhase'] {
+  const total = frame.sessionLapsTotal;
+  const remain = frame.sessionLapsRemain;
+
+  if (total > 0 && remain >= 0) {
+    if (remain <= 5) return 'final-laps';
+    const completedFrac = (total - remain) / total;
+    if (completedFrac < 0.25) return 'opening';
+    if (completedFrac > 0.75) return 'endgame';
+    return 'midrace';
+  }
+
+  // Time-limited fallback — we only know "remain", not total. Use absolute
+  // remaining seconds as a coarse heuristic.
+  if (frame.sessionTimeRemain > 0) {
+    if (frame.sessionTimeRemain <= 60) return 'final-laps';
+    if (frame.sessionTimeRemain <= 600) return 'endgame';
+  }
+
+  return 'unknown';
+}
+
+function computeClassGroups(
+  frame: TelemetryFrame,
+  state: SessionState,
+  carClassByCarIdx?: Map<number, number>,
+): Map<number, number[][]> {
+  const groups = new Map<number, number[][]>();
+  // Build per-class lists of [carIdx, classPosition, gapToAhead] tuples.
+  const byClass = new Map<number, Array<{ carIdx: number; classPos: number; gap: number }>>();
+  for (const [carIdx, ref] of state.knownRoster) {
+    const classId = ref.carClassId ?? carClassByCarIdx?.get(carIdx);
+    if (classId === undefined) continue;
+    const classPos = frame.carIdxClassPosition[carIdx];
+    if (classPos <= 0) continue;
+    const gap = frame.carIdxF2Time[carIdx] ?? 0;
+    if (!byClass.has(classId)) byClass.set(classId, []);
+    byClass.get(classId)!.push({ carIdx, classPos, gap });
+  }
+
+  for (const [classId, entries] of byClass) {
+    entries.sort((a, b) => a.classPos - b.classPos);
+    const classGroups: number[][] = [];
+    let current: number[] = [];
+    for (let i = 0; i < entries.length; i++) {
+      if (current.length === 0) {
+        current.push(entries[i].carIdx);
+        continue;
+      }
+      // gap value on this entry is gap-to-car-ahead in OVERALL order; for a
+      // class-grouping heuristic we treat any same-class car within
+      // CLASS_GROUP_GAP_SEC of its class-predecessor as part of the group.
+      if (entries[i].gap > 0 && entries[i].gap < CLASS_GROUP_GAP_SEC) {
+        current.push(entries[i].carIdx);
+      } else {
+        if (current.length > 1) classGroups.push(current);
+        current = [entries[i].carIdx];
+      }
+    }
+    if (current.length > 1) classGroups.push(current);
+    if (classGroups.length > 0) groups.set(classId, classGroups);
+  }
+
+  return groups;
+}

--- a/src/extensions/iracing/telemetry-frame.ts
+++ b/src/extensions/iracing/telemetry-frame.ts
@@ -48,6 +48,20 @@ export interface RawTelemetryReads {
   steeringWheelPctTorque: number[] | null;
   solarAltitude:          number[] | null;
   carIdxSpeed:            number[] | null;
+
+  // Race-narrative additions (#151–#156). All optional — koffi reads are
+  // added incrementally; missing values default to 0/-1 in assembleTelemetryFrame.
+  sessionLapsRemain?:   number[] | null;
+  sessionLapsTotal?:    number[] | null;
+  sessionTimeRemain?:   number[] | null;
+  lapDeltaToBestLap?:   number[] | null;
+  lapDeltaToBestLapOk?: number[] | null;
+  engineWarnings?:      number[] | null;
+  fuelUsePerHour?:      number[] | null;
+  lfTempCM?:            number[] | null;
+  rfTempCM?:            number[] | null;
+  lrTempCM?:            number[] | null;
+  rrTempCM?:            number[] | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -93,6 +107,18 @@ export function assembleTelemetryFrame(r: RawTelemetryReads): TelemetryFrame {
     steeringWheelPctTorque: r.steeringWheelPctTorque?.[0] ?? 0,
     solarAltitude:          r.solarAltitude?.[0]          ?? 0,
     carIdxSpeed:            Float32Array.from(r.carIdxSpeed ?? []),
+
+    sessionLapsRemain:   r.sessionLapsRemain?.[0]   ?? -1,
+    sessionLapsTotal:    r.sessionLapsTotal?.[0]    ?? -1,
+    sessionTimeRemain:   r.sessionTimeRemain?.[0]   ?? -1,
+    lapDeltaToBestLap:   r.lapDeltaToBestLap?.[0]   ?? 0,
+    lapDeltaToBestLapOk: r.lapDeltaToBestLapOk?.[0] ?? 0,
+    engineWarnings:      r.engineWarnings?.[0]      ?? 0,
+    fuelUsePerHour:      r.fuelUsePerHour?.[0]      ?? 0,
+    lfTempCM:            r.lfTempCM?.[0]            ?? 0,
+    rfTempCM:            r.rfTempCM?.[0]            ?? 0,
+    lrTempCM:            r.lrTempCM?.[0]            ?? 0,
+    rrTempCM:            r.rrTempCM?.[0]            ?? 0,
   };
 }
 


### PR DESCRIPTION
## Summary

Implements the full race-narrative epic: a shared per-frame **RaceStateAggregator** plus **four new detectors** that emit ten new narrative event types from the iRacing publisher pipeline.

Closes #151
Closes #152
Closes #153
Closes #154
Closes #155
Closes #156

## Architecture

A single aggregator pass runs **before** detectors each frame. Detectors stay pure observers of `CarState` / `SessionState`.

```
TelemetryFrame ──► aggregateRaceState (mutates state) ──► detectors (read-only) ──► PublisherEvents
```

## Changes

### Plumbing
- **`TelemetryFrame`** — 11 new fields (`sessionLapsRemain/Total`, `sessionTimeRemain`, `lapDeltaToBestLap[Ok]`, `engineWarnings`, `fuelUsePerHour`, `LF/RF/LR/RR tempCM`).
- **`CarState`** — 11 new trend fields (gap windows, closing rates, `lapsSinceLastPit`, `estimatedFuelLapsRemaining`, `inPitWindow`, `classPositionHistory`, `stintLapTimes`).
- **`SessionState`** — 16 new narrative fields (`racePhase`, `classGroups`, fuel projection, pace-drop / sector-PB / tyre-temp / engine-warning latches and baselines).
- **iRacing reader** — pulls the 11 new vars via koffi (with sane fallbacks).

### #151 / #152 — Aggregator
- `publisher/shared/race-state-aggregator.ts`
  - Rolling 5-sample gap window + slope (`closingRateToAhead/Behind`)
  - `classPositionHistory` (size 3) for hysteresis
  - `lapsSinceLastPit`, `estimatedFuelLapsRemaining`, `inPitWindow`
  - `racePhase` derivation (opening / midrace / endgame / final-laps)
  - Per-class adjacency clusters under 1.0s

### #153 — Gap trends
- `driver-publisher/gap-trend-detector.ts` — fires `GAP_CLOSING` / `GAP_OPENING` when |rate| ≥ 0.3 s/lap and gap < 3.0s; per-direction 30s cooldown unless direction flips.

### #154 — Class-position changes
- `driver-publisher/class-position-detector.ts` — 2-frame hysteresis. Emits `CLASS_POSITION_GAIN` / `CLASS_POSITION_LOSS`; pit-cycle `reason` heuristic when `onPitRoad` differs.

### #155 — Pit window + fuel projection
- `driver-publisher/pit-window-detector.ts` — `IN_PIT_WINDOW` once per stint (latched via `state.inPitWindowFired`); `FUEL_PROJECTION` ≤ once per lap.

### #156 — Narrative polish
- `driver-publisher/narrative-polish-detector.ts`
  - `PACE_DROP` — 2 consecutive laps ≥ 1.5% slower than stint best (latched, suppressed in pit window)
  - `SECTOR_PERSONAL_BEST` — `LapDeltaToBestLap` zero-crossing at sector boundaries 0.333 / 0.667
  - `TYRE_TEMP_DRIFT` — 5-sample rolling baseline; fire when delta > 15 °C; 60s per-tyre cooldown
  - `ENGINE_WARNING` — bitmask change on newly-set bits with named flags

### Wire-contract
10 new event types added to `PublisherEventType` + `EventPayloadMap`, with new payload interfaces in `event-types.ts`.

## Tests
- 5 new test files, **+19 tests** (aggregator / gap-trend / class-position / pit-window / narrative-polish)
- Pre-existing fixtures extended for new fields
- **726 total tests passing** (was 707)

## Cloud-side follow-up (not in this PR)

The 10 new event-type literals + `carClassId` persistence are tracked separately on the Race Control side:

- `racecontrol#324` — persist `carClassId` on stored events
- `racecontrol#325` — add new event-type literals to OpenAPI schema + validator

Director will start emitting these events as soon as this PR lands; cloud will accept them once `racecontrol#325` ships.