### PR TITLE
feat(iracing): emit DRIVER_STATE_SNAPSHOT and recentEvents ring buffer (#179)

### DIFF
--- a/src/extensions/iracing/publisher/__tests__/snapshot-emitter.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/snapshot-emitter.test.ts
@@ -1,0 +1,313 @@
+/**
+ * snapshot-emitter.test.ts — Issue #179
+ *
+ * Validates DRIVER_STATE_SNAPSHOT cadence, forced-flush triggers, payload
+ * shape, and the recentEvents ring buffer cap on DriverState.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildSnapshot,
+  maybeBuildSnapshot,
+  findForcedTrigger,
+  isCadenceElapsed,
+  deriveFlag,
+  DEFAULT_SNAPSHOT_INTERVAL_SEC,
+  SNAPSHOT_RECENT_EVENTS_LIMIT,
+} from '../driver-publisher/snapshot-emitter';
+import {
+  createDriverState,
+  pushRecentEvent,
+  RECENT_EVENTS_CAPACITY,
+} from '../driver-state';
+import { createSessionState, buildEvent, getOrCreateCarState } from '../session-state';
+import type { PublisherEvent, PublisherEventType } from '../event-types';
+import { makeFrame, seedRoster, FlagBits } from './frame-fixtures';
+
+const PLAYER = 0;
+const ctx = { rigId: 'r1', raceSessionId: 's1', playerCarIdx: PLAYER };
+
+function makeRosteredState() {
+  const state = createSessionState('s1', 1);
+  seedRoster(state, [PLAYER, 1, 2]);
+  state.estimatedStintLaps = 30;
+  return state;
+}
+
+function makeFakeEvent(type: PublisherEventType, sessionTime = 1): PublisherEvent {
+  const frame = makeFrame({ sessionTime, cars: [{ carIdx: PLAYER, position: 5 }] });
+  return buildEvent(
+    type as any,
+    { carIdx: PLAYER, carNumber: '0', driverName: 'Driver 0' },
+    {} as any,
+    { raceSessionId: 's1', rigId: 'r1', frame },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// pushRecentEvent — ring buffer
+// ---------------------------------------------------------------------------
+
+describe('pushRecentEvent ring buffer', () => {
+  it('appends events in order', () => {
+    const ds = createDriverState(PLAYER);
+    pushRecentEvent(ds, makeFakeEvent('OFF_TRACK', 1));
+    pushRecentEvent(ds, makeFakeEvent('OVERTAKE', 2));
+    expect(ds.recentEvents).toHaveLength(2);
+    expect(ds.recentEvents[0].type).toBe('OFF_TRACK');
+    expect(ds.recentEvents[1].type).toBe('OVERTAKE');
+  });
+
+  it('caps at RECENT_EVENTS_CAPACITY (50) and drops oldest', () => {
+    const ds = createDriverState(PLAYER);
+    for (let i = 0; i < RECENT_EVENTS_CAPACITY + 10; i++) {
+      pushRecentEvent(ds, makeFakeEvent('LAP_COMPLETED', i));
+    }
+    expect(ds.recentEvents).toHaveLength(RECENT_EVENTS_CAPACITY);
+    // Oldest 10 should have been shifted out — first remaining should be sessionTime=10.
+    expect(ds.recentEvents[0].sessionTime).toBe(10);
+    expect(ds.recentEvents[ds.recentEvents.length - 1].sessionTime).toBe(RECENT_EVENTS_CAPACITY + 10 - 1);
+  });
+
+  it('skips DRIVER_STATE_SNAPSHOT to avoid recursion', () => {
+    const ds = createDriverState(PLAYER);
+    pushRecentEvent(ds, makeFakeEvent('DRIVER_STATE_SNAPSHOT', 1));
+    expect(ds.recentEvents).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findForcedTrigger
+// ---------------------------------------------------------------------------
+
+describe('findForcedTrigger', () => {
+  it('returns the first HIGH_PRIORITY event in the batch', () => {
+    const t = findForcedTrigger([makeFakeEvent('OFF_TRACK'), makeFakeEvent('RACE_GREEN')]);
+    expect(t?.type).toBe('RACE_GREEN');
+  });
+
+  it('returns PIT_ENTRY/PIT_EXIT/DRIVER_SWAP_COMPLETED forced triggers', () => {
+    expect(findForcedTrigger([makeFakeEvent('PIT_ENTRY')])?.type).toBe('PIT_ENTRY');
+    expect(findForcedTrigger([makeFakeEvent('PIT_EXIT')])?.type).toBe('PIT_EXIT');
+    expect(findForcedTrigger([makeFakeEvent('DRIVER_SWAP_COMPLETED')])?.type).toBe('DRIVER_SWAP_COMPLETED');
+  });
+
+  it('returns null when no triggers present', () => {
+    expect(findForcedTrigger([makeFakeEvent('LAP_COMPLETED'), makeFakeEvent('OVERTAKE')])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCadenceElapsed
+// ---------------------------------------------------------------------------
+
+describe('isCadenceElapsed', () => {
+  it('returns true on first call (lastSnapshotSessionTime = -Infinity)', () => {
+    const ds = createDriverState(PLAYER);
+    const frame = makeFrame({ sessionTime: 0 });
+    expect(isCadenceElapsed(ds, frame, 15)).toBe(true);
+  });
+
+  it('returns false before interval elapses', () => {
+    const ds = createDriverState(PLAYER);
+    ds.lastSnapshotSessionTime = 100;
+    const frame = makeFrame({ sessionTime: 110 });
+    expect(isCadenceElapsed(ds, frame, 15)).toBe(false);
+  });
+
+  it('returns true when interval reached exactly', () => {
+    const ds = createDriverState(PLAYER);
+    ds.lastSnapshotSessionTime = 100;
+    const frame = makeFrame({ sessionTime: 115 });
+    expect(isCadenceElapsed(ds, frame, 15)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSnapshot — payload shape
+// ---------------------------------------------------------------------------
+
+describe('buildSnapshot payload', () => {
+  it('returns null when player car not in roster', () => {
+    const state = createSessionState('s1', 1); // no roster seeded
+    const ds = createDriverState(PLAYER);
+    const frame = makeFrame({ sessionTime: 1 });
+    expect(buildSnapshot(frame, state, ds, ctx, 'cadence')).toBeNull();
+  });
+
+  it('produces a well-formed snapshot with identity, state, and metadata', () => {
+    const state = makeRosteredState();
+    const ds = createDriverState(PLAYER);
+    const frame = makeFrame({
+      sessionTime: 100,
+      fuelLevel: 42.5,
+      sessionFlags: FlagBits.Green,
+      cars: [
+        { carIdx: PLAYER, position: 5, classPosition: 3, lapDistPct: 0.45, lapsCompleted: 12 },
+        { carIdx: 1, position: 4 },
+        { carIdx: 2, position: 6 },
+      ],
+    });
+
+    const snap = buildSnapshot(frame, state, ds, ctx, 'cadence');
+    expect(snap).not.toBeNull();
+    expect(snap!.type).toBe('DRIVER_STATE_SNAPSHOT');
+
+    const p = snap!.payload as any;
+    expect(p.reason).toBe('cadence');
+    expect(p.driverName).toBe('Driver 0');
+    expect(p.carIdx).toBe(0);
+    expect(p.position).toBe(5);
+    expect(p.classPosition).toBe(3);
+    expect(p.lap).toBe(12);
+    expect(p.lapDistPct).toBeCloseTo(0.45);
+    expect(p.fuelLevel).toBe(42.5);
+    expect(p.flag).toBe('green');
+    expect(p.recentEvents).toEqual([]);
+    expect(p.estimatedStintLaps).toBe(30);
+  });
+
+  it('includes carAhead and carBehind from state', () => {
+    const state = makeRosteredState();
+    const ds = createDriverState(PLAYER);
+
+    // Player at P5, gap to ahead = 1.2s, gap to behind tracked via carBehind's gapToAhead
+    const cs = getOrCreateCarState(state, PLAYER);
+    cs.recentGapToBehind = [2.0, 1.8, 1.5];
+    cs.closingRateToBehind = 0.25;
+    cs.closingRateToAhead = 0.10;
+
+    const frame = makeFrame({
+      sessionTime: 100,
+      cars: [
+        { carIdx: PLAYER, position: 5, f2Time: 1.2 },
+        { carIdx: 1, position: 4 }, // car ahead
+        { carIdx: 2, position: 6 }, // car behind
+      ],
+    });
+
+    const snap = buildSnapshot(frame, state, ds, ctx, 'cadence');
+    const p = snap!.payload as any;
+    expect(p.carAhead).toBeDefined();
+    expect(p.carAhead.car.carIdx).toBe(1);
+    expect(p.carAhead.gapSec).toBeCloseTo(1.2);
+    expect(p.carAhead.closingRateSecPerLap).toBeCloseTo(0.10);
+
+    expect(p.carBehind).toBeDefined();
+    expect(p.carBehind.car.carIdx).toBe(2);
+    expect(p.carBehind.gapSec).toBeCloseTo(1.5);
+    expect(p.carBehind.closingRateSecPerLap).toBeCloseTo(0.25);
+  });
+
+  it('embeds at most SNAPSHOT_RECENT_EVENTS_LIMIT recent events', () => {
+    const state = makeRosteredState();
+    const ds = createDriverState(PLAYER);
+    for (let i = 0; i < SNAPSHOT_RECENT_EVENTS_LIMIT + 5; i++) {
+      pushRecentEvent(ds, makeFakeEvent('LAP_COMPLETED', i));
+    }
+    const frame = makeFrame({ sessionTime: 100, cars: [{ carIdx: PLAYER }] });
+    const snap = buildSnapshot(frame, state, ds, ctx, 'forced');
+    const p = snap!.payload as any;
+    expect(p.recentEvents).toHaveLength(SNAPSHOT_RECENT_EVENTS_LIMIT);
+    // Newest last
+    expect(p.recentEvents[p.recentEvents.length - 1].sessionTime).toBe(SNAPSHOT_RECENT_EVENTS_LIMIT + 5 - 1);
+    // Each digest carries summary string
+    expect(p.recentEvents[0].summary).toContain('completed lap');
+  });
+
+  it('updates lastSnapshotSessionTime on success', () => {
+    const state = makeRosteredState();
+    const ds = createDriverState(PLAYER);
+    const frame = makeFrame({ sessionTime: 50, cars: [{ carIdx: PLAYER }] });
+    buildSnapshot(frame, state, ds, ctx, 'cadence');
+    expect(ds.lastSnapshotSessionTime).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maybeBuildSnapshot — decision logic
+// ---------------------------------------------------------------------------
+
+describe('maybeBuildSnapshot', () => {
+  it('emits on first frame (no prior snapshot)', () => {
+    const state = makeRosteredState();
+    const ds = createDriverState(PLAYER);
+    const frame = makeFrame({ sessionTime: 0, cars: [{ carIdx: PLAYER }] });
+    const snap = maybeBuildSnapshot(frame, state, ds, [], ctx);
+    expect(snap).not.toBeNull();
+    expect((snap!.payload as any).reason).toBe('cadence');
+  });
+
+  it('emits a forced snapshot when batch contains RACE_GREEN', () => {
+    const state = makeRosteredState();
+    const ds = createDriverState(PLAYER);
+    ds.lastSnapshotSessionTime = 100; // recent — would normally suppress
+    const frame = makeFrame({ sessionTime: 102, cars: [{ carIdx: PLAYER }] });
+    const snap = maybeBuildSnapshot(frame, state, ds, [makeFakeEvent('RACE_GREEN')], ctx);
+    expect(snap).not.toBeNull();
+    expect((snap!.payload as any).reason).toBe('forced');
+  });
+
+  it('emits a forced snapshot on PIT_ENTRY', () => {
+    const state = makeRosteredState();
+    const ds = createDriverState(PLAYER);
+    ds.lastSnapshotSessionTime = 100;
+    const frame = makeFrame({ sessionTime: 102, cars: [{ carIdx: PLAYER }] });
+    const snap = maybeBuildSnapshot(frame, state, ds, [makeFakeEvent('PIT_ENTRY')], ctx);
+    expect(snap).not.toBeNull();
+    expect((snap!.payload as any).reason).toBe('forced');
+  });
+
+  it('suppresses a snapshot when neither cadence elapsed nor trigger present', () => {
+    const state = makeRosteredState();
+    const ds = createDriverState(PLAYER);
+    ds.lastSnapshotSessionTime = 100;
+    const frame = makeFrame({ sessionTime: 105, cars: [{ carIdx: PLAYER }] });
+    const snap = maybeBuildSnapshot(frame, state, ds, [makeFakeEvent('LAP_COMPLETED')], ctx);
+    expect(snap).toBeNull();
+  });
+
+  it('emits at the cadence boundary', () => {
+    const state = makeRosteredState();
+    const ds = createDriverState(PLAYER);
+    ds.lastSnapshotSessionTime = 100;
+    const frame = makeFrame({
+      sessionTime: 100 + DEFAULT_SNAPSHOT_INTERVAL_SEC,
+      cars: [{ carIdx: PLAYER }],
+    });
+    const snap = maybeBuildSnapshot(frame, state, ds, [], ctx);
+    expect(snap).not.toBeNull();
+    expect((snap!.payload as any).reason).toBe('cadence');
+  });
+
+  it('honours custom snapshotIntervalSec', () => {
+    const state = makeRosteredState();
+    const ds = createDriverState(PLAYER);
+    ds.lastSnapshotSessionTime = 100;
+    const frame = makeFrame({ sessionTime: 103, cars: [{ carIdx: PLAYER }] });
+    const snap = maybeBuildSnapshot(frame, state, ds, [], { ...ctx, snapshotIntervalSec: 2 });
+    expect(snap).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveFlag
+// ---------------------------------------------------------------------------
+
+describe('deriveFlag', () => {
+  it.each([
+    [FlagBits.Green, 'green'],
+    [FlagBits.Yellow, 'yellow'],
+    [FlagBits.YellowFullCourse, 'yellow'],
+    [FlagBits.Red, 'red'],
+    [FlagBits.White, 'white'],
+    [FlagBits.Blue, 'blue'],
+    [FlagBits.Checkered, 'checkered'],
+    [0, 'unknown'],
+  ])('maps %d → %s', (flags, expected) => {
+    expect(deriveFlag(flags)).toBe(expected);
+  });
+
+  it('prioritises red over yellow', () => {
+    expect(deriveFlag(FlagBits.Red | FlagBits.Yellow)).toBe('red');
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/summarise-event.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/summarise-event.test.ts
@@ -1,0 +1,82 @@
+/**
+ * summarise-event.test.ts — Issue #179
+ *
+ * Validates that summariseEvent returns a non-empty 1-line string for every
+ * declared PublisherEventType. Guards against new event types being added
+ * without a corresponding case in the switch.
+ */
+import { describe, it, expect } from 'vitest';
+import { summariseEvent } from '../driver-publisher/summarise-event';
+import { buildEvent } from '../session-state';
+import type { PublisherEventType, PublisherEvent } from '../event-types';
+import { makeFrame } from './frame-fixtures';
+
+const ALL_EVENT_TYPES: PublisherEventType[] = [
+  'PUBLISHER_HELLO', 'PUBLISHER_HEARTBEAT', 'PUBLISHER_GOODBYE',
+  'IRACING_CONNECTED', 'IRACING_DISCONNECTED',
+  'SESSION_LOADED', 'SESSION_STATE_CHANGE', 'SESSION_TYPE_CHANGE',
+  'RACE_GREEN', 'RACE_CHECKERED', 'SESSION_ENDED',
+  'FLAG_GREEN', 'FLAG_YELLOW_LOCAL', 'FLAG_YELLOW_FULL_COURSE',
+  'FLAG_RED', 'FLAG_WHITE', 'FLAG_BLUE_DRIVER', 'FLAG_BLACK_DRIVER',
+  'FLAG_MEATBALL_DRIVER', 'FLAG_DEBRIS', 'FLAG_DISQUALIFY',
+  'LAP_COMPLETED', 'PERSONAL_BEST_LAP', 'SESSION_BEST_LAP', 'CLASS_BEST_LAP',
+  'LAP_TIME_DEGRADATION', 'STINT_MILESTONE', 'STINT_BEST_LAP',
+  'OVERTAKE', 'OVERTAKE_FOR_LEAD', 'OVERTAKE_FOR_CLASS', 'POSITION_CHANGE',
+  'BATTLE_ENGAGED', 'BATTLE_CLOSING', 'BATTLE_BROKEN',
+  'LAPPED_TRAFFIC_AHEAD', 'BEING_LAPPED',
+  'OVERALL_POSITION_LOSS', 'OVERALL_POSITION_GAIN',
+  'PIT_ENTRY', 'PIT_STOP_BEGIN', 'PIT_STOP_END', 'PIT_EXIT',
+  'FUEL_LEVEL_CHANGE', 'FUEL_LOW', 'OUT_LAP',
+  'OFF_TRACK', 'BACK_ON_TRACK', 'STOPPED_ON_TRACK', 'SLOW_CAR_AHEAD',
+  'INCIDENT_POINT', 'TEAM_INCIDENT_POINT', 'INCIDENT_LIMIT_WARNING',
+  'BIG_HIT', 'SPIN_DETECTED', 'PLAYER_STOPPED',
+  'IDENTITY_RESOLVED', 'IDENTITY_OVERRIDE_CHANGED',
+  'DRIVER_SWAP_INITIATED', 'DRIVER_SWAP_COMPLETED', 'ROSTER_UPDATED',
+  'WEATHER_CHANGE', 'TRACK_TEMP_DRIFT', 'WIND_SHIFT', 'TIME_OF_DAY_PHASE',
+  'GAP_CLOSING', 'GAP_OPENING',
+  'CLASS_POSITION_GAIN', 'CLASS_POSITION_LOSS',
+  'IN_PIT_WINDOW', 'FUEL_PROJECTION', 'PACE_DROP',
+  'SECTOR_PERSONAL_BEST', 'TYRE_TEMP_DRIFT', 'ENGINE_WARNING',
+  'DRIVER_STATE_SNAPSHOT',
+];
+
+function fakeEvent(type: PublisherEventType): PublisherEvent {
+  const frame = makeFrame({ sessionTime: 1 });
+  return buildEvent(
+    type as any,
+    { carIdx: 0, carNumber: '7', driverName: 'Test Driver' },
+    {} as any,
+    { raceSessionId: 's1', rigId: 'r1', frame },
+  );
+}
+
+describe('summariseEvent', () => {
+  it.each(ALL_EVENT_TYPES)('returns a non-empty string for %s', (type) => {
+    const summary = summariseEvent(fakeEvent(type));
+    expect(typeof summary).toBe('string');
+    expect(summary.length).toBeGreaterThan(0);
+  });
+
+  it('includes lap time in LAP_COMPLETED summary', () => {
+    const frame = makeFrame({ sessionTime: 1 });
+    const ev = buildEvent(
+      'LAP_COMPLETED',
+      { carIdx: 0, carNumber: '7', driverName: 'Test' },
+      { lapNumber: 5, lapTime: 92.345, fuelUsed: 2.1, position: 4, classPosition: 2 } as any,
+      { raceSessionId: 's1', rigId: 'r1', frame },
+    );
+    expect(summariseEvent(ev)).toContain('92.345');
+    expect(summariseEvent(ev)).toContain('lap 5');
+  });
+
+  it('handles missing car gracefully', () => {
+    const frame = makeFrame({ sessionTime: 1 });
+    const ev = buildEvent(
+      'RACE_GREEN',
+      { carIdx: 0 }, // minimal CarRef
+      { lapNumber: 1 } as any,
+      { raceSessionId: 's1', rigId: 'r1', frame },
+    );
+    expect(summariseEvent(ev)).toBe('Race green flag');
+  });
+});

--- a/src/extensions/iracing/publisher/driver-publisher/orchestrator.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/orchestrator.ts
@@ -38,6 +38,7 @@ import { detectOverallPositionChange } from './overall-position-detector';
 import { detectPlayerStopped } from './player-stopped-detector';
 import { detectPitWindow } from './pit-window-detector';
 import { detectNarrativePolish } from './narrative-polish-detector';
+import { maybeBuildSnapshot } from './snapshot-emitter';
 import {
   createSessionState,
   buildEvent,
@@ -45,7 +46,7 @@ import {
   type SessionState,
   type TelemetryFrame,
 } from '../session-state';
-import { createDriverState, type DriverState } from '../driver-state';
+import { createDriverState, pushRecentEvent, type DriverState } from '../driver-state';
 import type { PublisherEvent, PublisherCarRef } from '../event-types';
 
 export interface DriverPublisherConfig {
@@ -54,6 +55,8 @@ export interface DriverPublisherConfig {
   /** Callback to forward events to the renderer. */
   emitEvent: (event: string, payload: any) => void;
   log: (level: 'info' | 'warn' | 'error', message: string) => void;
+  /** Override the DRIVER_STATE_SNAPSHOT cadence in seconds (default 15). */
+  driverStateSnapshotIntervalSec?: number;
 }
 
 export class DriverPublisherOrchestrator {
@@ -214,6 +217,19 @@ export class DriverPublisherOrchestrator {
 
     this.dispatchEvents(events);
 
+    // DRIVER_STATE_SNAPSHOT (#179) — periodic cadence + forced flush on
+    // HIGH_PRIORITY events, pit transitions, and post driver-swap. Emitted
+    // strictly after the detector batch so it reflects the latest state.
+    if (playerCarIdx >= 0 && this.driverState) {
+      const snapshot = maybeBuildSnapshot(frame, this.state, this.driverState, events, {
+        raceSessionId: this.raceSessionId,
+        rigId: this.rigId,
+        playerCarIdx,
+        snapshotIntervalSec: this.cfg.driverStateSnapshotIntervalSec,
+      });
+      if (snapshot) this.dispatchEvents([snapshot]);
+    }
+
     // Emit operator state whenever player pit-road status changes.
     const playerIdx = this.playerCarIdx ?? 0;
     const nowOnPit  = frame.carIdxOnPitRoad[playerIdx] !== 0;
@@ -304,6 +320,10 @@ export class DriverPublisherOrchestrator {
     for (const ev of events) {
       this.cfg.transport.enqueue(ev);
       this._eventsEnqueued++;
+      // Keep a bounded ring buffer of recently-emitted events on the
+      // DriverState — used by DRIVER_STATE_SNAPSHOT (#179) and downstream
+      // composite detectors (#181 RECOVERY_DRIVE).
+      if (this.driverState) pushRecentEvent(this.driverState, ev);
       this.cfg.emitEvent('iracing.publisherEventEmitted', {
         type:      ev.type,
         carIdx:    ev.car?.carIdx,

--- a/src/extensions/iracing/publisher/driver-publisher/snapshot-emitter.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/snapshot-emitter.ts
@@ -1,0 +1,287 @@
+/**
+ * snapshot-emitter.ts — Issue #179
+ *
+ * Builds DRIVER_STATE_SNAPSHOT events on a fixed cadence and on forced-flush
+ * triggers (HIGH_PRIORITY events, pit transitions, post driver-swap).
+ *
+ * Pure module — never owns timers, never mutates DriverState directly except
+ * for `lastSnapshotSessionTime` (updated when a snapshot is emitted). The
+ * orchestrator calls `maybeBuildSnapshot()` after each frame's detector batch.
+ */
+
+import type {
+  PublisherEvent,
+  PublisherEventType,
+  DriverStateSnapshotPayload,
+  SnapshotBattleEntry,
+  SnapshotEventDigest,
+  SnapshotFlag,
+} from '../event-types';
+import { HIGH_PRIORITY_EVENTS } from '../event-types';
+import type { TelemetryFrame, SessionState } from '../session-state';
+import { buildEvent, carRefFromRoster, getOrCreateCarState } from '../session-state';
+import type { DriverState } from '../driver-state';
+import { summariseEvent } from './summarise-event';
+
+/** Default cadence between cadence-driven snapshots (seconds). */
+export const DEFAULT_SNAPSHOT_INTERVAL_SEC = 15;
+/** Maximum number of recent events embedded in each snapshot. */
+export const SNAPSHOT_RECENT_EVENTS_LIMIT = 10;
+
+/**
+ * Event types — beyond HIGH_PRIORITY_EVENTS — that should also force a
+ * snapshot. Stint-boundary and pit-transition events are valuable narrative
+ * inflection points for downstream consumers.
+ */
+const FORCED_SNAPSHOT_TRIGGERS: ReadonlySet<PublisherEventType> = new Set<PublisherEventType>([
+  'PIT_ENTRY',
+  'PIT_EXIT',
+  'DRIVER_SWAP_COMPLETED',
+]);
+
+export interface SnapshotEmitContext {
+  raceSessionId: string;
+  rigId: string;
+  playerCarIdx: number;
+  /** Override the default cadence (seconds). */
+  snapshotIntervalSec?: number;
+}
+
+/**
+ * Decides whether the just-emitted batch of events triggers a forced snapshot
+ * flush. Returns the matching trigger event (for diagnostic logging) or null.
+ */
+export function findForcedTrigger(events: readonly PublisherEvent[]): PublisherEvent | null {
+  for (const ev of events) {
+    if (HIGH_PRIORITY_EVENTS.has(ev.type) || FORCED_SNAPSHOT_TRIGGERS.has(ev.type)) {
+      return ev;
+    }
+  }
+  return null;
+}
+
+/**
+ * Returns true when the cadence interval has elapsed since the last snapshot.
+ */
+export function isCadenceElapsed(
+  driverState: DriverState,
+  frame: TelemetryFrame,
+  intervalSec: number,
+): boolean {
+  if (!Number.isFinite(driverState.lastSnapshotSessionTime)) return true;
+  return frame.sessionTime - driverState.lastSnapshotSessionTime >= intervalSec;
+}
+
+/**
+ * Build the snapshot payload + event. Returns null when carRef cannot be
+ * resolved from the roster yet (no roster data → nothing useful to publish).
+ *
+ * Mutates `driverState.lastSnapshotSessionTime` on success.
+ */
+export function buildSnapshot(
+  frame: TelemetryFrame,
+  state: SessionState,
+  driverState: DriverState,
+  ctx: SnapshotEmitContext,
+  reason: 'cadence' | 'forced',
+): PublisherEvent | null {
+  const carRef = carRefFromRoster(state, ctx.playerCarIdx);
+  if (!carRef) return null;
+
+  const payload = buildSnapshotPayload(frame, state, driverState, ctx, reason);
+
+  driverState.lastSnapshotSessionTime = frame.sessionTime;
+
+  return buildEvent('DRIVER_STATE_SNAPSHOT', carRef, payload, {
+    raceSessionId: ctx.raceSessionId,
+    rigId: ctx.rigId,
+    frame,
+  });
+}
+
+/**
+ * Convenience entrypoint for the orchestrator. Builds and returns the snapshot
+ * event when either (a) the just-dispatched batch contains a forced trigger,
+ * or (b) the cadence interval has elapsed. Returns null otherwise.
+ */
+export function maybeBuildSnapshot(
+  frame: TelemetryFrame,
+  state: SessionState,
+  driverState: DriverState,
+  dispatchedEvents: readonly PublisherEvent[],
+  ctx: SnapshotEmitContext,
+): PublisherEvent | null {
+  const intervalSec = ctx.snapshotIntervalSec ?? DEFAULT_SNAPSHOT_INTERVAL_SEC;
+
+  const trigger = findForcedTrigger(dispatchedEvents);
+  if (trigger) {
+    return buildSnapshot(frame, state, driverState, ctx, 'forced');
+  }
+  if (isCadenceElapsed(driverState, frame, intervalSec)) {
+    return buildSnapshot(frame, state, driverState, ctx, 'cadence');
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Payload assembly
+// ---------------------------------------------------------------------------
+
+function buildSnapshotPayload(
+  frame: TelemetryFrame,
+  state: SessionState,
+  driverState: DriverState,
+  ctx: SnapshotEmitContext,
+  reason: 'cadence' | 'forced',
+): DriverStateSnapshotPayload {
+  const idx = ctx.playerCarIdx;
+  const carRef = state.knownRoster.get(idx);
+  const cs = getOrCreateCarState(state, idx);
+
+  // Lap pace
+  const recentLapTimes = cs.stintLapTimes.slice(-5);
+  const lastLap = recentLapTimes.length > 0 ? recentLapTimes[recentLapTimes.length - 1] : 0;
+  const personalBestLapTime = cs.bestLapTime > 0 ? cs.bestLapTime : 0;
+  const paceVsBestPct =
+    personalBestLapTime > 0 && lastLap > 0
+      ? ((lastLap - personalBestLapTime) / personalBestLapTime) * 100
+      : 0;
+
+  // Battle context
+  const carAhead = buildBattleEntryAhead(frame, state, idx);
+  const carBehind = buildBattleEntryBehind(frame, state, idx, cs.recentGapToBehind, cs.closingRateToBehind);
+
+  // Recent events
+  const recentEvents: SnapshotEventDigest[] = driverState.recentEvents
+    .slice(-SNAPSHOT_RECENT_EVENTS_LIMIT)
+    .map((ev) => ({
+      type: ev.type,
+      sessionTime: ev.sessionTime,
+      summary: summariseEvent(ev),
+    }));
+
+  return {
+    reason,
+
+    // Identity
+    driverName: carRef?.driverName ?? '',
+    carIdx: idx,
+    carNumber: carRef?.carNumber ?? '',
+    stintNumber: driverState.stintNumber,
+
+    // Current state
+    position: frame.carIdxPosition[idx] ?? 0,
+    classPosition: frame.carIdxClassPosition[idx] ?? 0,
+    lap: frame.carIdxLapCompleted[idx] ?? 0,
+    lapDistPct: frame.carIdxLapDistPct[idx] ?? 0,
+    speed: frame.speed ?? 0,
+    onPitRoad: (frame.carIdxOnPitRoad[idx] ?? 0) !== 0,
+    trackSurface: frame.carIdxTrackSurface[idx] ?? 0,
+    isStopped: driverState.isStoppedBySpeed,
+    isOffTrack: (frame.carIdxTrackSurface[idx] ?? 0) === -1,
+
+    // Pace
+    recentLapTimes,
+    stintBestLapTime: cs.stintBestLapTime,
+    personalBestLapTime,
+    paceVsBestPct,
+
+    // Strategy
+    fuelLevel: frame.fuelLevel,
+    fuelLapsRemaining: cs.estimatedFuelLapsRemaining,
+    inPitWindow: cs.inPitWindow,
+    estimatedStintLaps: state.estimatedStintLaps,
+
+    // Battle
+    carAhead,
+    carBehind,
+
+    // Recent events
+    recentEvents,
+
+    // Race meta
+    racePhase: state.racePhase,
+    flag: deriveFlag(frame.sessionFlags),
+  };
+}
+
+function buildBattleEntryAhead(
+  frame: TelemetryFrame,
+  state: SessionState,
+  playerCarIdx: number,
+): SnapshotBattleEntry | undefined {
+  const cs = state.carStates.get(playerCarIdx);
+  if (!cs) return undefined;
+  const gapSec = frame.carIdxF2Time[playerCarIdx];
+  if (!Number.isFinite(gapSec) || gapSec <= 0) return undefined;
+
+  const playerPos = frame.carIdxPosition[playerCarIdx] ?? 0;
+  if (playerPos <= 1) return undefined;
+  const aheadPos = playerPos - 1;
+
+  let aheadIdx = -1;
+  for (let i = 0; i < frame.carIdxPosition.length; i++) {
+    if (frame.carIdxPosition[i] === aheadPos) { aheadIdx = i; break; }
+  }
+  if (aheadIdx < 0) return undefined;
+
+  const aheadRef = carRefFromRoster(state, aheadIdx);
+  if (!aheadRef) return undefined;
+
+  return {
+    car: aheadRef,
+    gapSec,
+    closingRateSecPerLap: cs.closingRateToAhead,
+  };
+}
+
+function buildBattleEntryBehind(
+  frame: TelemetryFrame,
+  state: SessionState,
+  playerCarIdx: number,
+  recentGapToBehind: number[],
+  closingRateToBehind: number,
+): SnapshotBattleEntry | undefined {
+  if (recentGapToBehind.length === 0) return undefined;
+  const playerPos = frame.carIdxPosition[playerCarIdx] ?? 0;
+  if (playerPos <= 0) return undefined;
+  const behindPos = playerPos + 1;
+
+  let behindIdx = -1;
+  for (let i = 0; i < frame.carIdxPosition.length; i++) {
+    if (frame.carIdxPosition[i] === behindPos) { behindIdx = i; break; }
+  }
+  if (behindIdx < 0) return undefined;
+
+  const behindRef = carRefFromRoster(state, behindIdx);
+  if (!behindRef) return undefined;
+
+  return {
+    car: behindRef,
+    gapSec: recentGapToBehind[recentGapToBehind.length - 1],
+    closingRateSecPerLap: closingRateToBehind,
+  };
+}
+
+/**
+ * Derive a coarse flag classification from the iRacing SessionFlags bitmask.
+ * Order matters — red > checkered > yellow > white > blue > green.
+ */
+export function deriveFlag(sessionFlags: number): SnapshotFlag {
+  // Bit constants mirror frame-fixtures FlagBits (irsdk_Flags).
+  const RED       = 0x0010;
+  const CHECKERED = 0x0001;
+  const YELLOW    = 0x0008;
+  const CAUTION   = 0x4000;
+  const WHITE     = 0x0002;
+  const BLUE      = 0x0020;
+  const GREEN     = 0x0004;
+
+  if (sessionFlags & RED) return 'red';
+  if (sessionFlags & CHECKERED) return 'checkered';
+  if (sessionFlags & (YELLOW | CAUTION)) return 'yellow';
+  if (sessionFlags & WHITE) return 'white';
+  if (sessionFlags & BLUE) return 'blue';
+  if (sessionFlags & GREEN) return 'green';
+  return 'unknown';
+}

--- a/src/extensions/iracing/publisher/driver-publisher/summarise-event.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/summarise-event.ts
@@ -1,0 +1,181 @@
+/**
+ * summarise-event.ts — Issue #179
+ *
+ * Pure function turning a PublisherEvent into a 1-line human-readable summary
+ * suitable for downstream LLM prompts and renderer logs. Strictly read-only;
+ * never mutates state. Returns a fallback when the event type is unknown so
+ * future event types remain forward-compatible.
+ */
+
+import type { PublisherEvent } from '../event-types';
+
+/**
+ * Returns a one-line, human-readable summary of `event`. Format intentionally
+ * compact (≤ 120 chars) — designed for inclusion in DRIVER_STATE_SNAPSHOT
+ * payloads where many summaries are concatenated.
+ */
+export function summariseEvent(event: PublisherEvent): string {
+  const carNum = event.car?.carNumber ? `#${event.car.carNumber}` : '';
+  const driver = event.car?.driverName ?? '';
+  const who = [carNum, driver].filter(Boolean).join(' ').trim();
+
+  switch (event.type) {
+    // §1 Lifecycle
+    case 'PUBLISHER_HELLO':       return 'Publisher online';
+    case 'PUBLISHER_HEARTBEAT':   return 'Heartbeat';
+    case 'PUBLISHER_GOODBYE':     return 'Publisher offline';
+    case 'IRACING_CONNECTED':     return 'iRacing connected';
+    case 'IRACING_DISCONNECTED':  return 'iRacing disconnected';
+    case 'SESSION_LOADED':        return 'Session loaded';
+    case 'SESSION_STATE_CHANGE':  return `Session state → ${(event.payload as any).newState}`;
+    case 'SESSION_TYPE_CHANGE':   return `Session type → ${(event.payload as any).newType}`;
+    case 'RACE_GREEN':            return 'Race green flag';
+    case 'RACE_CHECKERED':        return 'Race finished';
+    case 'SESSION_ENDED':         return 'Session ended';
+
+    // §2 Flags
+    case 'FLAG_GREEN':              return 'Green flag';
+    case 'FLAG_YELLOW_LOCAL':       return 'Local yellow';
+    case 'FLAG_YELLOW_FULL_COURSE': return 'Full-course yellow';
+    case 'FLAG_RED':                return 'Red flag';
+    case 'FLAG_WHITE':              return 'White flag (last lap)';
+    case 'FLAG_BLUE_DRIVER':        return `Blue flag for ${who}`;
+    case 'FLAG_BLACK_DRIVER':       return `Black flag for ${who}`;
+    case 'FLAG_MEATBALL_DRIVER':   return `Meatball for ${who}`;
+    case 'FLAG_DEBRIS':             return 'Debris flag';
+    case 'FLAG_DISQUALIFY':         return `Disqualified: ${who}`;
+
+    // §3 Lap performance
+    case 'LAP_COMPLETED': {
+      const p = event.payload as any;
+      return `${who} completed lap ${p.lapNumber} (${p.lapTime?.toFixed?.(3)}s)`;
+    }
+    case 'PERSONAL_BEST_LAP':
+      return `${who} personal best ${(event.payload as any).lapTime?.toFixed?.(3)}s`;
+    case 'SESSION_BEST_LAP':
+      return `Session best ${(event.payload as any).lapTime?.toFixed?.(3)}s by ${who}`;
+    case 'CLASS_BEST_LAP':
+      return `Class best ${(event.payload as any).lapTime?.toFixed?.(3)}s by ${who}`;
+    case 'LAP_TIME_DEGRADATION':
+      return `${who} pace dropping (+${((event.payload as any).deltaPct ?? 0).toFixed?.(1)}%)`;
+    case 'STINT_MILESTONE':
+      return `Stint ${(event.payload as any).milestonePct}% complete`;
+    case 'STINT_BEST_LAP':
+      return `Stint best ${(event.payload as any).lapTime?.toFixed?.(3)}s`;
+
+    // §4 Position & battle
+    case 'OVERTAKE':
+      return `${who} overtake`;
+    case 'OVERTAKE_FOR_LEAD':
+      return `${who} took the lead`;
+    case 'OVERTAKE_FOR_CLASS':
+      return `${who} class overtake`;
+    case 'POSITION_CHANGE': {
+      const p = event.payload as any;
+      return `${who} P${p.previousPosition}→P${p.newPosition}`;
+    }
+    case 'BATTLE_ENGAGED':
+      return `Battle engaged ${who}`;
+    case 'BATTLE_CLOSING':
+      return `Battle closing ${who}`;
+    case 'BATTLE_BROKEN':
+      return `Battle broken ${who}`;
+    case 'LAPPED_TRAFFIC_AHEAD':
+      return `Lapped traffic ahead`;
+    case 'BEING_LAPPED':
+      return `Being lapped`;
+    case 'OVERALL_POSITION_LOSS': {
+      const p = event.payload as any;
+      return `Lost a position (P${p.previousPosition}→P${p.newPosition})`;
+    }
+    case 'OVERALL_POSITION_GAIN': {
+      const p = event.payload as any;
+      return `Gained a position (P${p.previousPosition}→P${p.newPosition})`;
+    }
+
+    // §5 Pit & strategy
+    case 'PIT_ENTRY':       return `${who} pit entry`;
+    case 'PIT_STOP_BEGIN':  return `${who} pit stop begin`;
+    case 'PIT_STOP_END':    return `${who} pit stop end`;
+    case 'PIT_EXIT':        return `${who} pit exit`;
+    case 'FUEL_LEVEL_CHANGE':
+      return `Refuel to ${(event.payload as any).newFuelLevel?.toFixed?.(1)}L`;
+    case 'FUEL_LOW':
+      return `Fuel low (${((event.payload as any).fuelLevelPct * 100).toFixed?.(0)}%)`;
+    case 'OUT_LAP':
+      return `Out lap`;
+
+    // §6 Incidents
+    case 'OFF_TRACK':         return `${who} off track`;
+    case 'BACK_ON_TRACK':     return `${who} back on track`;
+    case 'STOPPED_ON_TRACK':  return `${who} stopped on track`;
+    case 'SLOW_CAR_AHEAD':    return `Slow car ahead`;
+    case 'INCIDENT_POINT':
+      return `Incident +${(event.payload as any).delta ?? 1}x`;
+    case 'TEAM_INCIDENT_POINT':
+      return `Team incident +${(event.payload as any).delta ?? 1}x`;
+    case 'INCIDENT_LIMIT_WARNING':
+      return `Incident limit at ${(event.payload as any).thresholdPct}%`;
+    case 'BIG_HIT':           return `Big hit`;
+    case 'SPIN_DETECTED':     return `Spin`;
+    case 'PLAYER_STOPPED': {
+      const p = event.payload as any;
+      return `Player stopped (${p.stoppedDurationSec?.toFixed?.(1)}s)`;
+    }
+
+    // §7 Identity
+    case 'IDENTITY_RESOLVED':         return `Identity resolved: ${who}`;
+    case 'IDENTITY_OVERRIDE_CHANGED': return `Identity override changed`;
+    case 'DRIVER_SWAP_INITIATED':     return `Driver swap initiated → ${(event.payload as any).incomingDriverName}`;
+    case 'DRIVER_SWAP_COMPLETED':     return `Driver swap complete → ${(event.payload as any).incomingDriverName}`;
+    case 'ROSTER_UPDATED':            return `Roster updated`;
+
+    // §8 Environment
+    case 'WEATHER_CHANGE':    return `Weather change`;
+    case 'TRACK_TEMP_DRIFT':
+      return `Track temp drift Δ${((event.payload as any).deltaFromStartCelsius ?? 0).toFixed?.(1)}°C`;
+    case 'WIND_SHIFT':        return `Wind shift`;
+    case 'TIME_OF_DAY_PHASE':
+      return `Time of day → ${(event.payload as any).phase}`;
+
+    // §9 Race-narrative
+    case 'GAP_CLOSING': {
+      const p = event.payload as any;
+      return `Closing on ${p.targetCar?.driverName ?? ''} (Δ${p.gapSec?.toFixed?.(2)}s)`;
+    }
+    case 'GAP_OPENING': {
+      const p = event.payload as any;
+      return `Gap opening to ${p.targetCar?.driverName ?? ''} (Δ${p.gapSec?.toFixed?.(2)}s)`;
+    }
+    case 'CLASS_POSITION_GAIN': {
+      const p = event.payload as any;
+      return `Class P${p.previousClassPos}→P${p.newClassPos}`;
+    }
+    case 'CLASS_POSITION_LOSS': {
+      const p = event.payload as any;
+      return `Class P${p.previousClassPos}→P${p.newClassPos}`;
+    }
+    case 'IN_PIT_WINDOW':
+      return `In pit window (${(event.payload as any).lapsRemainingInStint} laps left)`;
+    case 'FUEL_PROJECTION':
+      return `Fuel projection ${(event.payload as any).projectedLaps?.toFixed?.(1)} laps`;
+    case 'PACE_DROP':
+      return `Pace drop +${((event.payload as any).deltaPct ?? 0).toFixed?.(1)}%`;
+    case 'SECTOR_PERSONAL_BEST':
+      return `Sector ${(event.payload as any).sector} PB`;
+    case 'TYRE_TEMP_DRIFT': {
+      const p = event.payload as any;
+      return `Tyre ${p.tyre} Δ${p.deltaC?.toFixed?.(1)}°C`;
+    }
+    case 'ENGINE_WARNING':
+      return `Engine warning: ${((event.payload as any).warningNames ?? []).join(', ')}`;
+
+    // §10 AI consumer aids
+    case 'DRIVER_STATE_SNAPSHOT':
+      return `Driver state snapshot`;
+  }
+
+  // Forward-compatibility — exhaustive switch above; this is unreachable
+  // unless a new event type is added without a case here.
+  return `${(event as PublisherEvent).type}`;
+}

--- a/src/extensions/iracing/publisher/driver-state.ts
+++ b/src/extensions/iracing/publisher/driver-state.ts
@@ -16,6 +16,11 @@
  * Only the DriverPublisherOrchestrator creates and owns a DriverState instance.
  */
 
+import type { PublisherEvent } from './event-types';
+
+/** Maximum number of recent events retained on DriverState. */
+export const RECENT_EVENTS_CAPACITY = 50;
+
 // ---------------------------------------------------------------------------
 // DriverState — all player-scoped mutable runtime state
 // ---------------------------------------------------------------------------
@@ -73,8 +78,10 @@ export interface DriverState {
   bigHitCooldownUntilTick: number;
 
   // ---- Future use (Issue #179) ----
-  /** Reserved for the recent-events ring buffer planned in issue #179. */
-  recentEvents: never[];
+  /** Bounded ring buffer of recent events emitted from this pipeline (oldest→newest, capped at RECENT_EVENTS_CAPACITY). */
+  recentEvents: PublisherEvent[];
+  /** sessionTime of the most recent DRIVER_STATE_SNAPSHOT emission (-Infinity = never). */
+  lastSnapshotSessionTime: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -103,5 +110,19 @@ export function createDriverState(carIdx: number): DriverState {
     spinDetectedCooldownUntilTick: 0,
     bigHitCooldownUntilTick: 0,
     recentEvents: [],
+    lastSnapshotSessionTime: -Infinity,
   };
+}
+
+/**
+ * Append an event to the bounded recentEvents ring buffer. Mutates in place.
+ * Drops the oldest entry when at capacity. DRIVER_STATE_SNAPSHOT is excluded
+ * to avoid recursive noise in subsequent snapshots.
+ */
+export function pushRecentEvent(state: DriverState, event: PublisherEvent): void {
+  if (event.type === 'DRIVER_STATE_SNAPSHOT') return;
+  state.recentEvents.push(event);
+  while (state.recentEvents.length > RECENT_EVENTS_CAPACITY) {
+    state.recentEvents.shift();
+  }
 }

--- a/src/extensions/iracing/publisher/event-types.ts
+++ b/src/extensions/iracing/publisher/event-types.ts
@@ -153,7 +153,10 @@ export type PublisherEventType =
   | 'PACE_DROP'
   | 'SECTOR_PERSONAL_BEST'
   | 'TYRE_TEMP_DRIFT'
-  | 'ENGINE_WARNING';
+  | 'ENGINE_WARNING'
+  // §10 AI consumer aids (#179)
+  /** Periodic snapshot of the current driver situation + recent events ring buffer. */
+  | 'DRIVER_STATE_SNAPSHOT';
 
 // CLOUD-EMITTED — publisher never produces these. Listed here for documentation only.
 // 'FOCUS_VS_FOCUS_BATTLE' | 'FOCUS_GROUP_ON_TRACK' | 'FOCUS_GROUP_SPLIT'
@@ -285,6 +288,9 @@ export interface EventPayloadMap {
   SECTOR_PERSONAL_BEST: SectorPersonalBestPayload;
   TYRE_TEMP_DRIFT: TyreTempDriftPayload;
   ENGINE_WARNING: EngineWarningPayload;
+
+  // §10 AI consumer aids (#179)
+  DRIVER_STATE_SNAPSHOT: DriverStateSnapshotPayload;
 }
 
 // ---------------------------------------------------------------------------
@@ -664,4 +670,94 @@ export interface EngineWarningPayload {
   warningFlags: number;
   /** Decoded warning names (e.g. 'WaterTempWarning', 'OilPressureWarning'). */
   warningNames: string[];
+}
+
+// ---------------------------------------------------------------------------
+// §10 AI consumer aids — DRIVER_STATE_SNAPSHOT (#179)
+// ---------------------------------------------------------------------------
+
+export type SnapshotFlag =
+  | 'green'
+  | 'yellow'
+  | 'red'
+  | 'white'
+  | 'checkered'
+  | 'blue'
+  | 'unknown';
+
+export interface SnapshotBattleEntry {
+  /** Self-describing ref for the rival car. */
+  car: PublisherCarRef;
+  /** Current gap to that car in seconds (always positive). */
+  gapSec: number;
+  /** Closing rate in seconds-per-lap (positive = closing on us / we are closing on them). */
+  closingRateSecPerLap: number;
+}
+
+export interface SnapshotEventDigest {
+  type: PublisherEventType;
+  /** sessionTime (seconds) of the original event. */
+  sessionTime: number;
+  /** One-line summary suitable for downstream LLM prompts. */
+  summary: string;
+}
+
+/**
+ * DRIVER_STATE_SNAPSHOT — periodic + forced-flush snapshot of the player's
+ * current situation. Designed for downstream AI consumers (race-narrative,
+ * commentary, alerting). Strictly additive — never a substitute for the
+ * authoritative discrete events.
+ */
+export interface DriverStateSnapshotPayload {
+  /** ISO reason for this snapshot. */
+  reason: 'cadence' | 'forced';
+
+  // Identity
+  driverName: string;
+  carIdx: number;
+  carNumber: string;
+  stintNumber: number;
+
+  // Current state
+  position: number;
+  classPosition: number;
+  lap: number;
+  lapDistPct: number;
+  /** Player ground speed in m/s. */
+  speed: number;
+  onPitRoad: boolean;
+  /** iRacing CarIdxTrackSurface enum value. */
+  trackSurface: number;
+  isStopped: boolean;
+  isOffTrack: boolean;
+
+  // Pace
+  /** Most recent stint lap times (seconds, ordered oldest→newest, capped at 5). */
+  recentLapTimes: number[];
+  /** Best lap of the current stint (seconds, 0 = none). */
+  stintBestLapTime: number;
+  /** Personal best lap of the session (seconds, 0 = none). */
+  personalBestLapTime: number;
+  /** % delta of the most recent lap vs personal best (positive = slower, 0 when no data). */
+  paceVsBestPct: number;
+
+  // Strategy
+  /** Litres of fuel remaining (raw FuelLevel). */
+  fuelLevel: number;
+  /** Estimated laps the current fuel load will sustain (0 when unknown). */
+  fuelLapsRemaining: number;
+  inPitWindow: boolean;
+  /** Estimated stint length in laps (0 when unknown). */
+  estimatedStintLaps: number;
+
+  // Battle
+  carAhead?: SnapshotBattleEntry;
+  carBehind?: SnapshotBattleEntry;
+
+  // Recent events (most recent last, capped at 10)
+  recentEvents: SnapshotEventDigest[];
+
+  // Race meta
+  racePhase: 'unknown' | 'opening' | 'midrace' | 'endgame' | 'final-laps';
+  flag: SnapshotFlag;
 }


### PR DESCRIPTION
Closes #179. Part of epic #176.

Adds the `DRIVER_STATE_SNAPSHOT` event — a periodic + forced-flush snapshot of the player's situation aimed at downstream AI / narrative consumers. Strictly additive; never replaces the authoritative discrete events.

## Changes

**Wire contract**
- New event type `DRIVER_STATE_SNAPSHOT` with `DriverStateSnapshotPayload` (identity, current state, pace, strategy, battle context, recent events, race meta, flag).
- Helper types: `SnapshotBattleEntry`, `SnapshotEventDigest`, `SnapshotFlag`.

**DriverState**
- `recentEvents: PublisherEvent[]` — bounded ring buffer (capacity 50, see `RECENT_EVENTS_CAPACITY`). Replaces the `never[]` placeholder reserved in #177.
- `lastSnapshotSessionTime: number` — cadence tracker.
- `pushRecentEvent(state, event)` helper — appends + drops oldest at capacity, skips `DRIVER_STATE_SNAPSHOT` to avoid recursive noise.

**Snapshot emitter** (`driver-publisher/snapshot-emitter.ts`)
- Pure helpers: `findForcedTrigger`, `isCadenceElapsed`, `buildSnapshot`, `maybeBuildSnapshot`, `deriveFlag`.
- Default cadence: 15s (`DEFAULT_SNAPSHOT_INTERVAL_SEC`), configurable via `DriverPublisherConfig.driverStateSnapshotIntervalSec`.
- Forced-flush triggers: every event in `HIGH_PRIORITY_EVENTS` plus `PIT_ENTRY` / `PIT_EXIT` / `DRIVER_SWAP_COMPLETED`.
- Embeds the last 10 recent events as 1-line digests (`SNAPSHOT_RECENT_EVENTS_LIMIT`).

**Event summarisation** (`driver-publisher/summarise-event.ts`)
- Pure 1-line summary per event type — exhaustive switch covering every declared `PublisherEventType`.

**Orchestrator wiring**
- After each detector batch: every emitted event is appended to `DriverState.recentEvents`; then `maybeBuildSnapshot()` is consulted and a snapshot is dispatched when cadence elapsed or a forced trigger is present.

## Tests

107 new tests (869 total, was 762):
- Ring buffer ordering, capacity 50 cap, snapshot recursion exclusion.
- `findForcedTrigger` for HIGH_PRIORITY + pit/swap triggers.
- Cadence boundary conditions (first call, mid-interval, exact boundary, custom interval).
- Payload shape: identity / state / pace / strategy / battle (carAhead, carBehind) / recentEvents (limit 10).
- `lastSnapshotSessionTime` updated on emit.
- `deriveFlag` for every flag bit + red-priority-over-yellow.
- `summariseEvent` parametrised over all 73 event types — guards against missing cases when new types are added.

```
Test Files  43 passed (43)
     Tests  869 passed (869)
```
