### PR TITLE
feat(iracing): derived metrics on DriverState (#182)

### DIFF
--- a/src/extensions/iracing/publisher/__tests__/derived-metrics-aggregator.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/derived-metrics-aggregator.test.ts
@@ -1,0 +1,393 @@
+/**
+ * derived-metrics-aggregator.test.ts — Issue #182
+ *
+ * Validates each individual derived metric on `DriverState.derived` plus the
+ * end-to-end aggregator wiring. Pure functions — no orchestrator needed.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeDerivedMetrics,
+  computeMedian,
+  computePaceTrend,
+  computeConsistencyScore,
+  computeIncidentIntensity,
+  computeCompetitiveFocus,
+  closenessFromGap,
+  computeAggressionScore,
+  computeLowFuelStress,
+  computeTyreWearStress,
+  deriveNarrativeArc,
+  INCIDENT_WEIGHTS,
+} from '../driver-publisher/derived-metrics-aggregator';
+import { createDriverState } from '../driver-state';
+import { createSessionState, buildEvent, getOrCreateCarState } from '../session-state';
+import { makeFrame, seedRoster, makeDriverState } from './frame-fixtures';
+import type { PublisherEvent } from '../event-types';
+
+const PLAYER = 0;
+
+function makeRosteredState() {
+  const s = createSessionState('s1', 1);
+  seedRoster(s, [PLAYER, 1, 2]);
+  return s;
+}
+
+function fakeEvent(
+  type: PublisherEvent['type'],
+  sessionTime: number,
+  carIdx = PLAYER,
+): PublisherEvent {
+  const frame = makeFrame({ sessionTime, cars: [{ carIdx, position: 5 }] });
+  return buildEvent(
+    type as any,
+    { carIdx, carNumber: String(carIdx), driverName: `Driver ${carIdx}` },
+    {} as any,
+    { raceSessionId: 's1', rigId: 'r1', frame },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('computeMedian', () => {
+  it('returns 0 for empty input', () => {
+    expect(computeMedian([])).toBe(0);
+  });
+  it('handles odd-length samples', () => {
+    expect(computeMedian([90, 91, 92])).toBe(91);
+  });
+  it('handles even-length samples (mean of middle two)', () => {
+    expect(computeMedian([90, 91, 92, 93])).toBeCloseTo(91.5, 5);
+  });
+});
+
+describe('computePaceTrend', () => {
+  it('returns 0 when fewer than 2 samples', () => {
+    expect(computePaceTrend([])).toBe(0);
+    expect(computePaceTrend([90])).toBe(0);
+  });
+  it('positive slope when laps are slowing', () => {
+    expect(computePaceTrend([90, 90.5, 91, 91.5, 92])).toBeCloseTo(0.5, 3);
+  });
+  it('negative slope when laps are improving', () => {
+    expect(computePaceTrend([92, 91.5, 91, 90.5, 90])).toBeCloseTo(-0.5, 3);
+  });
+  it('near-zero slope for stable laps', () => {
+    expect(Math.abs(computePaceTrend([90, 90.01, 89.99, 90, 90.01]))).toBeLessThan(0.01);
+  });
+});
+
+describe('computeConsistencyScore', () => {
+  it('1.0 when laps are identical', () => {
+    expect(computeConsistencyScore([90, 90, 90, 90, 90])).toBe(1);
+  });
+  it('returns 0 when fewer than 2 samples', () => {
+    expect(computeConsistencyScore([90])).toBe(0);
+  });
+  it('drops toward 0 as variance grows', () => {
+    const high = computeConsistencyScore([90, 90.05, 90, 89.95, 90]);
+    const low  = computeConsistencyScore([90, 91, 89, 92, 88]);
+    expect(high).toBeGreaterThan(0.85);
+    expect(low).toBeLessThan(high);
+    expect(low).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('computeIncidentIntensity', () => {
+  it('returns 0 with no incidents', () => {
+    expect(computeIncidentIntensity([], 100)).toBe(0);
+  });
+  it('peaks shortly after a fresh incident', () => {
+    const intensity = computeIncidentIntensity(
+      [{ sessionTime: 100, weight: 0.9 }],
+      101,
+    );
+    expect(intensity).toBeGreaterThan(0.85);
+    expect(intensity).toBeLessThanOrEqual(1);
+  });
+  it('decays toward zero as time passes', () => {
+    const fresh = computeIncidentIntensity([{ sessionTime: 0, weight: 0.9 }], 1);
+    const stale = computeIncidentIntensity([{ sessionTime: 0, weight: 0.9 }], 50);
+    expect(stale).toBeLessThan(fresh);
+  });
+  it('clamps to 1 when many incidents stack', () => {
+    const incidents = Array.from({ length: 10 }, (_, i) => ({ sessionTime: 100 + i * 0.1, weight: 0.9 }));
+    expect(computeIncidentIntensity(incidents, 101)).toBe(1);
+  });
+});
+
+describe('closenessFromGap', () => {
+  it('1.0 when gap is at or below 0', () => {
+    expect(closenessFromGap(0)).toBe(0);          // 0 means "no data" by convention
+    expect(closenessFromGap(0.0001)).toBeCloseTo(1, 3);
+  });
+  it('0 when gap exceeds 3 s', () => {
+    expect(closenessFromGap(3)).toBe(0);
+    expect(closenessFromGap(10)).toBe(0);
+  });
+  it('linearly interpolates', () => {
+    expect(closenessFromGap(1.5)).toBeCloseTo(0.5, 3);
+  });
+});
+
+describe('computeCompetitiveFocus', () => {
+  it('returns 0 when both gaps are unknown', () => {
+    const state = makeRosteredState();
+    const frame = makeFrame();
+    expect(computeCompetitiveFocus(frame, state, PLAYER)).toBe(0);
+  });
+  it('uses larger of ahead/behind closeness', () => {
+    const state = makeRosteredState();
+    const cs = getOrCreateCarState(state, PLAYER);
+    cs.recentGapToBehind.push(0.5);
+    const frame = makeFrame({ cars: [{ carIdx: PLAYER, f2Time: 2.0 }] });
+    const focus = computeCompetitiveFocus(frame, state, PLAYER);
+    expect(focus).toBeGreaterThan(0.8); // 0.5 s behind ⇒ closeness ≈ 0.83
+  });
+});
+
+describe('computeAggressionScore', () => {
+  it('returns 0 with fewer than 2 samples', () => {
+    expect(computeAggressionScore([1], [0])).toBe(0);
+  });
+  it('returns 0 for steady-state inputs', () => {
+    expect(computeAggressionScore([1, 1, 1, 1], [0, 0, 0, 0])).toBe(0);
+  });
+  it('grows with input volatility', () => {
+    const calm    = computeAggressionScore([1, 1, 1, 1], [0, 0, 0, 0]);
+    const choppy  = computeAggressionScore([1, 0, 1, 0], [0, 1, 0, 1]);
+    expect(choppy).toBeGreaterThan(calm);
+    expect(choppy).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('computeLowFuelStress', () => {
+  it('0 when fuel is healthy', () => {
+    expect(computeLowFuelStress(0.5)).toBe(0);
+    expect(computeLowFuelStress(0.20)).toBe(0);
+  });
+  it('1 when fuel is empty', () => {
+    expect(computeLowFuelStress(0)).toBe(1);
+  });
+  it('scales linearly inside the danger band', () => {
+    expect(computeLowFuelStress(0.10)).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe('computeTyreWearStress', () => {
+  it('0 with brand-new tyres (all wear=1)', () => {
+    expect(computeTyreWearStress(makeFrame())).toBe(0);
+  });
+  it('approaches 1 as tyres go bald', () => {
+    const frame = makeFrame({
+      lfWearL: 0.05, lfWearM: 0.05, lfWearR: 0.05,
+      rfWearL: 0.05, rfWearM: 0.05, rfWearR: 0.05,
+      lrWearL: 0.05, lrWearM: 0.05, lrWearR: 0.05,
+      rrWearL: 0.05, rrWearM: 0.05, rrWearR: 0.05,
+    });
+    expect(computeTyreWearStress(frame)).toBeGreaterThan(0.9);
+  });
+});
+
+describe('deriveNarrativeArc', () => {
+  it('opens during opening race phase regardless of stress', () => {
+    expect(deriveNarrativeArc({
+      racePhase: 'opening',
+      incidentIntensity: 1,
+      competitiveFocus: 1,
+      raceStress: 1,
+      paceTrend: 0,
+    })).toBe('opening');
+  });
+  it('returns endgame for final-laps phase', () => {
+    expect(deriveNarrativeArc({
+      racePhase: 'final-laps',
+      incidentIntensity: 0,
+      competitiveFocus: 0,
+      raceStress: 0,
+      paceTrend: 0,
+    })).toBe('endgame');
+  });
+  it('recovery when incident intensity is high', () => {
+    expect(deriveNarrativeArc({
+      racePhase: 'midrace',
+      incidentIntensity: 0.8,
+      competitiveFocus: 0,
+      raceStress: 0.4,
+      paceTrend: 0,
+    })).toBe('recovery');
+  });
+  it('climax when stress is high but no recent incidents', () => {
+    expect(deriveNarrativeArc({
+      racePhase: 'midrace',
+      incidentIntensity: 0.1,
+      competitiveFocus: 0.9,
+      raceStress: 0.8,
+      paceTrend: 0,
+    })).toBe('climax');
+  });
+  it('building when in close company but not yet stressed', () => {
+    expect(deriveNarrativeArc({
+      racePhase: 'midrace',
+      incidentIntensity: 0,
+      competitiveFocus: 0.7,
+      raceStress: 0.3,
+      paceTrend: 0,
+    })).toBe('building');
+  });
+  it('cruise as the default lull state', () => {
+    expect(deriveNarrativeArc({
+      racePhase: 'midrace',
+      incidentIntensity: 0,
+      competitiveFocus: 0,
+      raceStress: 0,
+      paceTrend: 0,
+    })).toBe('cruise');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end aggregator
+// ---------------------------------------------------------------------------
+
+describe('computeDerivedMetrics — integration', () => {
+  it('no-ops when player carIdx is unresolved', () => {
+    const ds = makeDriverState(PLAYER);
+    const before = { ...ds.derived };
+    const state = makeRosteredState();
+    const frame = makeFrame();
+    computeDerivedMetrics(null, frame, state, ds, { playerCarIdx: -1 });
+    expect(ds.derived).toEqual(before);
+  });
+
+  it('writes a fully-populated derived block with sane defaults on first call', () => {
+    const ds = makeDriverState(PLAYER);
+    const state = makeRosteredState();
+    const frame = makeFrame({ sessionTime: 10 });
+    computeDerivedMetrics(null, frame, state, ds, { playerCarIdx: PLAYER });
+
+    expect(ds.derived.recentLapPace).toBe(0);
+    expect(ds.derived.paceTrend).toBe(0);
+    expect(ds.derived.incidentIntensity).toBe(0);
+    expect(ds.derived.competitiveFocus).toBe(0);
+    expect(ds.derived.raceStress).toBeGreaterThanOrEqual(0);
+    expect(ds.derived.consistencyScore).toBe(0);
+    expect(ds.derived.aggressionScore).toBe(0);
+    expect(['opening','building','climax','recovery','cruise','endgame']).toContain(ds.derived.narrativeArc);
+  });
+
+  it('reflects stable lap pace once 5 lap times exist on CarState', () => {
+    const ds = makeDriverState(PLAYER);
+    const state = makeRosteredState();
+    state.racePhase = 'midrace';
+    const cs = getOrCreateCarState(state, PLAYER);
+    cs.stintLapTimes = [90, 90, 90, 90, 90];
+    const frame = makeFrame({ sessionTime: 600 });
+    computeDerivedMetrics(null, frame, state, ds, { playerCarIdx: PLAYER });
+
+    expect(ds.derived.recentLapPace).toBe(90);
+    expect(Math.abs(ds.derived.paceTrend)).toBeLessThan(0.001);
+    expect(ds.derived.consistencyScore).toBe(1);
+  });
+
+  it('ingests CONTACT_DETECTED from recentEvents and bumps incidentIntensity', () => {
+    const ds = makeDriverState(PLAYER);
+    const state = makeRosteredState();
+    state.racePhase = 'midrace';
+    ds.recentEvents.push(fakeEvent('CONTACT_DETECTED', 99));
+    const frame = makeFrame({ sessionTime: 100 });
+    computeDerivedMetrics(null, frame, state, ds, { playerCarIdx: PLAYER });
+
+    expect(ds.recentIncidents.length).toBe(1);
+    expect(ds.recentIncidents[0].weight).toBe(INCIDENT_WEIGHTS.CONTACT_DETECTED);
+    expect(ds.derived.incidentIntensity).toBeGreaterThan(0);
+  });
+
+  it('does not double-ingest the same incident across calls (high-water mark)', () => {
+    const ds = makeDriverState(PLAYER);
+    const state = makeRosteredState();
+    ds.recentEvents.push(fakeEvent('CONTACT_DETECTED', 100));
+    const frame1 = makeFrame({ sessionTime: 101 });
+    computeDerivedMetrics(null, frame1, state, ds, { playerCarIdx: PLAYER });
+    const frame2 = makeFrame({ sessionTime: 102 });
+    computeDerivedMetrics(frame1, frame2, state, ds, { playerCarIdx: PLAYER });
+    expect(ds.recentIncidents.length).toBe(1);
+  });
+
+  it('prunes incidents older than the 60s window', () => {
+    const ds = makeDriverState(PLAYER);
+    const state = makeRosteredState();
+    ds.recentIncidents.push({ sessionTime: 0, weight: 0.6 });
+    const frame = makeFrame({ sessionTime: 100 });
+    computeDerivedMetrics(null, frame, state, ds, { playerCarIdx: PLAYER });
+    expect(ds.recentIncidents.length).toBe(0);
+  });
+
+  it('rolling throttle/brake samples drive aggressionScore', () => {
+    const ds = makeDriverState(PLAYER);
+    const state = makeRosteredState();
+    let prev = makeFrame({ sessionTime: 0, throttle: 1, brake: 0 });
+    computeDerivedMetrics(null, prev, state, ds, { playerCarIdx: PLAYER });
+    for (let i = 1; i <= 10; i++) {
+      const f = makeFrame({
+        sessionTime: i,
+        throttle: i % 2 === 0 ? 1 : 0,
+        brake:    i % 2 === 0 ? 0 : 1,
+      });
+      computeDerivedMetrics(prev, f, state, ds, { playerCarIdx: PLAYER });
+      prev = f;
+    }
+    expect(ds.derived.aggressionScore).toBeGreaterThan(0.5);
+  });
+
+  it('competitiveFocus contributes to raceStress via the 0.3 weight', () => {
+    const ds = makeDriverState(PLAYER);
+    const state = makeRosteredState();
+    state.racePhase = 'midrace';
+    const cs = getOrCreateCarState(state, PLAYER);
+    cs.recentGapToBehind.push(0.1); // ~3 cm — closeness ≈ 0.97
+    const frame = makeFrame({ sessionTime: 50, cars: [{ carIdx: PLAYER, f2Time: 0.1 }] });
+    computeDerivedMetrics(null, frame, state, ds, { playerCarIdx: PLAYER });
+    expect(ds.derived.competitiveFocus).toBeGreaterThan(0.9);
+    // raceStress >= 0.3 * competitiveFocus when no other stressors.
+    expect(ds.derived.raceStress).toBeGreaterThanOrEqual(0.27);
+  });
+
+  it('all derived scores remain bounded in [0,1] across a 50-frame synthetic replay', () => {
+    const ds = makeDriverState(PLAYER);
+    const state = makeRosteredState();
+    state.racePhase = 'midrace';
+    const cs = getOrCreateCarState(state, PLAYER);
+    cs.stintLapTimes = [90, 91, 89, 92, 88];
+    let prev: any = null;
+    for (let i = 0; i < 50; i++) {
+      // Sprinkle the odd contact event.
+      if (i === 10 || i === 25) {
+        ds.recentEvents.push(fakeEvent('CONTACT_DETECTED', i));
+      }
+      const f = makeFrame({
+        sessionTime: i,
+        throttle: Math.random(),
+        brake: Math.random(),
+        fuelLevelPct: Math.max(0, 0.8 - i * 0.015),
+        cars: [{ carIdx: PLAYER, f2Time: 1 + Math.random() * 2 }],
+      });
+      cs.recentGapToBehind.push(0.5 + Math.random());
+      computeDerivedMetrics(prev, f, state, ds, { playerCarIdx: PLAYER });
+      prev = f;
+
+      const d = ds.derived;
+      expect(d.incidentIntensity).toBeGreaterThanOrEqual(0);
+      expect(d.incidentIntensity).toBeLessThanOrEqual(1);
+      expect(d.competitiveFocus).toBeGreaterThanOrEqual(0);
+      expect(d.competitiveFocus).toBeLessThanOrEqual(1);
+      expect(d.raceStress).toBeGreaterThanOrEqual(0);
+      expect(d.raceStress).toBeLessThanOrEqual(1);
+      expect(d.consistencyScore).toBeGreaterThanOrEqual(0);
+      expect(d.consistencyScore).toBeLessThanOrEqual(1);
+      expect(d.aggressionScore).toBeGreaterThanOrEqual(0);
+      expect(d.aggressionScore).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/src/extensions/iracing/publisher/driver-publisher/derived-metrics-aggregator.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/derived-metrics-aggregator.ts
@@ -1,0 +1,306 @@
+/**
+ * derived-metrics-aggregator.ts — Issue #182
+ *
+ * Computes the continuous `DerivedMetrics` block on `DriverState` every frame.
+ * Pure, fully unit-testable, no event emission.
+ *
+ * Wired into the orchestrator BEFORE detectors so detectors and the snapshot
+ * emitter both see the freshest derived block.
+ *
+ * Metric definitions (spec #182):
+ *   - recentLapPace      : median of last 5 stint lap times (sec; 0 = no data)
+ *   - paceTrend          : linear-fit slope of last 5 lap times (sec/lap)
+ *   - incidentIntensity  : exp-decay of incident weights over 60 s
+ *                          weights: OFF_TRACK 0.3, CONTACT_DETECTED 0.6,
+ *                                   PLAYER_STOPPED 0.9
+ *   - competitiveFocus   : max(closeness ahead, closeness behind);
+ *                          closeness = 1 - clamp(gapSec/3, 0, 1)
+ *   - raceStress         : 0.4*incidentIntensity + 0.3*competitiveFocus
+ *                        + 0.2*lowFuel + 0.1*tyreWear
+ *                          lowFuel  = 1 - clamp(fuelLevelPct/0.20, 0, 1)
+ *                          tyreWear = 1 - mean(min wear/tyre across LF/RF/LR/RR)
+ *   - consistencyScore   : 1 - clamp(stdDev(last5Laps)/0.5, 0, 1)
+ *   - aggressionScore    : rolling avg of |Δthrottle| + |Δbrake| (last 30 samples)
+ *   - narrativeArc       : rule-based, see deriveNarrativeArc()
+ */
+
+import type { TelemetryFrame, SessionState } from '../session-state';
+import { getOrCreateCarState } from '../session-state';
+import type { DriverState } from '../driver-state';
+import { INPUT_SAMPLE_CAPACITY, INCIDENT_INTENSITY_WINDOW_SEC } from '../driver-state';
+import type { NarrativeArc, DerivedMetrics, PublisherEvent } from '../event-types';
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+export const COMPETITIVE_FOCUS_FULL_GAP_SEC = 3;
+export const LOW_FUEL_PCT_FULL_STRESS = 0.20;
+export const CONSISTENCY_DEGRADATION_SEC = 0.5;
+
+export const INCIDENT_WEIGHTS: Readonly<Record<string, number>> = {
+  OFF_TRACK:        0.3,
+  CONTACT_DETECTED: 0.6,
+  PLAYER_STOPPED:   0.9,
+};
+
+// ---------------------------------------------------------------------------
+// Aggregator
+// ---------------------------------------------------------------------------
+
+export interface DerivedMetricsContext {
+  playerCarIdx: number;
+  /**
+   * Optional override for incident scanning — defaults to scanning
+   * `driverState.recentEvents` (populated by the previous tick) and ingesting
+   * each event whose sessionTime is greater than the high-water mark held in
+   * `driverState.recentIncidents`. Tests may also push directly into
+   * `driverState.recentIncidents`.
+   */
+  incidentEventsOverride?: readonly PublisherEvent[];
+}
+
+/**
+ * Recompute the derived block on `driverState`. Mutates rolling buffers and
+ * the `derived` field in place; returns the same `derived` object for caller
+ * convenience.
+ */
+export function computeDerivedMetrics(
+  _prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  driverState: DriverState,
+  ctx: DerivedMetricsContext,
+): DerivedMetrics {
+  if (ctx.playerCarIdx < 0) return driverState.derived;
+
+  // ---- Update rolling input buffers ----
+  pushSample(driverState.throttleSamples, clamp01(curr.throttle ?? 0), INPUT_SAMPLE_CAPACITY);
+  pushSample(driverState.brakeSamples,    clamp01(curr.brake    ?? 0), INPUT_SAMPLE_CAPACITY);
+
+  // ---- Ingest fresh incident events into the rolling list ----
+  const eventSource = ctx.incidentEventsOverride ?? driverState.recentEvents;
+  const hwm = driverState.recentIncidents.length > 0
+    ? driverState.recentIncidents[driverState.recentIncidents.length - 1].sessionTime
+    : -Infinity;
+  for (const ev of eventSource) {
+    if (ev.car.carIdx !== ctx.playerCarIdx) continue;
+    if (ev.sessionTime <= hwm) continue;
+    const w = INCIDENT_WEIGHTS[ev.type as string];
+    if (w === undefined) continue;
+    driverState.recentIncidents.push({ sessionTime: ev.sessionTime, weight: w });
+  }
+  pruneIncidents(driverState.recentIncidents, curr.sessionTime);
+
+  const cs = getOrCreateCarState(state, ctx.playerCarIdx);
+  const recentLaps = cs.stintLapTimes.slice(-5);
+
+  const recentLapPace     = computeMedian(recentLaps);
+  const paceTrend         = computePaceTrend(recentLaps);
+  const consistencyScore  = computeConsistencyScore(recentLaps);
+  const incidentIntensity = computeIncidentIntensity(driverState.recentIncidents, curr.sessionTime);
+  const competitiveFocus  = computeCompetitiveFocus(curr, state, ctx.playerCarIdx);
+  const aggressionScore   = computeAggressionScore(driverState.throttleSamples, driverState.brakeSamples);
+  const lowFuelStress     = computeLowFuelStress(curr.fuelLevelPct);
+  const tyreWearStress    = computeTyreWearStress(curr);
+  const raceStress        = clamp01(
+    0.4 * incidentIntensity +
+    0.3 * competitiveFocus  +
+    0.2 * lowFuelStress     +
+    0.1 * tyreWearStress,
+  );
+  const narrativeArc      = deriveNarrativeArc({
+    racePhase:         state.racePhase,
+    incidentIntensity,
+    competitiveFocus,
+    raceStress,
+    paceTrend,
+  });
+
+  driverState.derived = {
+    recentLapPace,
+    paceTrend,
+    incidentIntensity,
+    competitiveFocus,
+    raceStress,
+    consistencyScore,
+    aggressionScore,
+    narrativeArc,
+  };
+
+  return driverState.derived;
+}
+
+// ---------------------------------------------------------------------------
+// Per-metric helpers (exported for direct unit tests)
+// ---------------------------------------------------------------------------
+
+export function computeMedian(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/** Linear-fit slope (least squares) over the index axis. Returns sec/lap. */
+export function computePaceTrend(values: readonly number[]): number {
+  const n = values.length;
+  if (n < 2) return 0;
+  let sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
+  for (let i = 0; i < n; i++) {
+    sumX  += i;
+    sumY  += values[i];
+    sumXY += i * values[i];
+    sumX2 += i * i;
+  }
+  const denom = n * sumX2 - sumX * sumX;
+  if (denom === 0) return 0;
+  return (n * sumXY - sumX * sumY) / denom;
+}
+
+export function computeConsistencyScore(values: readonly number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance = values.reduce((a, b) => a + (b - mean) ** 2, 0) / values.length;
+  const stdDev = Math.sqrt(variance);
+  return 1 - clamp01(stdDev / CONSISTENCY_DEGRADATION_SEC);
+}
+
+export function computeIncidentIntensity(
+  incidents: readonly { sessionTime: number; weight: number }[],
+  now: number,
+): number {
+  if (incidents.length === 0) return 0;
+  let acc = 0;
+  for (const inc of incidents) {
+    const age = now - inc.sessionTime;
+    if (age < 0 || age > INCIDENT_INTENSITY_WINDOW_SEC) continue;
+    // Exponential decay: at 60 s, e^-1 ≈ 0.37.
+    const decay = Math.exp(-age / INCIDENT_INTENSITY_WINDOW_SEC);
+    acc += inc.weight * decay;
+  }
+  return clamp01(acc);
+}
+
+export function computeCompetitiveFocus(
+  frame: TelemetryFrame,
+  state: SessionState,
+  playerCarIdx: number,
+): number {
+  const cs = state.carStates.get(playerCarIdx);
+  // Gap ahead — F2Time when valid, else last value from rolling buffer.
+  let gapAhead = frame.carIdxF2Time?.[playerCarIdx] ?? 0;
+  if (!Number.isFinite(gapAhead) || gapAhead <= 0) {
+    const buf = cs?.recentGapToAhead ?? [];
+    gapAhead = buf.length > 0 ? buf[buf.length - 1] : Infinity;
+  }
+  const gapBehindBuf = cs?.recentGapToBehind ?? [];
+  const gapBehind = gapBehindBuf.length > 0 ? gapBehindBuf[gapBehindBuf.length - 1] : Infinity;
+
+  const closenessAhead  = closenessFromGap(gapAhead);
+  const closenessBehind = closenessFromGap(gapBehind);
+  return Math.max(closenessAhead, closenessBehind);
+}
+
+export function closenessFromGap(gapSec: number): number {
+  if (!Number.isFinite(gapSec) || gapSec <= 0) return 0;
+  return 1 - clamp01(gapSec / COMPETITIVE_FOCUS_FULL_GAP_SEC);
+}
+
+export function computeAggressionScore(
+  throttleSamples: readonly number[],
+  brakeSamples: readonly number[],
+): number {
+  const tRate = meanAbsDelta(throttleSamples);
+  const bRate = meanAbsDelta(brakeSamples);
+  // |Δthrottle|+|Δbrake| each in [0,1]; sum can theoretically reach 2 — clamp.
+  return clamp01(tRate + bRate);
+}
+
+export function computeLowFuelStress(fuelLevelPct: number | undefined): number {
+  const pct = Number.isFinite(fuelLevelPct) ? (fuelLevelPct as number) : 1;
+  if (pct >= LOW_FUEL_PCT_FULL_STRESS) return 0;
+  if (pct <= 0) return 1;
+  return 1 - pct / LOW_FUEL_PCT_FULL_STRESS;
+}
+
+export function computeTyreWearStress(frame: TelemetryFrame): number {
+  // Per-tyre wear is reported as 1.0 = new, 0.0 = bald in the L/M/R buckets.
+  // Use the worst (lowest) of the three measurements per tyre, then average.
+  const lf = minOrOne(frame.lfWearL, frame.lfWearM, frame.lfWearR);
+  const rf = minOrOne(frame.rfWearL, frame.rfWearM, frame.rfWearR);
+  const lr = minOrOne(frame.lrWearL, frame.lrWearM, frame.lrWearR);
+  const rr = minOrOne(frame.rrWearL, frame.rrWearM, frame.rrWearR);
+  const meanRemaining = (lf + rf + lr + rr) / 4;
+  return clamp01(1 - meanRemaining);
+}
+
+export interface NarrativeArcInputs {
+  racePhase: SessionState['racePhase'];
+  incidentIntensity: number;
+  competitiveFocus: number;
+  raceStress: number;
+  paceTrend: number;
+}
+
+/**
+ * Rule-based narrative arc derivation:
+ *   - racePhase 'opening'    → 'opening'
+ *   - racePhase 'final-laps' → 'endgame'
+ *   - else if recovering from very recent incidents (intensity > 0.5
+ *     and no longer rising)             → 'recovery'
+ *   - else if raceStress > 0.7          → 'climax'
+ *   - else if competitiveFocus > 0.5    → 'building'
+ *   - else                              → 'cruise'
+ */
+export function deriveNarrativeArc(inputs: NarrativeArcInputs): NarrativeArc {
+  if (inputs.racePhase === 'opening')    return 'opening';
+  if (inputs.racePhase === 'final-laps') return 'endgame';
+  if (inputs.incidentIntensity > 0.5)    return 'recovery';
+  if (inputs.raceStress       > 0.7)     return 'climax';
+  if (inputs.competitiveFocus > 0.5)     return 'building';
+  return 'cruise';
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function pushSample(buf: number[], value: number, cap: number): void {
+  buf.push(value);
+  while (buf.length > cap) buf.shift();
+}
+
+function pruneIncidents(
+  buf: { sessionTime: number; weight: number }[],
+  now: number,
+): void {
+  const cutoff = now - INCIDENT_INTENSITY_WINDOW_SEC;
+  while (buf.length > 0 && buf[0].sessionTime < cutoff) buf.shift();
+}
+
+function meanAbsDelta(samples: readonly number[]): number {
+  if (samples.length < 2) return 0;
+  let acc = 0;
+  for (let i = 1; i < samples.length; i++) {
+    acc += Math.abs(samples[i] - samples[i - 1]);
+  }
+  return acc / (samples.length - 1);
+}
+
+function minOrOne(...vals: Array<number | undefined>): number {
+  let m = Infinity;
+  for (const v of vals) {
+    if (typeof v === 'number' && Number.isFinite(v)) {
+      if (v < m) m = v;
+    }
+  }
+  return Number.isFinite(m) ? m : 1;
+}

--- a/src/extensions/iracing/publisher/driver-publisher/orchestrator.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/orchestrator.ts
@@ -42,6 +42,7 @@ import { detectPlayerStopped } from './player-stopped-detector';
 import { detectPitWindow } from './pit-window-detector';
 import { detectNarrativePolish } from './narrative-polish-detector';
 import { maybeBuildSnapshot } from './snapshot-emitter';
+import { computeDerivedMetrics } from './derived-metrics-aggregator';
 import {
   createSessionState,
   buildEvent,
@@ -170,6 +171,14 @@ export class DriverPublisherOrchestrator {
         estimatedStintLaps: this.estimatedStintLaps,
         playerFuelPerLap: this.driverState?.fuelPerLap ?? 0,
       });
+
+      // Derived-metrics aggregator (#182) — also runs BEFORE detectors so the
+      // snapshot emitter and any consumer sees the freshest scores.
+      if (this.driverState) {
+        computeDerivedMetrics(this.prevFrame, frame, this.state, this.driverState, {
+          playerCarIdx,
+        });
+      }
     }
 
     // Identity — resolve on every frame; only emits on first resolve or change.

--- a/src/extensions/iracing/publisher/driver-publisher/snapshot-emitter.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/snapshot-emitter.ts
@@ -202,6 +202,10 @@ function buildSnapshotPayload(
     // Race meta
     racePhase: state.racePhase,
     flag: deriveFlag(frame.sessionFlags),
+
+    // Derived metrics (#182) — snapshot a copy so downstream mutations cannot
+    // leak back into DriverState.
+    derived: { ...driverState.derived },
   };
 }
 

--- a/src/extensions/iracing/publisher/driver-publisher/summarise-event.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/summarise-event.ts
@@ -176,8 +176,25 @@ export function summariseEvent(event: PublisherEvent): string {
       return `Engine warning: ${((event.payload as any).warningNames ?? []).join(', ')}`;
 
     // §10 AI consumer aids
-    case 'DRIVER_STATE_SNAPSHOT':
-      return `Driver state snapshot`;
+    case 'DRIVER_STATE_SNAPSHOT': {
+      const p = event.payload as any;
+      const d = p?.derived;
+      if (!d) return `Driver state snapshot`;
+      const arc = d.narrativeArc ?? 'cruise';
+      const stress =
+        d.raceStress >= 0.7 ? 'stressed' :
+        d.raceStress >= 0.4 ? 'engaged'  :
+        'composed';
+      const battle =
+        d.competitiveFocus >= 0.66 ? ', battling' :
+        d.competitiveFocus >= 0.33 ? ', in traffic' :
+        '';
+      const pace =
+        d.paceTrend >  0.05 ? ', slowing' :
+        d.paceTrend < -0.05 ? ', improving' :
+        '';
+      return `Snapshot[${arc}]: ${stress}${battle}${pace}`;
+    }
 
     // §11 Composite events (#181)
     case 'BEING_PASSED_WHILE_STOPPED': {

--- a/src/extensions/iracing/publisher/driver-state.ts
+++ b/src/extensions/iracing/publisher/driver-state.ts
@@ -17,13 +17,19 @@
  */
 
 import type { PublisherEvent } from './event-types';
-import type { PublisherCarRef } from './event-types';
+import type { PublisherCarRef, DerivedMetrics } from './event-types';
 
 /** Maximum number of recent events retained on DriverState. */
 export const RECENT_EVENTS_CAPACITY = 50;
 
 /** Number of frames retained in the contact-proximity ring (#180). */
 export const CONTACT_PROXIMITY_RING_CAPACITY = 3;
+
+/** Capacity of the throttle/brake sample rings used by the aggression score (#182). */
+export const INPUT_SAMPLE_CAPACITY = 30;
+
+/** Time window (sec) for the rolling incident decay (#182). */
+export const INCIDENT_INTENSITY_WINDOW_SEC = 60;
 
 // ---------------------------------------------------------------------------
 // Pending-contact resolution state (#180)
@@ -145,6 +151,19 @@ export interface DriverState {
     startPosition: number;
     trigger: 'PLAYER_STOPPED' | 'OFF_TRACK' | 'CONTACT_DETECTED';
   } | null;
+
+  // ---- Derived metrics (#182) ----
+  /** Continuous derived metrics; recomputed every frame by the aggregator. */
+  derived: DerivedMetrics;
+  /** Rolling buffer of recent throttle samples (0..1) for aggressionScore. */
+  throttleSamples: number[];
+  /** Rolling buffer of recent brake samples (0..1) for aggressionScore. */
+  brakeSamples: number[];
+  /**
+   * Rolling list of recent incident weights for `incidentIntensity` decay.
+   * Each entry: { sessionTime, weight }. Pruned to INCIDENT_INTENSITY_WINDOW_SEC.
+   */
+  recentIncidents: Array<{ sessionTime: number; weight: number }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -179,6 +198,24 @@ export function createDriverState(carIdx: number): DriverState {
     proximityRing: [],
     positionsLostThisStop: 0,
     recoveryActive: null,
+    derived: createDefaultDerivedMetrics(),
+    throttleSamples: [],
+    brakeSamples: [],
+    recentIncidents: [],
+  };
+}
+
+/** Default derived metrics state — all zeros and 'opening' arc. */
+export function createDefaultDerivedMetrics(): DerivedMetrics {
+  return {
+    recentLapPace: 0,
+    paceTrend: 0,
+    incidentIntensity: 0,
+    competitiveFocus: 0,
+    raceStress: 0,
+    consistencyScore: 0,
+    aggressionScore: 0,
+    narrativeArc: 'opening',
   };
 }
 

--- a/src/extensions/iracing/publisher/event-types.ts
+++ b/src/extensions/iracing/publisher/event-types.ts
@@ -810,6 +810,51 @@ export interface DriverStateSnapshotPayload {
   // Race meta
   racePhase: 'unknown' | 'opening' | 'midrace' | 'endgame' | 'final-laps';
   flag: SnapshotFlag;
+
+  // Derived metrics (#182) — continuous rolling-window scores describing
+  // how the driver is doing in human terms. Optional for forward-compat with
+  // older snapshot consumers.
+  derived?: DerivedMetrics;
+}
+
+// ---------------------------------------------------------------------------
+// §12 Derived metrics (#182)
+// ---------------------------------------------------------------------------
+
+/**
+ * Coarse phase of the player's race arc — rule-based on race progress and
+ * recent events. Sampled by DRIVER_STATE_SNAPSHOT.
+ */
+export type NarrativeArc =
+  | 'opening'
+  | 'building'
+  | 'climax'
+  | 'recovery'
+  | 'cruise'
+  | 'endgame';
+
+/**
+ * Continuous derived metrics on `DriverState`. Recomputed every frame by
+ * `derived-metrics-aggregator.ts`. All scores are normalised 0–1 except
+ * `recentLapPace` (seconds) and `paceTrend` (seconds-per-lap).
+ */
+export interface DerivedMetrics {
+  /** Median of the last 5 stint lap times in seconds (0 = no data). */
+  recentLapPace: number;
+  /** Linear-fit slope of the last 5 lap times (sec/lap; positive = slowing, 0 = no data). */
+  paceTrend: number;
+  /** 0–1 — exponential-decay weighted recent incident pressure (60 s window). */
+  incidentIntensity: number;
+  /** 0–1 — max closeness of car ahead/behind, where closeness=1 at ≤0 s gap, 0 at ≥3 s. */
+  competitiveFocus: number;
+  /** 0–1 — weighted blend of incident, focus, low-fuel, tyre-wear pressure. */
+  raceStress: number;
+  /** 0–1 — lap-time consistency (1 = perfectly consistent). */
+  consistencyScore: number;
+  /** 0–1 — rolling avg of throttle+brake change rate (input volatility). */
+  aggressionScore: number;
+  /** Rule-based race phase / narrative arc. */
+  narrativeArc: NarrativeArc;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a continuous **`DerivedMetrics`** block to `DriverState`, computed every frame by a new pure aggregator wired into `DriverPublisherOrchestrator` **before** detectors so both detectors and `DRIVER_STATE_SNAPSHOT` see the freshest scores.

Closes #182. Part of epic #176.

## Metrics

| Field | Range | Definition |
|---|---|---|
| `recentLapPace` | sec | Median of last 5 stint lap times (0 = no data) |
| `paceTrend` | sec/lap | Linear-fit slope of last 5 lap times (positive = slowing) |
| `incidentIntensity` | 0–1 | Exp-decay (60 s window) of weighted incidents — `OFF_TRACK 0.3`, `CONTACT_DETECTED 0.6`, `PLAYER_STOPPED 0.9` |
| `competitiveFocus` | 0–1 | `max(closenessAhead, closenessBehind)`; closeness = `1 - clamp(gap/3, 0, 1)` |
| `raceStress` | 0–1 | `0.4·incidentIntensity + 0.3·competitiveFocus + 0.2·lowFuel + 0.1·tyreWear` |
| `consistencyScore` | 0–1 | `1 - clamp(stdDev(last5)/0.5, 0, 1)` |
| `aggressionScore` | 0–1 | Rolling avg of `\|Δthrottle\|+\|Δbrake\|` over last 30 samples |
| `narrativeArc` | enum | `opening \| building \| climax \| recovery \| cruise \| endgame` (rule-based) |

## Files

- **`event-types.ts`** — adds `NarrativeArc` type, `DerivedMetrics` interface, and an optional `derived` field on `DriverStateSnapshotPayload`.
- **`driver-state.ts`** — adds `derived`, `throttleSamples`, `brakeSamples`, `recentIncidents` to `DriverState` (initialised in `createDriverState`).
- **`driver-publisher/derived-metrics-aggregator.ts`** *(new)* — pure `computeDerivedMetrics()` that mutates rolling buffers + the derived block. Each metric is also exported individually for direct unit-tests.
- **`driver-publisher/orchestrator.ts`** — invokes `computeDerivedMetrics()` immediately after `aggregateRaceState()`.
- **`driver-publisher/snapshot-emitter.ts`** — embeds a copy of `driverState.derived` in every snapshot payload.
- **`driver-publisher/summarise-event.ts`** — extends `DRIVER_STATE_SNAPSHOT` summary into a 1-line "feel" string (e.g. `Snapshot[climax]: stressed, battling, slowing`).

## Incident ingestion

Aggregator scans `driverState.recentEvents` (populated by the previous tick's detector batch) on every frame, with a high-water-mark dedupe so each event is counted once. Incidents older than 60 s are pruned.

## Tests

`__tests__/derived-metrics-aggregator.test.ts` — **42 new tests** covering each pure helper, the integration aggregator, dedupe / pruning, and a 50-frame randomised replay asserting every score stays in `[0, 1]`.

Full suite: **966 / 966** passing (was 924).

## Notes

- All scores clamp to bounds; `Number.isFinite` guards everywhere.
- `derived` is marked optional on the snapshot payload for backward-compat with consumers that haven't bumped their schema yet.
- Strictly additive — no behaviour change for existing detectors.
