### PR TITLE
feat(iracing): EventEnricher LLM stage (#183)

### DIFF
--- a/src/extensions/iracing/publisher/__tests__/enricher-cluster-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/enricher-cluster-detector.test.ts
@@ -1,0 +1,144 @@
+/**
+ * enricher-cluster-detector.test.ts — Issue #183
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ClusterDetector,
+  INCIDENT_WINDOW_SEC,
+  INCIDENT_MIN_COUNT,
+  BATTLE_MIN_SEC,
+  BATTLE_FOCUS_THRESHOLD,
+} from '../enricher/cluster-detector';
+import type { PublisherEvent, PublisherEventType } from '../event-types';
+
+let nextId = 0;
+function fakeEvent(type: PublisherEventType, sessionTime: number): PublisherEvent {
+  return {
+    id: `evt-${++nextId}`,
+    raceSessionId: 's1',
+    type,
+    timestamp: 1_000_000 + sessionTime * 1000,
+    sessionTime,
+    sessionTick: Math.floor(sessionTime * 60),
+    car: { carIdx: 0, carNumber: '7', driverName: 'Test' },
+    payload: {} as any,
+  };
+}
+
+describe('ClusterDetector — incident clustering', () => {
+  it('does not emit until min count is reached', () => {
+    const d = new ClusterDetector();
+    const r1 = d.ingest(fakeEvent('OFF_TRACK', 100));
+    const r2 = d.ingest(fakeEvent('OFF_TRACK', 101));
+    expect(r1).toEqual([]);
+    expect(r2).toEqual([]);
+  });
+
+  it('emits one cluster when 3 incidents land within the window', () => {
+    const d = new ClusterDetector();
+    d.ingest(fakeEvent('OFF_TRACK', 100));
+    d.ingest(fakeEvent('CONTACT_DETECTED', 102));
+    const out = d.ingest(fakeEvent('PLAYER_STOPPED', 105));
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe('incident');
+    expect(out[0].events).toHaveLength(INCIDENT_MIN_COUNT);
+    expect(out[0].startTime).toBe(100);
+    expect(out[0].endTime).toBe(105);
+  });
+
+  it('does NOT cluster when events span longer than the window', () => {
+    const d = new ClusterDetector();
+    d.ingest(fakeEvent('OFF_TRACK', 100));
+    d.ingest(fakeEvent('CONTACT_DETECTED', 105));
+    // 100 → 100+11 (= window+1): first event aged out, only 2 in window
+    const out = d.ingest(fakeEvent('PLAYER_STOPPED', 100 + INCIDENT_WINDOW_SEC + 1));
+    expect(out).toEqual([]);
+  });
+
+  it('ignores non-incident events', () => {
+    const d = new ClusterDetector();
+    d.ingest(fakeEvent('LAP_COMPLETED', 100));
+    d.ingest(fakeEvent('LAP_COMPLETED', 102));
+    const out = d.ingest(fakeEvent('LAP_COMPLETED', 105));
+    expect(out).toEqual([]);
+  });
+
+  it('honours cooldown — a 2nd burst right after one already emitted does not refire', () => {
+    const d = new ClusterDetector();
+    d.ingest(fakeEvent('OFF_TRACK', 100));
+    d.ingest(fakeEvent('OFF_TRACK', 101));
+    d.ingest(fakeEvent('OFF_TRACK', 102)); // emits
+    // Three more incidents within the cooldown window — must NOT re-emit.
+    d.ingest(fakeEvent('OFF_TRACK', 103));
+    d.ingest(fakeEvent('OFF_TRACK', 104));
+    const out = d.ingest(fakeEvent('OFF_TRACK', 105));
+    expect(out).toEqual([]);
+  });
+
+  it('re-fires after cooldown elapses', () => {
+    const d = new ClusterDetector();
+    d.ingest(fakeEvent('OFF_TRACK', 100));
+    d.ingest(fakeEvent('OFF_TRACK', 101));
+    d.ingest(fakeEvent('OFF_TRACK', 102)); // emits at 102
+    // Wait long enough that the prior burst ages out of the window AND the
+    // cooldown has elapsed.
+    d.ingest(fakeEvent('OFF_TRACK', 200));
+    d.ingest(fakeEvent('OFF_TRACK', 201));
+    const out = d.ingest(fakeEvent('OFF_TRACK', 202));
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe('incident');
+  });
+});
+
+describe('ClusterDetector — battle clustering', () => {
+  it('emits when sustained focus drops AFTER min duration', () => {
+    const d = new ClusterDetector();
+    d.ingest(fakeEvent('LAP_COMPLETED', 100), { competitiveFocus: 0.9 });
+    d.ingest(fakeEvent('LAP_COMPLETED', 110), { competitiveFocus: 0.9 });
+    d.ingest(fakeEvent('LAP_COMPLETED', 130), { competitiveFocus: 0.9 });
+    const out = d.ingest(fakeEvent('LAP_COMPLETED', 132), { competitiveFocus: 0.2 });
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe('battle');
+    expect(out[0].endTime - out[0].startTime).toBeGreaterThanOrEqual(BATTLE_MIN_SEC);
+  });
+
+  it('does NOT emit when battle window is too short', () => {
+    const d = new ClusterDetector();
+    d.ingest(fakeEvent('LAP_COMPLETED', 100), { competitiveFocus: 0.9 });
+    const out = d.ingest(fakeEvent('LAP_COMPLETED', 110), { competitiveFocus: 0.2 });
+    expect(out).toEqual([]);
+  });
+
+  it('does not start a window below the threshold', () => {
+    const d = new ClusterDetector();
+    d.ingest(fakeEvent('LAP_COMPLETED', 100), { competitiveFocus: BATTLE_FOCUS_THRESHOLD - 0.01 });
+    const out = d.ingest(fakeEvent('LAP_COMPLETED', 200), { competitiveFocus: 0.1 });
+    expect(out).toEqual([]);
+  });
+});
+
+describe('ClusterDetector — stint clustering', () => {
+  it('emits one stint cluster on PIT_ENTRY containing all events of the stint', () => {
+    const d = new ClusterDetector();
+    d.ingest(fakeEvent('LAP_COMPLETED', 10));
+    d.ingest(fakeEvent('LAP_COMPLETED', 100));
+    d.ingest(fakeEvent('LAP_COMPLETED', 200));
+    const out = d.ingest(fakeEvent('PIT_ENTRY', 250));
+    const stints = out.filter((c) => c.kind === 'stint');
+    expect(stints).toHaveLength(1);
+    expect(stints[0].events.length).toBe(4);
+    expect(stints[0].endTime).toBe(250);
+  });
+
+  it('starts a fresh stint after PIT_ENTRY', () => {
+    const d = new ClusterDetector();
+    d.ingest(fakeEvent('LAP_COMPLETED', 10));
+    d.ingest(fakeEvent('PIT_ENTRY', 50));
+    d.ingest(fakeEvent('LAP_COMPLETED', 60));
+    const out = d.ingest(fakeEvent('PIT_ENTRY', 100));
+    const stint = out.find((c) => c.kind === 'stint')!;
+    // Second stint contains LAP_COMPLETED@60 + PIT_ENTRY@100, not the earlier ones.
+    expect(stint.events.length).toBe(2);
+    expect(stint.startTime).toBe(50);
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/enricher-providers.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/enricher-providers.test.ts
@@ -1,0 +1,132 @@
+/**
+ * enricher-providers.test.ts — Issue #183
+ */
+import { describe, it, expect } from 'vitest';
+import { DisabledProvider } from '../enricher/providers/disabled';
+import { MockProvider } from '../enricher/providers/mock';
+import { OpenAIProvider } from '../enricher/providers/openai';
+import { AzureOpenAIProvider } from '../enricher/providers/azure-openai';
+import { OllamaProvider } from '../enricher/providers/ollama';
+import type { ClusterRequest } from '../enricher/provider';
+
+const cluster: ClusterRequest = {
+  kind: 'incident',
+  startTime: 100,
+  endTime: 105,
+  events: [
+    {
+      id: 'a', raceSessionId: 's', type: 'OFF_TRACK', timestamp: 0,
+      sessionTime: 100, sessionTick: 0,
+      car: { carIdx: 0, carNumber: '7', driverName: 'Test' },
+      payload: {} as any,
+    },
+  ],
+};
+
+describe('DisabledProvider', () => {
+  it('reports enabled=false', () => {
+    const p = new DisabledProvider();
+    expect(p.enabled).toBe(false);
+  });
+  it('throws when called', async () => {
+    const p = new DisabledProvider();
+    const ac = new AbortController();
+    await expect(p.enrich(cluster, ac.signal)).rejects.toThrow();
+  });
+});
+
+describe('MockProvider', () => {
+  it('returns a canned response', async () => {
+    const p = new MockProvider();
+    const ac = new AbortController();
+    const r = await p.enrich(cluster, ac.signal);
+    expect(r.headline).toBe('Mock headline');
+    expect(r.severity).toBe('minor');
+    expect(r.tokensIn).toBe(50);
+    expect(p.callCount).toBe(1);
+  });
+
+  it('rejects on abort', async () => {
+    const p = new MockProvider({ hang: true });
+    const ac = new AbortController();
+    const promise = p.enrich(cluster, ac.signal);
+    ac.abort();
+    await expect(promise).rejects.toThrow(/Abort/);
+  });
+});
+
+describe('OpenAIProvider', () => {
+  it('parses a successful response and merges usage', async () => {
+    const fetchFn = (async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"headline":"hi","narrative":"long enough","severity":"minor","confidence":0.5}' } }],
+          usage: { prompt_tokens: 12, completion_tokens: 7 },
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+    const p = new OpenAIProvider({ apiKey: 'k', model: 'gpt-4o-mini', fetchFn });
+    const r = await p.enrich(cluster, new AbortController().signal);
+    expect(r.headline).toBe('hi');
+    expect(r.tokensIn).toBe(12);
+    expect(r.tokensOut).toBe(7);
+    expect(r.model).toBe('gpt-4o-mini');
+  });
+
+  it('throws on non-2xx', async () => {
+    const fetchFn = (async () => new Response('nope', { status: 500 })) as unknown as typeof fetch;
+    const p = new OpenAIProvider({ apiKey: 'k', model: 'm', fetchFn });
+    await expect(p.enrich(cluster, new AbortController().signal)).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('throws on invalid JSON content', async () => {
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({ choices: [{ message: { content: 'not-json' } }] }), { status: 200 })) as unknown as typeof fetch;
+    const p = new OpenAIProvider({ apiKey: 'k', model: 'm', fetchFn });
+    await expect(p.enrich(cluster, new AbortController().signal)).rejects.toThrow();
+  });
+});
+
+describe('AzureOpenAIProvider', () => {
+  it('builds the deployment URL with api-version', async () => {
+    let captured = '';
+    const fetchFn = (async (url: string) => {
+      captured = url;
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: '{"headline":"x","narrative":"y here","severity":"minor","confidence":0.1}' } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1 },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+    const p = new AzureOpenAIProvider({
+      endpoint: 'https://r.openai.azure.com/',
+      deployment: 'mydeploy',
+      apiVersion: '2024-02-15',
+      apiKey: 'k',
+      fetchFn,
+    });
+    await p.enrich(cluster, new AbortController().signal);
+    expect(captured).toContain('/openai/deployments/mydeploy/chat/completions?api-version=2024-02-15');
+  });
+});
+
+describe('OllamaProvider', () => {
+  it('uses prompt_eval_count + eval_count for token accounting', async () => {
+    const fetchFn = (async () =>
+      new Response(
+        JSON.stringify({
+          message: { content: '{"headline":"a","narrative":"bbbb cccc","severity":"minor","confidence":0.4}' },
+          prompt_eval_count: 33,
+          eval_count: 11,
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+    const p = new OllamaProvider({ model: 'llama3', fetchFn });
+    const r = await p.enrich(cluster, new AbortController().signal);
+    expect(r.tokensIn).toBe(33);
+    expect(r.tokensOut).toBe(11);
+    expect(r.model).toBe('llama3');
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/enricher-schema.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/enricher-schema.test.ts
@@ -1,0 +1,64 @@
+/**
+ * enricher-schema.test.ts — Issue #183
+ */
+import { describe, it, expect } from 'vitest';
+import { parseLlmJson, validateLlmJson } from '../enricher/schema';
+
+const valid = {
+  headline: 'Lynn beached at Turn 4',
+  narrative: 'Alex Lynn ran wide, made contact and is now stopped on track.',
+  severity: 'major',
+  confidence: 0.86,
+};
+
+describe('validateLlmJson', () => {
+  it('accepts a well-formed payload', () => {
+    expect(validateLlmJson(valid)).toEqual(valid);
+  });
+
+  it('rejects non-objects', () => {
+    expect(() => validateLlmJson(null)).toThrow();
+    expect(() => validateLlmJson('hi')).toThrow();
+    expect(() => validateLlmJson(42)).toThrow();
+  });
+
+  it('rejects missing or oversize headline', () => {
+    expect(() => validateLlmJson({ ...valid, headline: '' })).toThrow();
+    expect(() => validateLlmJson({ ...valid, headline: 'x'.repeat(61) })).toThrow();
+    const { headline: _h, ...noHead } = valid;
+    expect(() => validateLlmJson(noHead)).toThrow();
+  });
+
+  it('rejects missing or oversize narrative', () => {
+    expect(() => validateLlmJson({ ...valid, narrative: '' })).toThrow();
+    expect(() => validateLlmJson({ ...valid, narrative: 'x'.repeat(601) })).toThrow();
+  });
+
+  it('rejects unknown severity', () => {
+    expect(() => validateLlmJson({ ...valid, severity: 'huge' })).toThrow();
+  });
+
+  it('rejects out-of-range confidence', () => {
+    expect(() => validateLlmJson({ ...valid, confidence: -0.1 })).toThrow();
+    expect(() => validateLlmJson({ ...valid, confidence: 1.1 })).toThrow();
+    expect(() => validateLlmJson({ ...valid, confidence: 'high' })).toThrow();
+  });
+});
+
+describe('parseLlmJson', () => {
+  it('parses bare JSON', () => {
+    expect(parseLlmJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('strips ```json fences', () => {
+    expect(parseLlmJson('```json\n{"a":1}\n```')).toEqual({ a: 1 });
+  });
+
+  it('strips bare ``` fences', () => {
+    expect(parseLlmJson('```\n{"a":1}\n```')).toEqual({ a: 1 });
+  });
+
+  it('throws on malformed JSON', () => {
+    expect(() => parseLlmJson('{not json')).toThrow();
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/enricher-token-budget.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/enricher-token-budget.test.ts
@@ -1,0 +1,53 @@
+/**
+ * token-budget.test.ts — Issue #183
+ */
+import { describe, it, expect } from 'vitest';
+import { TokenBudget } from '../enricher/token-budget';
+
+describe('TokenBudget', () => {
+  it('rejects non-positive caps', () => {
+    expect(() => new TokenBudget(0)).toThrow();
+    expect(() => new TokenBudget(-1)).toThrow();
+  });
+
+  it('starts un-exhausted with full remaining', () => {
+    const b = new TokenBudget(100);
+    expect(b.isExhausted()).toBe(false);
+    expect(b.remaining()).toBe(100);
+  });
+
+  it('counts both input and output tokens', () => {
+    const b = new TokenBudget(100);
+    b.consume(30, 20);
+    expect(b.remaining()).toBe(50);
+    expect(b.snapshot()).toEqual({ consumedIn: 30, consumedOut: 20, total: 50, exhausted: false });
+  });
+
+  it('marks exhausted at the cap', () => {
+    const b = new TokenBudget(50);
+    b.consume(40, 10);
+    expect(b.isExhausted()).toBe(true);
+    expect(b.remaining()).toBe(0);
+  });
+
+  it('marks exhausted past the cap', () => {
+    const b = new TokenBudget(50);
+    b.consume(40, 20);
+    expect(b.isExhausted()).toBe(true);
+    expect(b.remaining()).toBe(0);
+  });
+
+  it('reset() returns to fresh state', () => {
+    const b = new TokenBudget(50);
+    b.consume(50, 0);
+    b.reset();
+    expect(b.isExhausted()).toBe(false);
+    expect(b.remaining()).toBe(50);
+  });
+
+  it('rejects negative consumption', () => {
+    const b = new TokenBudget(100);
+    expect(() => b.consume(-1, 0)).toThrow();
+    expect(() => b.consume(0, -1)).toThrow();
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/event-enricher.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/event-enricher.test.ts
@@ -1,0 +1,199 @@
+/**
+ * event-enricher.test.ts — Issue #183
+ *
+ * Integration: ingest a stream of raw events into a fully-wired enricher
+ * (mock provider) and assert that meta-events are emitted and counters
+ * advance correctly.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { EventEnricher } from '../enricher/event-enricher';
+import { MockProvider } from '../enricher/providers/mock';
+import { DisabledProvider } from '../enricher/providers/disabled';
+import type { PublisherEvent, PublisherEventType } from '../event-types';
+
+let nextId = 0;
+function ev(type: PublisherEventType, sessionTime: number): PublisherEvent {
+  return {
+    id: `e-${++nextId}`,
+    raceSessionId: 's',
+    type,
+    timestamp: 1_000_000 + sessionTime * 1000,
+    sessionTime,
+    sessionTick: Math.floor(sessionTime * 60),
+    car: { carIdx: 0, carNumber: '7', driverName: 'Test' },
+    payload: {} as any,
+  };
+}
+
+describe('EventEnricher — disabled', () => {
+  it('does nothing when provider is disabled', () => {
+    const emit = vi.fn();
+    const en = new EventEnricher({
+      provider: new DisabledProvider(),
+      emitMetaEvent: emit,
+      raceSessionId: 's',
+    });
+    en.ingest(ev('OFF_TRACK', 1));
+    en.ingest(ev('OFF_TRACK', 2));
+    en.ingest(ev('OFF_TRACK', 3));
+    expect(en.enabled).toBe(false);
+    expect(emit).not.toHaveBeenCalled();
+    expect(en.counters.clustersDetected).toBe(0);
+  });
+});
+
+describe('EventEnricher — incident clustering integration', () => {
+  it('emits one INCIDENT_SUMMARY for a 3-event burst', async () => {
+    const emit = vi.fn();
+    const provider = new MockProvider();
+    const en = new EventEnricher({
+      provider,
+      emitMetaEvent: emit,
+      raceSessionId: 'race-1',
+      rigId: 'rig-1',
+    });
+    en.ingest(ev('OFF_TRACK', 100));
+    en.ingest(ev('CONTACT_DETECTED', 102));
+    en.ingest(ev('PLAYER_STOPPED', 105));
+    // provider call is async — drain microtasks
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(en.counters.clustersDetected).toBe(1);
+    expect(en.counters.providerCalls).toBe(1);
+    expect(en.counters.emitted).toBe(1);
+    expect(emit).toHaveBeenCalledTimes(1);
+    const meta = emit.mock.calls[0][0] as PublisherEvent;
+    expect(meta.type).toBe('INCIDENT_SUMMARY');
+    expect(meta.raceSessionId).toBe('race-1');
+    expect(meta.rigId).toBe('rig-1');
+    const p = meta.payload as any;
+    expect(p.startTime).toBe(100);
+    expect(p.endTime).toBe(105);
+    expect(p.rawEventTypes).toEqual(['OFF_TRACK', 'CONTACT_DETECTED', 'PLAYER_STOPPED']);
+    expect(p.llm.provider).toBe('mock');
+    expect(p.llm.tokensIn).toBe(50);
+  });
+});
+
+describe('EventEnricher — token budget', () => {
+  it('skips provider calls once budget is exhausted', async () => {
+    const emit = vi.fn();
+    const provider = new MockProvider();
+    const en = new EventEnricher({
+      provider,
+      emitMetaEvent: emit,
+      raceSessionId: 's',
+      tokenBudgetCap: 10, // mock returns 50+25 → exhausts on first call
+    });
+    en.ingest(ev('OFF_TRACK', 100));
+    en.ingest(ev('OFF_TRACK', 101));
+    en.ingest(ev('OFF_TRACK', 102)); // cluster #1 → consumes 75 tokens
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(en.counters.emitted).toBe(1);
+
+    en.ingest(ev('OFF_TRACK', 200));
+    en.ingest(ev('OFF_TRACK', 201));
+    en.ingest(ev('OFF_TRACK', 202)); // cluster #2 → budget exhausted → skip
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(en.counters.budgetSkips).toBe(1);
+    expect(en.counters.emitted).toBe(1);
+    expect(provider.callCount).toBe(1);
+  });
+});
+
+describe('EventEnricher — provider errors are isolated', () => {
+  it('counts provider errors but does not throw', async () => {
+    const emit = vi.fn();
+    const provider = {
+      name: 'mock' as const,
+      enabled: true,
+      enrich: async () => {
+        throw new Error('provider boom');
+      },
+    };
+    const en = new EventEnricher({
+      provider,
+      emitMetaEvent: emit,
+      raceSessionId: 's',
+    });
+    en.ingest(ev('OFF_TRACK', 1));
+    en.ingest(ev('OFF_TRACK', 2));
+    en.ingest(ev('OFF_TRACK', 3));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(en.counters.providerErrors).toBe(1);
+    expect(en.counters.emitted).toBe(0);
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('counts parse errors when provider returns invalid shape', async () => {
+    const emit = vi.fn();
+    const provider = {
+      name: 'mock' as const,
+      enabled: true,
+      enrich: async () => {
+        throw new Error('confidence must be a number in [0, 1]');
+      },
+    };
+    const en = new EventEnricher({
+      provider,
+      emitMetaEvent: emit,
+      raceSessionId: 's',
+    });
+    en.ingest(ev('OFF_TRACK', 1));
+    en.ingest(ev('OFF_TRACK', 2));
+    en.ingest(ev('OFF_TRACK', 3));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(en.counters.parseErrors).toBe(1);
+  });
+});
+
+describe('EventEnricher — timeout', () => {
+  it('aborts provider calls that exceed callTimeoutMs', async () => {
+    vi.useFakeTimers();
+    try {
+      const emit = vi.fn();
+      const provider = new MockProvider({ hang: true });
+      const en = new EventEnricher({
+        provider,
+        emitMetaEvent: emit,
+        raceSessionId: 's',
+        callTimeoutMs: 100,
+      });
+      en.ingest(ev('OFF_TRACK', 1));
+      en.ingest(ev('OFF_TRACK', 2));
+      en.ingest(ev('OFF_TRACK', 3));
+      // Trigger the timeout.
+      vi.advanceTimersByTime(150);
+      // Drain microtasks created by the AbortError rejection.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(en.counters.timeouts).toBe(1);
+      expect(en.counters.emitted).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('EventEnricher — STINT_SUMMARY on PIT_ENTRY', () => {
+  it('emits a stint summary on pit entry', async () => {
+    const emit = vi.fn();
+    const en = new EventEnricher({
+      provider: new MockProvider(),
+      emitMetaEvent: emit,
+      raceSessionId: 's',
+    });
+    en.ingest(ev('LAP_COMPLETED', 10));
+    en.ingest(ev('LAP_COMPLETED', 100));
+    en.ingest(ev('PIT_ENTRY', 200));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect((emit.mock.calls[0][0] as PublisherEvent).type).toBe('STINT_SUMMARY');
+  });
+});

--- a/src/extensions/iracing/publisher/__tests__/summarise-event.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/summarise-event.test.ts
@@ -39,6 +39,7 @@ const ALL_EVENT_TYPES: PublisherEventType[] = [
   'IN_PIT_WINDOW', 'FUEL_PROJECTION', 'PACE_DROP',
   'SECTOR_PERSONAL_BEST', 'TYRE_TEMP_DRIFT', 'ENGINE_WARNING',
   'DRIVER_STATE_SNAPSHOT',
+  'INCIDENT_SUMMARY', 'BATTLE_SUMMARY', 'STINT_SUMMARY',
 ];
 
 function fakeEvent(type: PublisherEventType): PublisherEvent {

--- a/src/extensions/iracing/publisher/driver-publisher/summarise-event.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/summarise-event.ts
@@ -210,6 +210,15 @@ export function summariseEvent(event: PublisherEvent): string {
       const p = event.payload as any;
       return `Safety car imminent (${p.stoppedCarCount} stopped in ${p.windowSec}s)`;
     }
+
+    // §12 Enricher meta-events (#183)
+    case 'INCIDENT_SUMMARY':
+    case 'BATTLE_SUMMARY':
+    case 'STINT_SUMMARY': {
+      const p = event.payload as any;
+      const headline = typeof p?.llmHeadline === 'string' ? p.llmHeadline : event.type;
+      return `${event.type}: ${headline}`;
+    }
   }
 
   // Forward-compatibility — exhaustive switch above; this is unreachable

--- a/src/extensions/iracing/publisher/enricher/cluster-detector.ts
+++ b/src/extensions/iracing/publisher/enricher/cluster-detector.ts
@@ -1,0 +1,141 @@
+/**
+ * cluster-detector.ts — Issue #183
+ *
+ * Pure clustering logic over the publisher's event stream. The enricher
+ * feeds every emitted `PublisherEvent` into `ingest()`; the detector keeps
+ * sliding windows internally and returns zero or more `ClusterRequest`s
+ * each call. No I/O, no async — easy to test deterministically.
+ *
+ * Three cluster kinds:
+ *   - incident : ≥3 INCIDENT_EVENT_TYPES events within `INCIDENT_WINDOW_SEC`
+ *   - battle   : continuous focus block ≥ `BATTLE_MIN_SEC` ending when focus
+ *                drops or its window times out
+ *   - stint    : on PIT_ENTRY — emits all events of the stint just ended
+ */
+
+import type { PublisherEvent } from '../event-types';
+import type { ClusterRequest } from './provider';
+import { INCIDENT_EVENT_TYPES } from './provider';
+
+/** Sliding window for incident clustering (seconds, sessionTime units). */
+export const INCIDENT_WINDOW_SEC = 10;
+/** Min number of incident-weight events required to trigger one incident cluster. */
+export const INCIDENT_MIN_COUNT = 3;
+/** Min duration of a sustained focus block (seconds). */
+export const BATTLE_MIN_SEC = 30;
+/** Focus value above which a battle is considered "engaged". */
+export const BATTLE_FOCUS_THRESHOLD = 0.7;
+/** Cooldown between successive incident clusters (seconds). Prevents repeats from the same burst. */
+export const INCIDENT_COOLDOWN_SEC = 5;
+
+/**
+ * Optional per-tick context. The enricher only needs `competitiveFocus` to
+ * decide battle clustering — derived metrics live on `DriverState.derived`.
+ */
+export interface ClusterContext {
+  /** Current competitive-focus score (0–1). Provided by the caller — usually
+   *  read from `driverState.derived.competitiveFocus` once per tick. */
+  competitiveFocus?: number;
+  /** sessionTime (s) — used to time-out an open battle window if `competitiveFocus`
+   *  hasn't been updated for a while. */
+  now?: number;
+}
+
+interface BattleWindow {
+  startTime: number;
+  events: PublisherEvent[];
+}
+
+interface StintAccumulator {
+  startTime: number;
+  events: PublisherEvent[];
+}
+
+export class ClusterDetector {
+  private readonly recentIncidents: PublisherEvent[] = [];
+  private lastIncidentEmitEnd = -Infinity;
+  private battle: BattleWindow | null = null;
+  private stint: StintAccumulator = { startTime: 0, events: [] };
+
+  /**
+   * Feed one event + optional context. Returns 0+ clusters that became
+   * "ready" as a result of this ingest.
+   */
+  ingest(ev: PublisherEvent, ctx: ClusterContext = {}): ClusterRequest[] {
+    const out: ClusterRequest[] = [];
+
+    // ---- Incident clustering ------------------------------------------------
+    if (INCIDENT_EVENT_TYPES.has(ev.type)) {
+      this.recentIncidents.push(ev);
+      // Drop anything older than the window.
+      const cutoff = ev.sessionTime - INCIDENT_WINDOW_SEC;
+      while (this.recentIncidents.length > 0 && this.recentIncidents[0].sessionTime < cutoff) {
+        this.recentIncidents.shift();
+      }
+      const sinceLast = ev.sessionTime - this.lastIncidentEmitEnd;
+      if (this.recentIncidents.length >= INCIDENT_MIN_COUNT && sinceLast >= INCIDENT_COOLDOWN_SEC) {
+        const cluster: ClusterRequest = {
+          kind: 'incident',
+          startTime: this.recentIncidents[0].sessionTime,
+          endTime: ev.sessionTime,
+          events: [...this.recentIncidents],
+        };
+        out.push(cluster);
+        this.lastIncidentEmitEnd = ev.sessionTime;
+        this.recentIncidents.length = 0;
+      }
+    }
+
+    // ---- Stint accumulation ------------------------------------------------
+    // Every event belongs to the current stint until PIT_ENTRY closes it.
+    this.stint.events.push(ev);
+    if (ev.type === 'PIT_ENTRY') {
+      const cluster: ClusterRequest = {
+        kind: 'stint',
+        startTime: this.stint.startTime,
+        endTime: ev.sessionTime,
+        events: this.stint.events,
+      };
+      out.push(cluster);
+      this.stint = { startTime: ev.sessionTime, events: [] };
+    }
+
+    // ---- Battle clustering -------------------------------------------------
+    const focus = ctx.competitiveFocus;
+    if (typeof focus === 'number') {
+      if (focus >= BATTLE_FOCUS_THRESHOLD) {
+        if (!this.battle) {
+          this.battle = { startTime: ev.sessionTime, events: [ev] };
+        } else {
+          this.battle.events.push(ev);
+        }
+      } else if (this.battle) {
+        const dur = ev.sessionTime - this.battle.startTime;
+        if (dur >= BATTLE_MIN_SEC) {
+          out.push({
+            kind: 'battle',
+            startTime: this.battle.startTime,
+            endTime: ev.sessionTime,
+            events: this.battle.events,
+          });
+        }
+        this.battle = null;
+      }
+    }
+
+    return out;
+  }
+
+  /**
+   * Test/teardown helper — flush any open battle window.
+   */
+  flushBattle(now: number): ClusterRequest | null {
+    if (!this.battle) return null;
+    const dur = now - this.battle.startTime;
+    const events = this.battle.events;
+    const startTime = this.battle.startTime;
+    this.battle = null;
+    if (dur < BATTLE_MIN_SEC) return null;
+    return { kind: 'battle', startTime, endTime: now, events };
+  }
+}

--- a/src/extensions/iracing/publisher/enricher/enriching-transport.ts
+++ b/src/extensions/iracing/publisher/enricher/enriching-transport.ts
@@ -1,0 +1,52 @@
+/**
+ * enriching-transport.ts — Issue #183
+ *
+ * Decorator over `PublisherTransport`. Behaviour is IDENTICAL for raw event
+ * publishing — events are still enqueued / batched / flushed the same way.
+ * The only addition: every enqueued event is also fed to the `EventEnricher`
+ * so the LLM stage can detect clusters and emit meta-events.
+ *
+ * The decorator subclasses `PublisherTransport` so existing call sites
+ * (sub-orchestrators) accept it without type changes. Since the constructor
+ * cannot defer to the parent without re-stating its config, we accept the
+ * already-constructed transport via a small adapter pattern: callers pass
+ * the regular `PublisherTransportConfig` to this class, which forwards to
+ * the parent.
+ */
+
+import { PublisherTransport, type PublisherTransportConfig } from '../transport';
+import type { PublisherEvent } from '../event-types';
+import type { EventEnricher } from './event-enricher';
+import type { ClusterContext } from './cluster-detector';
+
+export interface EnrichingTransportConfig extends PublisherTransportConfig {
+  enricher: EventEnricher;
+  /**
+   * Optional per-event context provider — looked up at enqueue time so the
+   * enricher sees up-to-date `competitiveFocus`. Returns `undefined` to skip.
+   */
+  contextProvider?: (ev: PublisherEvent) => ClusterContext | undefined;
+}
+
+export class EnrichingTransport extends PublisherTransport {
+  private readonly enricher: EventEnricher;
+  private readonly contextProvider?: (ev: PublisherEvent) => ClusterContext | undefined;
+
+  constructor(cfg: EnrichingTransportConfig) {
+    const { enricher, contextProvider, ...base } = cfg;
+    super(base);
+    this.enricher = enricher;
+    this.contextProvider = contextProvider;
+  }
+
+  override enqueue(event: PublisherEvent): void {
+    super.enqueue(event);
+    // Best-effort — never let enricher errors disturb the main queue.
+    try {
+      const ctx = this.contextProvider?.(event);
+      this.enricher.ingest(event, ctx ?? {});
+    } catch {
+      // swallow — enricher.ingest already logs
+    }
+  }
+}

--- a/src/extensions/iracing/publisher/enricher/event-enricher.ts
+++ b/src/extensions/iracing/publisher/enricher/event-enricher.ts
@@ -1,0 +1,218 @@
+/**
+ * event-enricher.ts — Issue #183
+ *
+ * Top-level coordinator. Accepts every emitted `PublisherEvent`, runs the
+ * pure `ClusterDetector`, dispatches "ready" clusters to the configured
+ * `EnricherProvider`, and emits validated meta-events back via the supplied
+ * `emitMetaEvent` callback.
+ *
+ * Operates entirely OUT-of-band:
+ *   - Provider calls are async with a per-call timeout (`AbortSignal`).
+ *   - A shared `TokenBudget` short-circuits further calls when exhausted.
+ *   - Failures (timeout / parse-error / network) are counted and logged but
+ *     never block raw event publishing — the enricher is strictly additive.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import type {
+  EventPayloadMap,
+  IncidentSummaryPayload,
+  BattleSummaryPayload,
+  StintSummaryPayload,
+  PublisherCarRef,
+  PublisherEvent,
+  PublisherEventType,
+} from '../event-types';
+import { ClusterDetector, type ClusterContext } from './cluster-detector';
+import type { ClusterRequest, EnricherProvider } from './provider';
+import { TokenBudget } from './token-budget';
+
+export interface EnricherCounters {
+  clustersDetected: number;
+  providerCalls: number;
+  providerErrors: number;
+  parseErrors: number;
+  timeouts: number;
+  budgetSkips: number;
+  emitted: number;
+}
+
+export interface EventEnricherConfig {
+  provider: EnricherProvider;
+  /** Token cap for the lifetime of this enricher (resettable). */
+  tokenBudgetCap?: number;
+  /** Per-call timeout in ms. Defaults to 5000. */
+  callTimeoutMs?: number;
+  /**
+   * Where to put validated meta-events. Implementations should forward to
+   * the publisher transport so the Race Control API receives them just like
+   * raw events. The enricher does NOT call the transport directly — keeps
+   * the dependency one-way and easy to test.
+   */
+  emitMetaEvent: (ev: PublisherEvent) => void;
+  /** Optional structured logger. */
+  log?: (level: 'debug' | 'info' | 'warn' | 'error', msg: string, meta?: unknown) => void;
+  /** Race session id stamped into every emitted meta-event. */
+  raceSessionId: string;
+  /** Optional rig id stamped into every emitted meta-event. */
+  rigId?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_BUDGET = 100_000;
+
+const META_TYPE_BY_KIND: Record<ClusterRequest['kind'], PublisherEventType> = {
+  incident: 'INCIDENT_SUMMARY',
+  battle: 'BATTLE_SUMMARY',
+  stint: 'STINT_SUMMARY',
+};
+
+export class EventEnricher {
+  private readonly detector = new ClusterDetector();
+  private readonly budget: TokenBudget;
+  private readonly callTimeoutMs: number;
+  readonly counters: EnricherCounters = {
+    clustersDetected: 0,
+    providerCalls: 0,
+    providerErrors: 0,
+    parseErrors: 0,
+    timeouts: 0,
+    budgetSkips: 0,
+    emitted: 0,
+  };
+
+  constructor(private readonly cfg: EventEnricherConfig) {
+    this.budget = new TokenBudget(cfg.tokenBudgetCap ?? DEFAULT_BUDGET);
+    this.callTimeoutMs = cfg.callTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /** True when the enricher will actually call the LLM. False = no-op. */
+  get enabled(): boolean {
+    return this.cfg.provider.enabled;
+  }
+
+  /**
+   * Ingest one raw publisher event + optional cluster context (e.g.
+   * `competitiveFocus` from `DriverState.derived`). Fires off zero or more
+   * provider calls in the background — never throws.
+   */
+  ingest(ev: PublisherEvent, ctx: ClusterContext = {}): void {
+    if (!this.enabled) return;
+    let clusters: ClusterRequest[];
+    try {
+      clusters = this.detector.ingest(ev, ctx);
+    } catch (err) {
+      this.cfg.log?.('error', 'enricher: detector threw', err);
+      return;
+    }
+    for (const c of clusters) {
+      this.counters.clustersDetected += 1;
+      void this.dispatch(c);
+    }
+  }
+
+  private async dispatch(cluster: ClusterRequest): Promise<void> {
+    if (this.budget.isExhausted()) {
+      this.counters.budgetSkips += 1;
+      this.cfg.log?.('warn', 'enricher: token budget exhausted, skipping cluster', {
+        kind: cluster.kind,
+      });
+      return;
+    }
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), this.callTimeoutMs);
+    this.counters.providerCalls += 1;
+    try {
+      const resp = await this.cfg.provider.enrich(cluster, ac.signal);
+      this.budget.consume(resp.tokensIn, resp.tokensOut);
+      const ev = this.buildMetaEvent(cluster, resp);
+      this.cfg.emitMetaEvent(ev);
+      this.counters.emitted += 1;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('Abort')) {
+        this.counters.timeouts += 1;
+        this.cfg.log?.('warn', 'enricher: provider call timed out', { kind: cluster.kind });
+      } else if (msg.toLowerCase().includes('json') || msg.includes('must be')) {
+        this.counters.parseErrors += 1;
+        this.cfg.log?.('warn', 'enricher: provider response failed validation', { msg });
+      } else {
+        this.counters.providerErrors += 1;
+        this.cfg.log?.('warn', 'enricher: provider call failed', { msg });
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private buildMetaEvent(
+    cluster: ClusterRequest,
+    resp: Awaited<ReturnType<EnricherProvider['enrich']>>,
+  ): PublisherEvent {
+    const last = cluster.events[cluster.events.length - 1];
+    const cars = uniqueCars(cluster.events);
+    const rawTypes = uniqueTypes(cluster.events);
+    const type = META_TYPE_BY_KIND[cluster.kind];
+    const base = {
+      startTime: cluster.startTime,
+      endTime: cluster.endTime,
+      involvedCars: cars,
+      rawEventTypes: rawTypes,
+      llmHeadline: resp.headline,
+      llmNarrative: resp.narrative,
+      severity: resp.severity,
+      confidence: resp.confidence,
+      llm: {
+        provider: this.cfg.provider.name as
+          | 'openai'
+          | 'azure-openai'
+          | 'ollama'
+          | 'mock',
+        model: resp.model,
+        latencyMs: resp.latencyMs,
+        tokensIn: resp.tokensIn,
+        tokensOut: resp.tokensOut,
+      },
+    };
+    let payload: EventPayloadMap[typeof type];
+    if (type === 'INCIDENT_SUMMARY') payload = base as IncidentSummaryPayload;
+    else if (type === 'BATTLE_SUMMARY') payload = base as BattleSummaryPayload;
+    else payload = base as StintSummaryPayload;
+    return {
+      id: randomUUID(),
+      raceSessionId: this.cfg.raceSessionId,
+      rigId: this.cfg.rigId,
+      type,
+      timestamp: Date.now(),
+      sessionTime: last.sessionTime,
+      sessionTick: last.sessionTick,
+      car: cars[0] ?? last.car,
+      payload,
+      context: last.context,
+    };
+  }
+}
+
+function uniqueCars(events: readonly PublisherEvent[]): PublisherCarRef[] {
+  const seen = new Set<number>();
+  const out: PublisherCarRef[] = [];
+  for (const ev of events) {
+    if (!ev.car) continue;
+    if (seen.has(ev.car.carIdx)) continue;
+    seen.add(ev.car.carIdx);
+    out.push(ev.car);
+  }
+  return out;
+}
+
+function uniqueTypes(events: readonly PublisherEvent[]): PublisherEventType[] {
+  const seen = new Set<PublisherEventType>();
+  const out: PublisherEventType[] = [];
+  for (const ev of events) {
+    if (seen.has(ev.type)) continue;
+    seen.add(ev.type);
+    out.push(ev.type);
+  }
+  return out;
+}

--- a/src/extensions/iracing/publisher/enricher/factory.ts
+++ b/src/extensions/iracing/publisher/enricher/factory.ts
@@ -1,0 +1,48 @@
+/**
+ * factory.ts — Issue #183
+ *
+ * Build an `EnricherProvider` from director settings. Returns the no-op
+ * `DisabledProvider` when configuration is missing or `provider === 'disabled'`.
+ */
+
+import type { EnricherProvider, EnricherProviderName } from './provider';
+import { DisabledProvider } from './providers/disabled';
+import { OpenAIProvider } from './providers/openai';
+import { AzureOpenAIProvider } from './providers/azure-openai';
+import { OllamaProvider } from './providers/ollama';
+
+export interface EnricherSettings {
+  /** When omitted or `'disabled'`, the enricher does nothing. */
+  provider?: EnricherProviderName;
+  /** Provider-specific opts. Shape depends on `provider`. */
+  openai?: { apiKey: string; model: string; baseUrl?: string };
+  azureOpenai?: {
+    endpoint: string;
+    deployment: string;
+    apiVersion: string;
+    apiKey: string;
+  };
+  ollama?: { baseUrl?: string; model: string };
+}
+
+export function createProvider(s: EnricherSettings | undefined, fetchFn?: typeof fetch): EnricherProvider {
+  if (!s || !s.provider || s.provider === 'disabled') return new DisabledProvider();
+  switch (s.provider) {
+    case 'openai':
+      if (!s.openai) throw new Error('Enricher: openai settings missing');
+      return new OpenAIProvider({ ...s.openai, fetchFn });
+    case 'azure-openai':
+      if (!s.azureOpenai) throw new Error('Enricher: azureOpenai settings missing');
+      return new AzureOpenAIProvider({ ...s.azureOpenai, fetchFn });
+    case 'ollama':
+      if (!s.ollama) throw new Error('Enricher: ollama settings missing');
+      return new OllamaProvider({ ...s.ollama, fetchFn });
+    case 'mock':
+      // Mock provider is test-only — never returned from production settings.
+      throw new Error('Enricher: mock provider must be wired explicitly in tests');
+    default: {
+      const _exhaustive: never = s.provider;
+      throw new Error(`Enricher: unknown provider ${_exhaustive as string}`);
+    }
+  }
+}

--- a/src/extensions/iracing/publisher/enricher/prompts.ts
+++ b/src/extensions/iracing/publisher/enricher/prompts.ts
@@ -1,0 +1,59 @@
+/**
+ * prompts.ts — Issue #183
+ *
+ * Prompt templates for each cluster kind. Plain-string templates kept inline
+ * (no file IO) to keep the publisher dependency-free and side-effect-free.
+ *
+ * Every prompt asks the model to respond as STRICT JSON with the exact
+ * fields validated by `schema.validateLlmJson`. A few-shot example is
+ * included to lock the format.
+ */
+
+import type { ClusterRequest } from './provider';
+
+const SYSTEM = `You are a sim-racing broadcast colour commentator condensing a burst of telemetry events into one short narrative beat.
+Respond with ONLY a JSON object — no prose, no markdown fences — matching this exact shape:
+{
+  "headline":   string (≤ 60 chars, present tense, broadcast tone),
+  "narrative":  string (1–3 sentences, ≤ 600 chars),
+  "severity":   "minor" | "major" | "race-defining",
+  "confidence": number in [0, 1]
+}`;
+
+const FEW_SHOT = `Example input (incident cluster):
+[
+  {"type":"OFF_TRACK","car":{"carNumber":"7","driverName":"Alex Lynn"},"sessionTime":1234.5},
+  {"type":"CONTACT_DETECTED","car":{"carNumber":"7","driverName":"Alex Lynn"},"sessionTime":1235.1},
+  {"type":"PLAYER_STOPPED","car":{"carNumber":"7","driverName":"Alex Lynn"},"sessionTime":1236.0}
+]
+Example output:
+{"headline":"Lynn beached at Turn 4","narrative":"Alex Lynn ran wide, made contact and is now stopped on track. The #7 will need a recovery and is losing time to the field.","severity":"major","confidence":0.86}`;
+
+function summariseCluster(req: ClusterRequest): string {
+  const items = req.events.map((e) => ({
+    type: e.type,
+    sessionTime: e.sessionTime,
+    car: e.car ? { carNumber: e.car.carNumber, driverName: e.car.driverName } : undefined,
+    payload: e.payload,
+  }));
+  return JSON.stringify(items, null, 0);
+}
+
+/**
+ * Build the user-message prompt body for a cluster. The system message is
+ * shared across all cluster kinds and provided separately by the adapter.
+ */
+export function buildUserPrompt(req: ClusterRequest): string {
+  const kindLabel =
+    req.kind === 'incident'
+      ? 'an incident cluster'
+      : req.kind === 'battle'
+        ? 'a sustained on-track battle'
+        : 'a completed stint';
+  return `${FEW_SHOT}
+
+Now condense ${kindLabel} (${req.events.length} events from sessionTime ${req.startTime.toFixed(2)} to ${req.endTime.toFixed(2)}):
+${summariseCluster(req)}`;
+}
+
+export const SYSTEM_PROMPT = SYSTEM;

--- a/src/extensions/iracing/publisher/enricher/provider.ts
+++ b/src/extensions/iracing/publisher/enricher/provider.ts
@@ -1,0 +1,73 @@
+/**
+ * provider.ts — Issue #183
+ *
+ * Provider abstraction for the EventEnricher LLM stage. Pluggable so the
+ * publisher can be configured for OpenAI, Azure-OpenAI, a local Ollama
+ * server, or fully disabled.
+ */
+
+import type { PublisherEvent, PublisherEventType } from '../event-types';
+
+export type EnricherProviderName =
+  | 'openai'
+  | 'azure-openai'
+  | 'ollama'
+  | 'mock'
+  | 'disabled';
+
+/** Cluster kinds the enricher recognises. */
+export type ClusterKind = 'incident' | 'battle' | 'stint';
+
+/**
+ * One clustered batch of events handed to the LLM provider for narration.
+ * Pure data — no live references.
+ */
+export interface ClusterRequest {
+  kind: ClusterKind;
+  startTime: number;
+  endTime: number;
+  events: readonly PublisherEvent[];
+}
+
+/**
+ * Strict-shape response the provider must produce. Anything that does not
+ * validate is dropped by the enricher (with a parse-error counter bump).
+ */
+export interface ProviderResponse {
+  headline: string;
+  narrative: string;
+  severity: 'minor' | 'major' | 'race-defining';
+  confidence: number;
+  /** Token accounting reported by the provider. */
+  tokensIn: number;
+  tokensOut: number;
+  /** Wall-clock latency observed by the provider adapter. */
+  latencyMs: number;
+  /** Provider-reported model identifier (echoed back into the meta-event). */
+  model: string;
+}
+
+/**
+ * Provider adapter interface. Implementations MUST honour the timeout and
+ * either return a validated `ProviderResponse` or throw.
+ */
+export interface EnricherProvider {
+  readonly name: EnricherProviderName;
+  /** Indicates the provider is disabled — used by the enricher to short-circuit. */
+  readonly enabled: boolean;
+  /**
+   * Run a clustering job. Implementations should respect the abort signal.
+   * Throws on timeout, network error, or invalid response shape.
+   */
+  enrich(req: ClusterRequest, signal: AbortSignal): Promise<ProviderResponse>;
+}
+
+/** Helper — list of event types eligible for incident clustering. */
+export const INCIDENT_EVENT_TYPES: ReadonlySet<PublisherEventType> = new Set<PublisherEventType>([
+  'OFF_TRACK',
+  'CONTACT_DETECTED',
+  'PLAYER_STOPPED',
+  'STOPPED_ON_TRACK',
+  'BIG_HIT',
+  'SPIN_DETECTED',
+]);

--- a/src/extensions/iracing/publisher/enricher/providers/azure-openai.ts
+++ b/src/extensions/iracing/publisher/enricher/providers/azure-openai.ts
@@ -1,0 +1,71 @@
+/**
+ * azure-openai.ts — Issue #183
+ *
+ * Azure-OpenAI Chat Completions adapter. Differences vs the public OpenAI
+ * endpoint: requires `endpoint`, `deployment`, and `apiVersion`; uses an
+ * `api-key` header instead of bearer auth.
+ */
+
+import type { ClusterRequest, EnricherProvider, ProviderResponse } from '../provider';
+import { SYSTEM_PROMPT, buildUserPrompt } from '../prompts';
+import { parseLlmJson, validateLlmJson } from '../schema';
+
+export interface AzureOpenAIProviderConfig {
+  /** Azure resource endpoint, e.g. `https://my-resource.openai.azure.com`. */
+  endpoint: string;
+  /** Deployment name configured in Azure. */
+  deployment: string;
+  /** API version, e.g. `2024-02-15-preview`. */
+  apiVersion: string;
+  apiKey: string;
+  fetchFn?: typeof fetch;
+}
+
+export class AzureOpenAIProvider implements EnricherProvider {
+  readonly name = 'azure-openai' as const;
+  readonly enabled = true;
+  private readonly fetch: typeof fetch;
+  constructor(private readonly cfg: AzureOpenAIProviderConfig) {
+    if (!cfg.endpoint) throw new Error('AzureOpenAIProvider: endpoint is required');
+    if (!cfg.deployment) throw new Error('AzureOpenAIProvider: deployment is required');
+    if (!cfg.apiVersion) throw new Error('AzureOpenAIProvider: apiVersion is required');
+    if (!cfg.apiKey) throw new Error('AzureOpenAIProvider: apiKey is required');
+    this.fetch = cfg.fetchFn ?? globalThis.fetch.bind(globalThis);
+  }
+
+  async enrich(req: ClusterRequest, signal: AbortSignal): Promise<ProviderResponse> {
+    const start = Date.now();
+    const url = `${this.cfg.endpoint.replace(/\/$/, '')}/openai/deployments/${this.cfg.deployment}/chat/completions?api-version=${this.cfg.apiVersion}`;
+    const res = await this.fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'api-key': this.cfg.apiKey,
+      },
+      body: JSON.stringify({
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: buildUserPrompt(req) },
+        ],
+      }),
+      signal,
+    });
+    const latencyMs = Date.now() - start;
+    if (!res.ok) throw new Error(`AzureOpenAI HTTP ${res.status}`);
+    const body = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    const content = body.choices?.[0]?.message?.content;
+    if (!content) throw new Error('AzureOpenAI: empty completion');
+    const parsed = validateLlmJson(parseLlmJson(content));
+    return {
+      ...parsed,
+      tokensIn: body.usage?.prompt_tokens ?? 0,
+      tokensOut: body.usage?.completion_tokens ?? 0,
+      latencyMs,
+      model: this.cfg.deployment,
+    };
+  }
+}

--- a/src/extensions/iracing/publisher/enricher/providers/disabled.ts
+++ b/src/extensions/iracing/publisher/enricher/providers/disabled.ts
@@ -1,0 +1,18 @@
+/**
+ * disabled.ts — Issue #183
+ *
+ * No-op provider used when the enricher is configured off. Construction is
+ * cheap and `enrich()` always rejects so calling code can short-circuit on
+ * `enabled === false`.
+ */
+
+import type { ClusterRequest, EnricherProvider, ProviderResponse } from '../provider';
+
+export class DisabledProvider implements EnricherProvider {
+  readonly name = 'disabled' as const;
+  readonly enabled = false;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async enrich(_req: ClusterRequest, _signal: AbortSignal): Promise<ProviderResponse> {
+    throw new Error('DisabledProvider.enrich called — caller must check `enabled`');
+  }
+}

--- a/src/extensions/iracing/publisher/enricher/providers/mock.ts
+++ b/src/extensions/iracing/publisher/enricher/providers/mock.ts
@@ -1,0 +1,52 @@
+/**
+ * mock.ts — Issue #183
+ *
+ * Deterministic provider used in tests. Returns a canned response after an
+ * optional artificial delay. Honours the abort signal — on abort it rejects
+ * with `AbortError`.
+ */
+
+import type { ClusterRequest, EnricherProvider, ProviderResponse } from '../provider';
+
+export interface MockProviderOptions {
+  /** Delay before resolving (ms). Defaults to 0 (synchronous). */
+  delayMs?: number;
+  /** Override the response. */
+  response?: Partial<ProviderResponse>;
+  /** When true, never resolves until aborted (used to test timeouts). */
+  hang?: boolean;
+}
+
+export class MockProvider implements EnricherProvider {
+  readonly name = 'mock' as const;
+  readonly enabled = true;
+  callCount = 0;
+  constructor(private readonly opts: MockProviderOptions = {}) {}
+
+  enrich(req: ClusterRequest, signal: AbortSignal): Promise<ProviderResponse> {
+    this.callCount += 1;
+    return new Promise<ProviderResponse>((resolve, reject) => {
+      const onAbort = () => reject(new Error('AbortError'));
+      if (signal.aborted) return onAbort();
+      signal.addEventListener('abort', onAbort, { once: true });
+      if (this.opts.hang) return; // never settle on its own
+      const delay = this.opts.delayMs ?? 0;
+      const finish = () => {
+        signal.removeEventListener('abort', onAbort);
+        resolve({
+          headline: 'Mock headline',
+          narrative: `Mock narrative for ${req.kind} cluster of ${req.events.length} events.`,
+          severity: 'minor',
+          confidence: 0.5,
+          tokensIn: 50,
+          tokensOut: 25,
+          latencyMs: delay,
+          model: 'mock-model',
+          ...this.opts.response,
+        });
+      };
+      if (delay <= 0) finish();
+      else setTimeout(finish, delay);
+    });
+  }
+}

--- a/src/extensions/iracing/publisher/enricher/providers/ollama.ts
+++ b/src/extensions/iracing/publisher/enricher/providers/ollama.ts
@@ -1,0 +1,64 @@
+/**
+ * ollama.ts — Issue #183
+ *
+ * Local Ollama adapter (`/api/chat` endpoint). Token counts come from
+ * `prompt_eval_count` / `eval_count`. Latency is measured locally.
+ */
+
+import type { ClusterRequest, EnricherProvider, ProviderResponse } from '../provider';
+import { SYSTEM_PROMPT, buildUserPrompt } from '../prompts';
+import { parseLlmJson, validateLlmJson } from '../schema';
+
+export interface OllamaProviderConfig {
+  /** Defaults to `http://localhost:11434`. */
+  baseUrl?: string;
+  model: string;
+  fetchFn?: typeof fetch;
+}
+
+export class OllamaProvider implements EnricherProvider {
+  readonly name = 'ollama' as const;
+  readonly enabled = true;
+  private readonly fetch: typeof fetch;
+  private readonly baseUrl: string;
+  constructor(private readonly cfg: OllamaProviderConfig) {
+    if (!cfg.model) throw new Error('OllamaProvider: model is required');
+    this.fetch = cfg.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this.baseUrl = cfg.baseUrl ?? 'http://localhost:11434';
+  }
+
+  async enrich(req: ClusterRequest, signal: AbortSignal): Promise<ProviderResponse> {
+    const start = Date.now();
+    const res = await this.fetch(`${this.baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: this.cfg.model,
+        stream: false,
+        format: 'json',
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: buildUserPrompt(req) },
+        ],
+      }),
+      signal,
+    });
+    const latencyMs = Date.now() - start;
+    if (!res.ok) throw new Error(`Ollama HTTP ${res.status}`);
+    const body = (await res.json()) as {
+      message?: { content?: string };
+      prompt_eval_count?: number;
+      eval_count?: number;
+    };
+    const content = body.message?.content;
+    if (!content) throw new Error('Ollama: empty completion');
+    const parsed = validateLlmJson(parseLlmJson(content));
+    return {
+      ...parsed,
+      tokensIn: body.prompt_eval_count ?? 0,
+      tokensOut: body.eval_count ?? 0,
+      latencyMs,
+      model: this.cfg.model,
+    };
+  }
+}

--- a/src/extensions/iracing/publisher/enricher/providers/openai.ts
+++ b/src/extensions/iracing/publisher/enricher/providers/openai.ts
@@ -1,0 +1,70 @@
+/**
+ * openai.ts — Issue #183
+ *
+ * OpenAI Chat Completions adapter. Uses JSON-mode (`response_format`) so the
+ * model is forced to emit valid JSON. Honours the abort signal for timeout.
+ */
+
+import type { ClusterRequest, EnricherProvider, ProviderResponse } from '../provider';
+import { SYSTEM_PROMPT, buildUserPrompt } from '../prompts';
+import { parseLlmJson, validateLlmJson } from '../schema';
+
+export interface OpenAIProviderConfig {
+  apiKey: string;
+  model: string;
+  /** Defaults to https://api.openai.com */
+  baseUrl?: string;
+  /** Custom fetch (tests inject a stub). */
+  fetchFn?: typeof fetch;
+}
+
+export class OpenAIProvider implements EnricherProvider {
+  readonly name = 'openai' as const;
+  readonly enabled = true;
+  private readonly fetch: typeof fetch;
+  private readonly baseUrl: string;
+  constructor(private readonly cfg: OpenAIProviderConfig) {
+    if (!cfg.apiKey) throw new Error('OpenAIProvider: apiKey is required');
+    if (!cfg.model) throw new Error('OpenAIProvider: model is required');
+    this.fetch = cfg.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this.baseUrl = cfg.baseUrl ?? 'https://api.openai.com';
+  }
+
+  async enrich(req: ClusterRequest, signal: AbortSignal): Promise<ProviderResponse> {
+    const start = Date.now();
+    const res = await this.fetch(`${this.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.cfg.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.cfg.model,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: buildUserPrompt(req) },
+        ],
+      }),
+      signal,
+    });
+    const latencyMs = Date.now() - start;
+    if (!res.ok) {
+      throw new Error(`OpenAI HTTP ${res.status}`);
+    }
+    const body = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    const content = body.choices?.[0]?.message?.content;
+    if (!content) throw new Error('OpenAI: empty completion');
+    const parsed = validateLlmJson(parseLlmJson(content));
+    return {
+      ...parsed,
+      tokensIn: body.usage?.prompt_tokens ?? 0,
+      tokensOut: body.usage?.completion_tokens ?? 0,
+      latencyMs,
+      model: this.cfg.model,
+    };
+  }
+}

--- a/src/extensions/iracing/publisher/enricher/schema.ts
+++ b/src/extensions/iracing/publisher/enricher/schema.ts
@@ -1,0 +1,67 @@
+/**
+ * schema.ts — Issue #183
+ *
+ * Strict, dependency-free validation of provider JSON output. Used by every
+ * provider adapter before returning a `ProviderResponse`. Returns either a
+ * normalised value or throws a descriptive `Error` consumed by the enricher's
+ * parse-error counter.
+ */
+
+import type { ProviderResponse } from './provider';
+
+/**
+ * Validate the JSON-mode response from an LLM provider. Required fields:
+ *   - headline   string ≤ 60 chars
+ *   - narrative  string ≤ 600 chars
+ *   - severity   'minor' | 'major' | 'race-defining'
+ *   - confidence number in [0, 1]
+ *
+ * `tokensIn`, `tokensOut`, `latencyMs`, `model` come from the adapter, NOT
+ * from the LLM, and are merged in by the caller.
+ */
+export function validateLlmJson(input: unknown): {
+  headline: string;
+  narrative: string;
+  severity: ProviderResponse['severity'];
+  confidence: number;
+} {
+  if (!input || typeof input !== 'object') {
+    throw new Error('LLM response is not an object');
+  }
+  const r = input as Record<string, unknown>;
+
+  const headline = r.headline;
+  if (typeof headline !== 'string' || headline.length === 0 || headline.length > 60) {
+    throw new Error('headline must be a non-empty string ≤ 60 chars');
+  }
+
+  const narrative = r.narrative;
+  if (typeof narrative !== 'string' || narrative.length === 0 || narrative.length > 600) {
+    throw new Error('narrative must be a non-empty string ≤ 600 chars');
+  }
+
+  const severity = r.severity;
+  if (severity !== 'minor' && severity !== 'major' && severity !== 'race-defining') {
+    throw new Error('severity must be one of minor | major | race-defining');
+  }
+
+  const confidence = r.confidence;
+  if (typeof confidence !== 'number' || !Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    throw new Error('confidence must be a number in [0, 1]');
+  }
+
+  return { headline, narrative, severity, confidence };
+}
+
+/**
+ * Strict JSON.parse wrapper. Some chat models prefix/suffix the JSON with
+ * markdown fences — this strips them before parsing.
+ */
+export function parseLlmJson(raw: string): unknown {
+  let s = raw.trim();
+  if (s.startsWith('```')) {
+    // Strip a markdown fence: ```json ... ``` or ``` ... ```
+    s = s.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/, '').trim();
+  }
+  return JSON.parse(s);
+}

--- a/src/extensions/iracing/publisher/enricher/token-budget.ts
+++ b/src/extensions/iracing/publisher/enricher/token-budget.ts
@@ -1,0 +1,58 @@
+/**
+ * token-budget.ts — Issue #183
+ *
+ * Cost guardrail for the EventEnricher. Counts both input and output tokens
+ * against a single shared budget. Once exhausted the enricher MUST stop
+ * making provider calls until the budget is reset.
+ */
+
+export interface TokenBudgetSnapshot {
+  consumedIn: number;
+  consumedOut: number;
+  total: number;
+  exhausted: boolean;
+}
+
+export class TokenBudget {
+  private consumedIn = 0;
+  private consumedOut = 0;
+  /** Total token cap (in + out). Use Number.POSITIVE_INFINITY for "no cap". */
+  constructor(private readonly cap: number) {
+    if (!(cap > 0)) {
+      throw new Error('TokenBudget cap must be positive');
+    }
+  }
+
+  /** Pre-flight check — call BEFORE issuing a provider request. */
+  isExhausted(): boolean {
+    return this.consumedIn + this.consumedOut >= this.cap;
+  }
+
+  /** Remaining tokens (never negative). */
+  remaining(): number {
+    return Math.max(0, this.cap - (this.consumedIn + this.consumedOut));
+  }
+
+  /** Record actual usage after a provider call returns. */
+  consume(tokensIn: number, tokensOut: number): void {
+    if (tokensIn < 0 || tokensOut < 0) {
+      throw new Error('TokenBudget.consume: negative tokens');
+    }
+    this.consumedIn += tokensIn;
+    this.consumedOut += tokensOut;
+  }
+
+  snapshot(): TokenBudgetSnapshot {
+    return {
+      consumedIn: this.consumedIn,
+      consumedOut: this.consumedOut,
+      total: this.consumedIn + this.consumedOut,
+      exhausted: this.isExhausted(),
+    };
+  }
+
+  reset(): void {
+    this.consumedIn = 0;
+    this.consumedOut = 0;
+  }
+}

--- a/src/extensions/iracing/publisher/event-types.ts
+++ b/src/extensions/iracing/publisher/event-types.ts
@@ -162,7 +162,12 @@ export type PublisherEventType =
   | 'ENGINE_WARNING'
   // §10 AI consumer aids (#179)
   /** Periodic snapshot of the current driver situation + recent events ring buffer. */
-  | 'DRIVER_STATE_SNAPSHOT';
+  | 'DRIVER_STATE_SNAPSHOT'
+  // §12 Enricher meta-events (#183) — emitted by the optional post-publisher
+  // LLM stage when it clusters bursts of low-level events into one beat.
+  | 'INCIDENT_SUMMARY'
+  | 'BATTLE_SUMMARY'
+  | 'STINT_SUMMARY';
 
 // CLOUD-EMITTED — publisher never produces these. Listed here for documentation only.
 // 'FOCUS_VS_FOCUS_BATTLE' | 'FOCUS_GROUP_ON_TRACK' | 'FOCUS_GROUP_SPLIT'
@@ -305,6 +310,11 @@ export interface EventPayloadMap {
 
   // §10 AI consumer aids (#179)
   DRIVER_STATE_SNAPSHOT: DriverStateSnapshotPayload;
+
+  // §12 Enricher meta-events (#183)
+  INCIDENT_SUMMARY: IncidentSummaryPayload;
+  BATTLE_SUMMARY: BattleSummaryPayload;
+  STINT_SUMMARY: StintSummaryPayload;
 }
 
 // ---------------------------------------------------------------------------
@@ -912,3 +922,76 @@ export interface SafetyCarImminentPayload {
   /** Refs for every stopped car contributing to the trigger. */
   affectedCars: PublisherCarRef[];
 }
+
+// ---------------------------------------------------------------------------
+// §12 Enricher meta-events (#183)
+// ---------------------------------------------------------------------------
+
+/** Severity classification for enricher meta-events. */
+export type EnricherSeverity = 'minor' | 'major' | 'race-defining';
+
+/**
+ * Provider/model attribution attached to every meta-event for observability.
+ * `provider='disabled'` is reserved — the disabled provider never emits.
+ */
+export interface EnricherLlmMeta {
+  provider: 'openai' | 'azure-openai' | 'ollama' | 'mock';
+  model: string;
+  latencyMs: number;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+/**
+ * INCIDENT_SUMMARY — clusters 3+ incident-weight events (OFF_TRACK,
+ * CONTACT_DETECTED, PLAYER_STOPPED, BIG_HIT, SPIN_DETECTED) within a 10s
+ * sliding window into one narrative beat.
+ */
+export interface IncidentSummaryPayload {
+  startTime: number;
+  endTime: number;
+  involvedCars: PublisherCarRef[];
+  rawEventTypes: PublisherEventType[];
+  /** 2–3 sentence human description from the LLM. */
+  llmNarrative: string;
+  /** ≤ 60 char headline from the LLM. */
+  llmHeadline: string;
+  severity: EnricherSeverity;
+  /** 0–1 self-rated confidence from the LLM. */
+  confidence: number;
+  /** Provider attribution + cost metadata. */
+  llm: EnricherLlmMeta;
+}
+
+/**
+ * BATTLE_SUMMARY — emitted when a sustained 30s window of high
+ * `competitiveFocus` (> 0.7) ends. Captures the on-track battle as a beat.
+ */
+export interface BattleSummaryPayload {
+  startTime: number;
+  endTime: number;
+  involvedCars: PublisherCarRef[];
+  rawEventTypes: PublisherEventType[];
+  llmNarrative: string;
+  llmHeadline: string;
+  severity: EnricherSeverity;
+  confidence: number;
+  llm: EnricherLlmMeta;
+}
+
+/**
+ * STINT_SUMMARY — emitted on PIT_ENTRY (stint boundary). Covers every event
+ * of the stint that just ended.
+ */
+export interface StintSummaryPayload {
+  startTime: number;
+  endTime: number;
+  involvedCars: PublisherCarRef[];
+  rawEventTypes: PublisherEventType[];
+  llmNarrative: string;
+  llmHeadline: string;
+  severity: EnricherSeverity;
+  confidence: number;
+  llm: EnricherLlmMeta;
+}
+

--- a/src/extensions/iracing/publisher/orchestrator.ts
+++ b/src/extensions/iracing/publisher/orchestrator.ts
@@ -36,6 +36,9 @@
 
 import { randomUUID } from 'crypto';
 import { PublisherTransport, type TransportStatus } from './transport';
+import { EventEnricher } from './enricher/event-enricher';
+import { EnrichingTransport } from './enricher/enriching-transport';
+import { createProvider, type EnricherSettings } from './enricher/factory';
 import { LifecycleEventDetector, type LifecycleDetectorContext } from './shared/lifecycle-event-detector';
 import { SessionPublisherOrchestrator } from './session-publisher/orchestrator';
 import { DriverPublisherOrchestrator } from './driver-publisher/orchestrator';
@@ -106,6 +109,11 @@ const LEGACY_KEYS = [
 export class PublisherOrchestrator {
   /** Single transport instance — shared by both pipelines. Non-null while running. */
   private transport: PublisherTransport | null = null;
+
+  /** Optional LLM enricher (#183). Null when `publisher.enricher.provider` is
+   *  unset/`'disabled'` — the default. When non-null, the transport above
+   *  is an `EnrichingTransport` that forwards every event to it. */
+  private enricher: EventEnricher | null = null;
 
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -620,13 +628,45 @@ export class PublisherOrchestrator {
     );
 
     // Single transport — shared by both sub-orchestrators (hard architectural constraint).
-    this.transport = new PublisherTransport({
-      endpointUrl,
-      batchIntervalMs,
-      getAuthToken:   () => this.cfg.director.getAuthToken(),
-      onStatusChange: (s) => this.onTransportStatus(s),
-      fetchFn:        this.cfg.fetchFn,
-    });
+    // When the enricher is configured, we wrap the transport so every enqueued
+    // event is also fed to the LLM clustering stage. Default = disabled = no overhead.
+    const enricherSettings = this.cfg.director.settings['publisher.enricher'] as
+      | EnricherSettings
+      | undefined;
+    const enricherProvider = createProvider(enricherSettings, this.cfg.fetchFn);
+    if (enricherProvider.enabled) {
+      this.enricher = new EventEnricher({
+        provider: enricherProvider,
+        emitMetaEvent: (ev) => this.transport?.enqueue(ev),
+        log: (level, msg, meta) =>
+          this.cfg.director.log(level === 'debug' ? 'info' : level, `enricher: ${msg}${meta ? ' ' + JSON.stringify(meta) : ''}`),
+        raceSessionId: this.raceSessionId,
+        rigId: this.rigId,
+        tokenBudgetCap: Number(
+          this.cfg.director.settings['publisher.enricher.tokenBudget'] ?? 100_000,
+        ),
+        callTimeoutMs: Number(
+          this.cfg.director.settings['publisher.enricher.timeoutMs'] ?? 5000,
+        ),
+      });
+      this.transport = new EnrichingTransport({
+        endpointUrl,
+        batchIntervalMs,
+        getAuthToken:   () => this.cfg.director.getAuthToken(),
+        onStatusChange: (s) => this.onTransportStatus(s),
+        fetchFn:        this.cfg.fetchFn,
+        enricher:       this.enricher,
+      });
+      this.cfg.director.log('info', `Publisher enricher enabled (provider=${enricherProvider.name})`);
+    } else {
+      this.transport = new PublisherTransport({
+        endpointUrl,
+        batchIntervalMs,
+        getAuthToken:   () => this.cfg.director.getAuthToken(),
+        onStatusChange: (s) => this.onTransportStatus(s),
+        fetchFn:        this.cfg.fetchFn,
+      });
+    }
     this.transport.start();
 
     const emitEvent = (event: string, payload: any) =>


### PR DESCRIPTION
Closes #183. Part of epic #176.

## Summary
Adds an **optional** post-publisher LLM enricher that clusters bursts of low-level publisher events into one narrative beat. Default behaviour is **disabled** — zero overhead unless `publisher.enricher.provider` is configured.

## New event types
Three meta-events on the publisher wire contract (see `event-types.ts §12`):
- `INCIDENT_SUMMARY` — fires when 3+ incident-weight events (`OFF_TRACK`, `CONTACT_DETECTED`, `PLAYER_STOPPED`, `STOPPED_ON_TRACK`, `BIG_HIT`, `SPIN_DETECTED`) land within a 10s window
- `BATTLE_SUMMARY` — fires when a sustained 30s window of `competitiveFocus > 0.7` ends
- `STINT_SUMMARY` — fires on every `PIT_ENTRY`

Each carries `{ startTime, endTime, involvedCars, rawEventTypes, llmHeadline, llmNarrative, severity, confidence, llm: { provider, model, latencyMs, tokensIn, tokensOut } }`.

## Architecture

```
PublisherTransport ─┐                                   PublisherTransport.enqueue
                    │
            EnrichingTransport (decorator) ────►  EventEnricher.ingest(ev)
                                                          │
                                                  ClusterDetector (pure)
                                                          │
                                                  EnricherProvider.enrich  ──►  TokenBudget
                                                          │
                                                  validateLlmJson  ──►  emitMetaEvent ──► transport.enqueue
```

- `ClusterDetector` is a pure object — easy to test deterministically.
- `TokenBudget` short-circuits further provider calls when the cap is hit (default 100k tokens).
- Provider calls run with a 5s `AbortSignal` timeout.
- Failures are counted (`providerErrors`, `parseErrors`, `timeouts`, `budgetSkips`) but never disturb raw event publishing — strictly additive.

## Providers
- `openai` — Chat Completions JSON mode
- `azure-openai` — deployment URL + `api-key`
- `ollama` — local `http://localhost:11434/api/chat` with `format: json`
- `mock` — deterministic, used only in tests
- `disabled` — no-op (default)

## Tests
**1013/1013 passing** (47 new).

| File | Coverage |
| --- | --- |
| `enricher-token-budget.test.ts` | cap, exhaustion, reset, negative-input rejection |
| `enricher-schema.test.ts` | strict shape validation, fence stripping, malformed JSON |
| `enricher-cluster-detector.test.ts` | incident min-count, window expiry, cooldown, re-fire, battle min-duration, stint boundary, fresh stint after PIT_ENTRY |
| `enricher-providers.test.ts` | disabled, mock (incl. abort), OpenAI happy path + non-2xx + invalid JSON, Azure URL composition, Ollama token mapping |
| `event-enricher.test.ts` | end-to-end ingest → meta-event emit, budget exhaustion skip, provider error isolation, parse-error counter, timeout via fake timers, STINT_SUMMARY on PIT_ENTRY |

## Wiring
Top-level `PublisherOrchestrator` reads `publisher.enricher` settings:
```jsonc
{
  "publisher.enricher": { "provider": "openai", "openai": { "apiKey": "...", "model": "gpt-4o-mini" } },
  "publisher.enricher.tokenBudget": 100000,
  "publisher.enricher.timeoutMs": 5000
}
```
When `provider === 'disabled'` (or unset), the regular `PublisherTransport` is used and no enricher exists. Otherwise we instantiate `EventEnricher` and wrap the transport in `EnrichingTransport`. Sub-orchestrators are unchanged — they still receive a `PublisherTransport` and only call `enqueue()`.

## Out of scope (follow-up)
- Wiring `competitiveFocus` from `DriverState.derived` into the enricher's per-event context. The detector supports it; needs a small getter on `DriverPublisherOrchestrator`. Until then, `BATTLE_SUMMARY` fires only when callers supply context — `INCIDENT_SUMMARY` and `STINT_SUMMARY` work today.