### PR TITLE
fix(#193): gate first check-in on stable iRacing roster

### DIFF
--- a/src/main/director-types.ts
+++ b/src/main/director-types.ts
@@ -283,6 +283,13 @@ export interface DirectorCapabilities {
   scenes?: string[];
   /** Drivers in the current simulator session at check-in time. */
   drivers?: CapabilityDriver[];
+  /**
+   * Whether the iRacing driver roster captured in `drivers` has stabilised
+   * (issue #193). When `false`, the cloud Planner should treat the identities
+   * here as provisional and avoid baking them into long-lived templates.
+   * When omitted, identity resolution is unknown (older Director clients).
+   */
+  identityResolved?: boolean;
 }
 
 export interface SessionCheckinRequest {

--- a/src/main/extension-host/extension-host.ts
+++ b/src/main/extension-host/extension-host.ts
@@ -105,6 +105,12 @@ export class ExtensionHostService {
   private cachedObsScenes: string[] = [];
   private cachedCameraGroups: { groupNum: number; groupName: string }[] = [];
   private cachedDrivers: { carNumber: string; userName: string; carName?: string }[] = [];
+  /**
+   * Wall-clock timestamp (ms) of the most recent change to `cachedDrivers`.
+   * Used to gate the first session check-in on a stable iRacing roster
+   * (issue #193). Null until the first `iracing.driversChanged` event arrives.
+   */
+  private driversLastChangedAt: number | null = null;
 
   constructor(
     extensionsPath: string, 
@@ -307,6 +313,15 @@ export class ExtensionHostService {
   }
 
   /**
+   * Returns how many ms the cached iRacing driver roster has been unchanged
+   * (issue #193). Returns `null` if no roster has been observed yet.
+   */
+  public getDriversStableForMs(): number | null {
+    if (this.driversLastChangedAt == null) return null;
+    return Date.now() - this.driversLastChangedAt;
+  }
+
+  /**
    * Allows main process to set connection health for extensions that don't
    * emit events themselves (e.g., discord delegates to main process).
    */
@@ -374,11 +389,18 @@ export class ExtensionHostService {
         newDrivers.some((d, i) => d.carNumber !== this.cachedDrivers[i]?.carNumber || d.userName !== this.cachedDrivers[i]?.userName);
       this.cachedDrivers = newDrivers;
       if (changed) {
+        // Stamp the roster mutation so callers can gate first check-in on a
+        // stable iRacing roster (issue #193).
+        this.driversLastChangedAt = Date.now();
         this.eventBus.emitExtensionEvent(data.extensionId || 'director-iracing', 'extension.capabilitiesChanged', {
           extensionId: data.extensionId || 'director-iracing',
           enabled: true,
           reason: 'drivers',
         });
+      } else if (this.driversLastChangedAt == null) {
+        // First-ever roster snapshot, even if structurally identical to the
+        // empty default — record so stability windows can begin.
+        this.driversLastChangedAt = Date.now();
       }
     });
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -224,6 +224,18 @@ app.on('ready', () => {
     const drivers: { carNumber: string; userName: string; carName: string }[] =
       (driverPayload?.drivers ?? []).map((d: any) => ({ carNumber: d.carNumber, userName: d.userName, carName: d.carName }));
 
+    // Issue #193: identityResolved signals the cloud Planner whether the
+    // captured iRacing roster is trustworthy. The roster is considered resolved
+    // when (a) it is non-empty and (b) it has been stable for at least
+    // IDENTITY_STABILITY_MS without further `iracing.driversChanged` events —
+    // long enough for iRacing to overwrite any stale slot data from the prior
+    // session that the SDK exposes in the first ~1–2 minutes after load.
+    const IDENTITY_STABILITY_MS = 15_000;
+    const stableForMs = extensionHost.getDriversStableForMs();
+    const identityResolved = drivers.length > 0
+      && stableForMs != null
+      && stableForMs >= IDENTITY_STABILITY_MS;
+
     // #192: use extensionHost.getObsScenes() — populated by the obs.scenes event cache
     // maintained in the extension host. Warn when OBS is connected but scenes are empty
     // so regressions are visible in logs without needing to inspect the check-in payload.
@@ -262,6 +274,7 @@ app.on('ready', () => {
       ...(cameraGroups.length > 0 && { cameraGroups }),
       ...(scenes.length > 0 && { scenes }),
       ...(drivers.length > 0 && { drivers }),
+      ...(drivers.length > 0 && { identityResolved }),
     };
   });
   sessionManager.setLocalSequencesGetter(async () => {

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -15,7 +15,16 @@ vi.mock('./auth-config', () => ({
     baseUrl: 'https://test.simracecenter.com',
     endpoints: {
       listSessions: '/api/director/v1/sessions',
+      checkin: (id: string) => `/api/director/v1/sessions/${id}/checkin`,
+      refreshCheckin: (id: string) => `/api/director/v1/sessions/${id}/checkin`,
+      wrap: (id: string) => `/api/director/v1/sessions/${id}/checkin`,
     },
+  },
+}));
+
+vi.mock('./config-service', () => ({
+  configService: {
+    getOrCreateDirectorId: () => 'd_inst_test',
   },
 }));
 
@@ -334,6 +343,152 @@ describe('SessionManager', () => {
 
       const sessions = sessionManager.getSessions();
       expect(sessions).toEqual(mockSessions);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Issue #193: identity resolution gating before first check-in
+  // -----------------------------------------------------------------------
+  describe('checkinSession identity resolution (#193)', () => {
+    const selected: RaceSession = {
+      raceSessionId: 'sess-193',
+      name: 'Identity Test',
+      centerId: 'test-center',
+    };
+
+    beforeEach(async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [selected],
+        headers: new Headers(),
+      });
+      await sessionManager.discover();
+      await sessionManager.selectSession('sess-193');
+    });
+
+    it('defers POST /checkin until capabilities report identityResolved=true', async () => {
+      vi.useFakeTimers();
+      try {
+        let resolved = false;
+        const builder = vi.fn(() => ({
+          extensions: [],
+          connections: {},
+          drivers: [{ carNumber: '15', userName: 'Paul Crofts', carName: '' }],
+          identityResolved: resolved,
+        }));
+        sessionManager.setCapabilitiesBuilder(builder as any);
+        sessionManager.setRaceContextGetter(() => null);
+
+        // Stub the actual HTTP POST so we can observe when it fires.
+        let postFired = false;
+        mockFetch.mockImplementation(async () => {
+          postFired = true;
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              status: 'standby',
+              checkinId: 'ci-1',
+              checkinTtlSeconds: 120,
+              sessionConfig: { raceSessionId: 'sess-193', name: '', status: '', simulator: 'iRacing', drivers: [], obsScenes: [] },
+              warnings: [],
+            }),
+            headers: new Headers(),
+          };
+        });
+
+        const inFlight = sessionManager.checkinSession();
+
+        // Advance several poll intervals — POST should still be blocked.
+        for (let i = 0; i < 5; i++) {
+          await vi.advanceTimersByTimeAsync(1000);
+        }
+        expect(postFired).toBe(false);
+
+        // Roster stabilises — next poll should release the gate.
+        resolved = true;
+        await vi.advanceTimersByTimeAsync(1000);
+        await inFlight;
+
+        expect(postFired).toBe(true);
+        expect(builder).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('proceeds with check-in after timeout when identity never resolves', async () => {
+      vi.useFakeTimers();
+      try {
+        const builder = vi.fn(() => ({
+          extensions: [],
+          connections: {},
+          drivers: [{ carNumber: '15', userName: 'Stale Name', carName: '' }],
+          identityResolved: false,
+        }));
+        sessionManager.setCapabilitiesBuilder(builder as any);
+        sessionManager.setRaceContextGetter(() => null);
+
+        const sentBody: any = {};
+        mockFetch.mockImplementation(async (_url: any, init: any) => {
+          sentBody.body = JSON.parse(init.body);
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              status: 'standby', checkinId: 'ci-2', checkinTtlSeconds: 120,
+              sessionConfig: { raceSessionId: 'sess-193', name: '', status: '', simulator: 'iRacing', drivers: [], obsScenes: [] },
+              warnings: [],
+            }),
+            headers: new Headers(),
+          };
+        });
+
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const inFlight = sessionManager.checkinSession();
+
+        // Advance just past the 90s timeout.
+        await vi.advanceTimersByTimeAsync(91_000);
+        await inFlight;
+
+        // Body should carry identityResolved=false from the builder.
+        expect(sentBody.body.capabilities.identityResolved).toBe(false);
+        // Should have logged the timeout warning at least once.
+        expect(warnSpy.mock.calls.some(c => String(c[0]).includes('without confirmed iRacing roster'))).toBe(true);
+        warnSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('skips the stability wait when forceCheckin=true', async () => {
+      const builder = vi.fn(() => ({
+        extensions: [],
+        connections: {},
+        drivers: [{ carNumber: '15', userName: 'Stale Name', carName: '' }],
+        identityResolved: false,
+      }));
+      sessionManager.setCapabilitiesBuilder(builder as any);
+      sessionManager.setRaceContextGetter(() => null);
+
+      let posted = false;
+      mockFetch.mockImplementation(async () => {
+        posted = true;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            status: 'standby', checkinId: 'ci-3', checkinTtlSeconds: 120,
+            sessionConfig: { raceSessionId: 'sess-193', name: '', status: '', simulator: 'iRacing', drivers: [], obsScenes: [] },
+            warnings: [],
+          }),
+          headers: new Headers(),
+        };
+      });
+
+      await sessionManager.checkinSession({ forceCheckin: true });
+      expect(posted).toBe(true);
     });
   });
 });

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -296,6 +296,78 @@ export class SessionManager extends EventEmitter {
   // ---------------------------------------------------------------------------
 
   /**
+   * Maximum time (ms) to wait for the iRacing roster to stabilise before
+   * proceeding with the first session check-in (issue #193). After this
+   * timeout, check-in proceeds anyway and the cloud is told identity is
+   * unresolved via `capabilities.identityResolved=false`.
+   */
+  private static readonly IDENTITY_RESOLUTION_TIMEOUT_MS = 90_000;
+  /** Poll interval while waiting for identity resolution. */
+  private static readonly IDENTITY_POLL_INTERVAL_MS = 1_000;
+
+  /**
+   * Block until the live capabilities snapshot reports
+   * `identityResolved === true`, or until a bounded timeout elapses.
+   *
+   * The cloud Planner runs once at POST /checkin and bakes the captured
+   * driver roster into ~100+ templates with a long TTL — so a stale roster
+   * captured here poisons broadcast decisions for the rest of the session.
+   * Waiting for the roster to settle is cheap insurance against that.
+   */
+  private async awaitIdentityResolved(): Promise<void> {
+    if (!this.buildCapabilities) return;
+    const start = Date.now();
+    while (Date.now() - start < SessionManager.IDENTITY_RESOLUTION_TIMEOUT_MS) {
+      let caps: DirectorCapabilities;
+      try {
+        caps = this.buildCapabilities();
+      } catch {
+        return; // capabilities builder failed; don't block check-in indefinitely
+      }
+      if (caps.identityResolved === true) {
+        if (Date.now() - start > 0) {
+          console.log(`[SessionManager] iRacing identity resolved after ${Date.now() - start}ms`);
+        }
+        return;
+      }
+      await new Promise(r => setTimeout(r, SessionManager.IDENTITY_POLL_INTERVAL_MS));
+    }
+    console.warn(
+      `[SessionManager] Proceeding with check-in after ${SessionManager.IDENTITY_RESOLUTION_TIMEOUT_MS}ms ` +
+      'without confirmed iRacing roster — capabilities.identityResolved will be false. ' +
+      'Cloud should treat driver identities as provisional.'
+    );
+  }
+
+  /**
+   * Log a warning when the live iRacing roster reports a `userName` for a car
+   * number that disagrees with the `iracingName` configured on the
+   * `SessionOperationalConfig.drivers` mapping returned from a prior check-in
+   * (issue #193). Distinct from identityResolved gating because it operates
+   * on the post-checkin session config, which only exists for refresh paths.
+   */
+  private warnOnIdentityMismatch(capabilities: DirectorCapabilities): void {
+    const cfg = this.sessionConfig;
+    if (!cfg?.drivers?.length || !capabilities.drivers?.length) return;
+    const liveByCar = new Map(capabilities.drivers.map(d => [String(d.carNumber), d]));
+    for (const mapping of cfg.drivers) {
+      const live = liveByCar.get(String(mapping.carNumber));
+      if (!live) continue;
+      const expected = (mapping as any).iracingName ?? mapping.displayName;
+      if (!expected) continue;
+      if (typeof expected === 'string' && expected.trim() && live.userName !== expected) {
+        console.warn(
+          `[SessionManager] iRacing identity mismatch on car #${mapping.carNumber}: ` +
+          `live roster reports "${live.userName}" but session is configured for "${expected}". ` +
+          'Cloud Planner will be told identityResolved=false.'
+        );
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+
+  /**
    * Check into the currently selected session with Race Control.
    * Transitions: selected → checked-in (or stays selected on error).
    */
@@ -317,6 +389,15 @@ export class SessionManager extends EventEmitter {
     this.lastError = undefined;
     this.emitStateChanged();
 
+    // Issue #193: defer first check-in until the iRacing roster has had a
+    // chance to stabilise. iRacing's shared memory can expose stale slot data
+    // from the prior session for ~1–2 minutes after a session loads, which
+    // would poison the cloud Planner's templates with the wrong identities.
+    // Skip the wait when the operator explicitly forces check-in.
+    if (!options?.forceCheckin) {
+      await this.awaitIdentityResolved();
+    }
+
     const token = await this.authService.getAccessToken();
     if (!token) {
       this.checkinStatus = 'error';
@@ -326,6 +407,7 @@ export class SessionManager extends EventEmitter {
     }
 
     const capabilities = this.buildCapabilities?.() ?? { extensions: [], connections: {} };
+    this.warnOnIdentityMismatch(capabilities);
     const directorId = configService.getOrCreateDirectorId();
 
     // Always include raceContext — live spec requires it (issue #142).
@@ -526,6 +608,7 @@ export class SessionManager extends EventEmitter {
     }
 
     const capabilities = this.buildCapabilities?.() ?? { extensions: [], connections: {} };
+    this.warnOnIdentityMismatch(capabilities);
 
     // Include raceContext when available so the Planner can scope re-generated
     // templates to the correct session type (issue #142 / racecontrol#319).


### PR DESCRIPTION
## Problem

Closes #193

iRacing shared memory exposes stale slot data from the prior session for ~1–2 minutes after a new session loads. The first `POST /checkin` captured that stale roster and let the cloud Planner bake the wrong driver identities into ~100+ long-lived templates — poisoning broadcast decisions for the rest of the session.

**Observed:** session `IMSA Road Atlanta` (2026-05-15) — car #15 reported as `Jorge Alejandro Fonseca Correa` at check-in #1, corrected to `Paul Crofts` 7 minutes later, but 133 templates had already been generated from stale data.

## Changes

### 1. Roster stability tracking (`extension-host.ts`)
- `driversLastChangedAt` timestamp is stamped on every `iracing.driversChanged` event (and on the very first snapshot).
- New public method `getDriversStableForMs()` returns how long (ms) the roster has been unchanged, or `null` if no roster has been observed yet.

### 2. `identityResolved` capability flag (`main.ts` + `director-types.ts`)
- New optional field `identityResolved?: boolean` on `DirectorCapabilities`.
- Computed `true` only when drivers list is non-empty **and** has been stable for ≥ 15 s — long enough for iRacing to finish overwriting stale slot data.
- Sent on every check-in and refresh, so the cloud Planner can skip template generation until identity is confirmed.

### 3. Stability gate before first `POST /checkin` (`session-manager.ts`)
- `checkinSession()` calls `awaitIdentityResolved()` before sending the HTTP request.
- Polls `buildCapabilities().identityResolved` every 1 s.
- Hard timeout: 90 s — after which the check-in proceeds anyway and the cloud receives `identityResolved: false` (provisional).
- `forceCheckin: true` bypasses the wait entirely (operator override).

### 4. Identity mismatch warning on refresh
- `warnOnIdentityMismatch()` compares the live roster's `userName` against the `iracingName` / `displayName` in `sessionConfig.drivers` returned by the original check-in.
- Logs a `[SessionManager] iRacing identity mismatch` warning whenever they disagree, so operators can see the issue in logs without inspecting the check-in payload.

## Tests

3 new unit tests in `session-manager.test.ts`:

| Test | What it verifies |
|---|---|
| *defers POST until identityResolved=true* | HTTP POST is blocked while `identityResolved=false`, fires as soon as it flips `true`. |
| *proceeds after timeout* | After 90 s with identity never resolving, check-in fires with `identityResolved: false` in the payload and logs the timeout warning. |
| *forceCheckin bypasses gate* | `{ forceCheckin: true }` skips the wait and POSTs immediately. |

**Test run:** 1016/1016 pass. `tsc -p tsconfig.main.json` clean.

## Coordination needed

The field name `identityResolved` should be confirmed with the racecontrol team — see margic/racecontrol. If the agreed name differs, only `DirectorCapabilities.identityResolved` in `director-types.ts` and the two assignment sites in `main.ts` need updating.