### PR TITLE
fix(#196): publisher event quality — PR-A through PR-E

### DIFF
--- a/src/extensions/iracing/publisher/__tests__/incident-stint-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/incident-stint-detector.test.ts
@@ -237,6 +237,9 @@ describe('STINT_MILESTONE', () => {
       lapsSinceLastPit: 0, estimatedFuelLapsRemaining: 0, inPitWindow: false,
       classPositionHistory: [], stintLapTimes: [],
       overallPositionHistory: [],
+      pitEntrySessionTime: null, pitStopType: null,
+      stallArrivalSessionTime: null, stallFuelOnEntry: 0,
+      lastIncidentSessionTime: undefined,
     });
 
     // Pit exit frame

--- a/src/extensions/iracing/publisher/__tests__/overtake-battle-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/overtake-battle-detector.test.ts
@@ -21,6 +21,7 @@ const CTX = { rigId: 'rig-01', raceSessionId: 'session-abc' };
 function makeState() {
   const s = createSessionState('session-abc', 1);
   seedRoster(s, ALL_CAR_INDICES);
+  s.raceGreenFired = true;
   return s;
 }
 
@@ -582,7 +583,8 @@ describe('BATTLE_CLOSING', () => {
     f1.sessionTime = 101;
     f1.carIdxF2Time[1] = 1.5;
     const e1 = detect(base, f1, state);
-    expect(e1.filter(e => e.type === 'BATTLE_CLOSING')).toHaveLength(1);
+    // Dual-perspective: both chaser and leader receive BATTLE_CLOSING
+    expect(e1.filter(e => e.type === 'BATTLE_CLOSING')).toHaveLength(2);
 
     const f2 = cloneFrame(f1);
     f2.sessionTime = 102;
@@ -663,17 +665,25 @@ describe('LAPPED_TRAFFIC_AHEAD', () => {
     const state = prime(base);
     detect(base, cloneFrame(base), state);  // first fire, latches la:0-1 / bl:0-1
 
-    // Car 0 moves to 50% of the lap — physGap 0.5 × 90 s = 45 s >> 2 s threshold.
-    const wide = cloneFrame(base);
-    wide.carIdxLapDistPct[0] = 0.5;
-    detect(base, wide, state);
-    expect(state.trafficAnnouncements.has('la:0-1')).toBe(false); // latch cleared
+    // Car 0 moves to 50% of the lap — physGap 0.5 × 90 s = 45 s >> exit threshold.
+    // Hysteresis requires TRAFFIC_EXIT_MIN_FRAMES (2) frames above the exit threshold.
+    const wide1 = cloneFrame(base);
+    wide1.carIdxLapDistPct[0] = 0.5;
+    detect(base, wide1, state);
+    // After 1 frame: latch still held (hysteresis)
+    expect(state.trafficAnnouncements.has('la:0-1')).toBe(true);
+
+    const wide2 = cloneFrame(wide1);
+    wide2.carIdxLapDistPct[0] = 0.5;
+    detect(wide1, wide2, state);
+    // After 2 frames: latch released
+    expect(state.trafficAnnouncements.has('la:0-1')).toBe(false);
     expect(state.trafficAnnouncements.has('bl:0-1')).toBe(false);
 
     // Car 0 moves back close to car 1 (1% of lap ≈ 0.9 s gap).
-    const close = cloneFrame(wide);
+    const close = cloneFrame(wide2);
     close.carIdxLapDistPct[0] = 0.01;
-    const events = detect(wide, close, state);
+    const events = detect(wide2, close, state);
     expect(events.find(e => e.type === 'LAPPED_TRAFFIC_AHEAD')).toBeDefined();
   });
 });

--- a/src/extensions/iracing/publisher/__tests__/safety-car-imminent-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/safety-car-imminent-detector.test.ts
@@ -21,6 +21,7 @@ let ctx:   SafetyCarImminentContext;
 beforeEach(() => {
   state = createSessionState('rs-1', 1);
   seedRoster(state, ALL_CAR_INDICES);
+  state.raceGreenFired = true;
   ctx = {
     rigId:           'rig-01',
     raceSessionId:   'rs-1',

--- a/src/extensions/iracing/publisher/__tests__/session-lifecycle-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/session-lifecycle-detector.test.ts
@@ -246,6 +246,7 @@ describe('RACE_CHECKERED — via flag bit (state unchanged)', () => {
   it('does NOT emit duplicate RACE_CHECKERED once state is already Checkered', () => {
     const state = makeState();
     state.lastSessionState = SessionStateEnum.Checkered; // already fired
+    state.checkeredFired = true;
     const prev = makeFrame({ sessionState: SessionStateEnum.Checkered, sessionFlags: FlagBits.Checkered });
     const curr = makeFrame({ sessionState: SessionStateEnum.Checkered, sessionFlags: FlagBits.Checkered });
     const events = detect(prev, curr, state);

--- a/src/extensions/iracing/publisher/__tests__/session-state.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/session-state.test.ts
@@ -181,7 +181,7 @@ describe('buildEvent', () => {
   const opts = { raceSessionId: TEST_SESSION_ID, rigId: TEST_PUBLISHER_CODE, frame, leaderLap: 5 };
 
   it('assigns a UUID id', () => {
-    const event = buildEvent('OVERTAKE', car, { overtakingCarIdx: 1, overtakenCar: { carIdx: 2 }, newPosition: 3, lap: 5, lapDistPct: 0.45 }, opts);
+    const event = buildEvent('OVERTAKE', car, { overtakingCarIdx: 1, overtakenCar: { carIdx: 2 }, newPosition: 3, lap: 5, lapDistPct: 0.45, classPosition: 1, forPosition: 3, gapAfterSec: 0.5 }, opts);
     expect(event.id).toMatch(/^[0-9a-f-]{36}$/);
   });
 
@@ -199,7 +199,7 @@ describe('buildEvent', () => {
   });
 
   it('populates context from frame and options', () => {
-    const event = buildEvent('PIT_ENTRY', car, { entryLap: 5, position: 3, gapToLeaderSec: 4.5 }, opts);
+    const event = buildEvent('PIT_ENTRY', car, { entryLap: 5, position: 3, gapToLeaderSec: 4.5, stopType: 'unknown' as const }, opts);
     expect(event.context?.leaderLap).toBe(5);
     expect(event.context?.sessionFlags).toBe(frame.sessionFlags);
     expect(event.context?.trackTemp).toBe(frame.trackTemp);
@@ -243,7 +243,9 @@ describe('session state reset', () => {
 describe('carRefFromRoster', () => {
   it('returns undefined when carIdx is not in the roster', () => {
     const state = createSessionState('rs-1', 1);
-    expect(carRefFromRoster(state, 0)).toBeUndefined();
+    const ref = carRefFromRoster(state, 0);
+    expect(ref).toBeDefined();
+    expect(ref.driverName).toBe(''); // stub: not in roster
   });
 
   it('returns a PublisherCarRef with all fields when carIdx is in the roster', () => {
@@ -281,6 +283,8 @@ describe('carRefFromRoster', () => {
   it('returns undefined for a different carIdx not in the roster', () => {
     const state = createSessionState('rs-1', 1);
     state.knownRoster.set(2, { carIdx: 2, carNumber: '2', driverName: 'Two', carClassShortName: 'GT3', carClassId: 100 });
-    expect(carRefFromRoster(state, 7)).toBeUndefined();
+    const ref = carRefFromRoster(state, 7);
+    expect(ref).toBeDefined();
+    expect(ref.driverName).toBe(''); // stub: not in roster
   });
 });

--- a/src/extensions/iracing/publisher/driver-publisher/pit-incident-detector.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/pit-incident-detector.ts
@@ -90,6 +90,7 @@ export function detectPitAndIncidents(
             entryLap:       curr.carIdxLapCompleted[i],
             position:       curr.carIdxPosition[i],
             gapToLeaderSec: curr.carIdxF2Time[i],
+            stopType:       'unknown' as const,
           },
           opts,
         ));

--- a/src/extensions/iracing/publisher/driver-publisher/snapshot-emitter.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/snapshot-emitter.ts
@@ -85,8 +85,8 @@ export function buildSnapshot(
   ctx: SnapshotEmitContext,
   reason: 'cadence' | 'forced',
 ): PublisherEvent | null {
+  if (!state.knownRoster.has(ctx.playerCarIdx)) return null;
   const carRef = carRefFromRoster(state, ctx.playerCarIdx);
-  if (!carRef) return null;
 
   const payload = buildSnapshotPayload(frame, state, driverState, ctx, reason);
 

--- a/src/extensions/iracing/publisher/event-types.ts
+++ b/src/extensions/iracing/publisher/event-types.ts
@@ -113,7 +113,9 @@ export type PublisherEventType =
   | 'OVERALL_POSITION_GAIN'
   // §5 Pit & strategy
   | 'PIT_ENTRY'
+  | 'PIT_STATIONARY'
   | 'PIT_STOP_BEGIN'
+  | 'PIT_STOP_COMPLETED'
   | 'PIT_STOP_END'
   | 'PIT_EXIT'
   | 'FUEL_LEVEL_CHANGE'
@@ -137,7 +139,10 @@ export type PublisherEventType =
   /** Composite — player climbs ≥2 positions within 60s after an incident (#181). */
   | 'RECOVERY_DRIVE'
   /** Session-publisher — ≥3 STOPPED_ON_TRACK in 30s OR ≥2 in same sector (#181). */
-  | 'SAFETY_CAR_IMMINENT'  // §7 Identity & roster (edge-authoritative)
+  | 'SAFETY_CAR_IMMINENT'
+  /** Session-wide incident — off-track, contact, or loss-of-control for any car (#196). */
+  | 'INCIDENT'
+  // §7 Identity & roster (edge-authoritative)
   | 'IDENTITY_RESOLVED'
   | 'IDENTITY_OVERRIDE_CHANGED'
   | 'DRIVER_SWAP_INITIATED'
@@ -244,9 +249,13 @@ export interface EventPayloadMap {
   // §5 Pit & strategy
   /** iRacing source: CarIdxOnPitRoad false→true */
   PIT_ENTRY: PitEntryPayload;
-  /** iRacing source: CarIdxTrackSurface == 2 (in pit stall) */
+  /** iRacing source: CarIdxTrackSurface == 2 (car stationary in stall) */
+  PIT_STATIONARY: PitStationaryPayload;
+  /** iRacing source: CarIdxTrackSurface == 2 (in pit stall) — player-car detail */
   PIT_STOP_BEGIN: PitStopBeginPayload;
-  /** iRacing source: leaving stall */
+  /** iRacing source: car leaves stall after service */
+  PIT_STOP_COMPLETED: PitStopCompletedPayload;
+  /** iRacing source: leaving stall — player-car detail */
   PIT_STOP_END: PitStopEndPayload;
   /** iRacing source: CarIdxOnPitRoad true→false */
   PIT_EXIT: PitExitPayload;
@@ -282,6 +291,8 @@ export interface EventPayloadMap {
   RECOVERY_DRIVE: RecoveryDrivePayload;
   /** Session-publisher (#181) — cluster of stopped cars predicting yellow. */
   SAFETY_CAR_IMMINENT: SafetyCarImminentPayload;
+  /** Session-wide incident — off-track, contact, or loss-of-control (#196). */
+  INCIDENT: IncidentPayload;
 
   // §7 Identity
   IDENTITY_RESOLVED: IdentityResolvedPayload;
@@ -375,6 +386,12 @@ export interface LapCompletedPayload {
   classPosition: number;
   /** iRacing source: CarIdxF2Time — gap to leader in seconds */
   gapToLeaderSec: number;
+  /** Seconds to the car immediately ahead in running order (same lap only). Omitted for cross-lap neighbours. */
+  intervalAheadSec?: number;
+  /** Seconds to the car immediately behind in running order (same lap only). */
+  intervalBehindSec?: number;
+  carAhead?: PublisherCarRef;
+  carBehind?: PublisherCarRef;
 }
 
 export interface PersonalBestLapPayload {
@@ -425,6 +442,12 @@ export interface OvertakePayload {
   lap: number;
   /** Fraction of lap where pass occurred — iRacing: CarIdxLapDistPct */
   lapDistPct: number;
+  /** Class position of the overtaking car after the pass. */
+  classPosition: number;
+  /** Overall position being contested (== newPosition). */
+  forPosition: number;
+  /** Gap to the new car immediately ahead after the pass (CarIdxF2Time). */
+  gapAfterSec: number;
 }
 
 export interface PositionChangePayload {
@@ -442,6 +465,10 @@ export interface BattlePayload {
   gapSec: number;
   closingRateSecPerLap: number;
   status: 'ENGAGED' | 'CLOSING' | 'BROKEN';
+  /** Perspective: 'engager' when envelope.car === chaser; 'engaged' when envelope.car === leader. */
+  role: 'engager' | 'engaged';
+  /** Overall position being contested (position of the leader car). */
+  forPosition: number;
 }
 
 export interface TrafficPayload {
@@ -450,11 +477,20 @@ export interface TrafficPayload {
   lappedCar?: PublisherCarRef;
   /** Self-describing ref for the lapping car — populated on BEING_LAPPED only. */
   lappingCar?: PublisherCarRef;
+  /** Edge discriminator. 'entered' on initial proximity; 'exited' on hysteresis release. */
+  state?: 'entered' | 'exited';
+  /** 'edge' for the rising/falling edge, 'refresh' for periodic re-emission. Consumers
+   *  can safely ignore events with kind === 'refresh' if RU cost is a concern. */
+  kind?: 'edge' | 'refresh';
 }
 
 export interface StoppedOnTrackPayload {
   lapDistPct: number;
   stoppedDurationSec: number;
+  /** Edge discriminator. 'entered' when the car first stops; 'exited' when it starts moving. */
+  state?: 'entered' | 'exited';
+  /** 'edge' for the transition, 'refresh' for a periodic reminder while still stopped. */
+  kind?: 'edge' | 'refresh';
 }
 
 // §5 Pit & strategy
@@ -463,6 +499,14 @@ export interface PitEntryPayload {
   entryLap: number;
   position: number;
   gapToLeaderSec: number;
+  /** Gap to the car immediately ahead at the moment of pit entry. */
+  gapToCarAheadSec?: number;
+  /** Gap from the car immediately behind at the moment of pit entry. */
+  gapToCarBehindSec?: number;
+  carAhead?: PublisherCarRef;
+  carBehind?: PublisherCarRef;
+  /** Race condition at entry (from SessionFlags). */
+  stopType: 'green' | 'sc' | 'red' | 'unknown';
 }
 
 export interface PitStopBeginPayload {
@@ -477,10 +521,36 @@ export interface PitStopEndPayload {
   fuelLevelDelta: number;
 }
 
+/** PIT_STATIONARY — car is stationary in the pit stall (trackSurface === 2). */
+export interface PitStationaryPayload {
+  /** SessionTime when the car arrived in the stall. */
+  arrivalSessionTime: number;
+  /** FuelLevel at stall arrival (player car only — 0 for other cars). */
+  fuelLevelOnEntry: number;
+}
+
+/** PIT_STOP_COMPLETED — car is leaving the pit stall after service. */
+export interface PitStopCompletedPayload {
+  /** Milliseconds the car was stationary in the stall. */
+  stationaryMs: number;
+  /** Race condition at entry. */
+  stopType: 'green' | 'sc' | 'red' | 'unknown';
+  /** Fuel added in litres (player car only — 0 for other cars). */
+  fuelAdded: number;
+  /** Whether tires were changed (player car only — false for other cars). */
+  tiresChanged: boolean;
+  /** CarIdxPosition at stall exit. */
+  exitPosition: number;
+  /** Gap (seconds) to the car immediately ahead at stall exit. */
+  deltaVsCarAheadSec?: number;
+}
+
 export interface PitExitPayload {
   exitLap: number;
   newPosition: number;
   positionsLost: number;
+  /** Gap (seconds) to the car that was immediately ahead at pit entry. */
+  deltaVsPreviousNeighbourSec?: number;
 }
 
 export interface FuelLevelChangePayload {
@@ -524,6 +594,31 @@ export interface IncidentLimitWarningPayload {
   thresholdPercent: number;
   currentCount: number;
   incidentLimit: number;
+}
+
+/**
+ * INCIDENT — session-wide incident for any car (#196).
+ *
+ * Emitted by the session-publisher incident detector on:
+ *   - any car going off-track (trackSurface === -1 edge)
+ *   - kinematic discontinuity consistent with loss-of-control / spin
+ *   - two-car proximity contact (both show kinematic discontinuity)
+ *
+ * For the player car, also emitted as a companion to INCIDENT_POINT
+ * with severity derived from the incident-point delta.
+ */
+export interface IncidentPayload {
+  severity: 'light' | 'moderate' | 'severe';
+  type: 'OFF_TRACK' | 'CONTACT' | 'LOSS_OF_CONTROL' | 'SPIN';
+  lap: number;
+  /** Fraction along the lap (0.0–1.0). */
+  lapDistPct: number;
+  /** Approximate track sector (0–2) derived from lapDistPct. */
+  sector: 0 | 1 | 2;
+  /** iRacing CarIdxTrackSurface enum value at the trigger frame. */
+  trackSurface: number;
+  /** Other car involved when type === 'CONTACT'. */
+  otherCar?: PublisherCarRef;
 }
 
 // §7 Identity & roster
@@ -575,6 +670,9 @@ export const HIGH_PRIORITY_EVENTS = new Set<PublisherEventType>([
   'FLAG_RED',
   'FLAG_YELLOW_FULL_COURSE',
   'INCIDENT_LIMIT_WARNING',
+  'INCIDENT',
+  'PIT_ENTRY',
+  'PIT_EXIT',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/src/extensions/iracing/publisher/session-publisher/incident-detector.ts
+++ b/src/extensions/iracing/publisher/session-publisher/incident-detector.ts
@@ -1,0 +1,209 @@
+/**
+ * incident-detector.ts — Issue #201 (PR-E for #196)
+ *
+ * Session-wide incident detection for all 64 car slots.
+ *
+ * Emits:
+ *   INCIDENT — when a car experiences an on-track incident
+ *
+ * Three trigger patterns (all require raceGreenFired):
+ *
+ *   1. OFF_TRACK edge — CarIdxTrackSurface transitions to -1 (off track).
+ *      Severity depends on prior speed delta: we use CarIdxSpeed at the frame
+ *      before and after the edge as a proxy.
+ *        speed < 10 m/s drop  → 'light'
+ *        speed ≥ 10 m/s drop  → 'moderate'
+ *        speed ≥ 25 m/s drop  → 'severe'
+ *
+ *   2. Sudden deceleration while on-track (kinematic discontinuity).
+ *      CarIdxSpeed drops by ≥ KINEMATIC_THRESHOLD_MPS in a single frame AND
+ *      the car is on the racing surface (trackSurface 1) AND not in a braking
+ *      zone we'd normally expect (we use the raw speed delta as a proxy).
+ *      This catches CONTACT events between cars on-track.
+ *        speed drop ≥ 10 m/s → 'moderate'
+ *        speed drop ≥ 25 m/s → 'severe'
+ *
+ *   3. Two-car proximity + simultaneous kinematic disturbance.
+ *      If two cars' speeds both drop by ≥ 5 m/s in the same frame while ≤
+ *      CONTACT_PROXIMITY_LAP_PCT apart on track → 'CONTACT' type.
+ *
+ * Sector mapping:
+ *   lap distance [0, 0.33)  → sector 0
+ *   lap distance [0.33, 0.66) → sector 1
+ *   lap distance [0.66, 1.0) → sector 2
+ *
+ * Design notes:
+ *  - Latched per car: once INCIDENT fires, a cooldown of INCIDENT_COOLDOWN_SEC
+ *    prevents repeated events for the same car from the same incident.
+ *  - otherCar is only populated for CONTACT type (when a two-car pair is identified).
+ *  - Requires CarIdxSpeed in TelemetryFrame (added in #178).
+ *  - iRacing CarIdxTrackSurface values: -1 = off track, 1 = on track, 2 = pit stall,
+ *    3 = approaching pits, 4 = pit lane.
+ */
+
+import type { TelemetryFrame, SessionState } from '../session-state';
+import { getOrCreateCarState, carRefFromRoster, buildEvent } from '../session-state';
+import type { PublisherEvent } from '../event-types';
+
+export interface IncidentDetectorContext {
+  rigId: string;
+  raceSessionId: string;
+}
+
+const CAR_COUNT = 64;
+
+/** Speed drop (m/s) in a single frame that triggers a 'moderate' incident. */
+const KINEMATIC_MOD_THRESHOLD_MPS = 10;
+/** Speed drop (m/s) in a single frame that triggers a 'severe' incident. */
+const KINEMATIC_SEV_THRESHOLD_MPS = 25;
+/** Speed drop (m/s) in a single frame to consider a car as 'disturbed' for contact detection. */
+const CONTACT_DISTURBANCE_MPS = 5;
+/** Track-distance fraction (laps) within which two disturbed cars count as a CONTACT. */
+const CONTACT_PROXIMITY_LAP_PCT = 0.02; // ≈ 2% of lap
+/** Seconds after an INCIDENT emission during which further events for the same car are suppressed. */
+const INCIDENT_COOLDOWN_SEC = 8;
+
+function lapSector(pct: number): 0 | 1 | 2 {
+  if (pct < 0.33) return 0;
+  if (pct < 0.66) return 1;
+  return 2;
+}
+
+function speedDropSeverity(dropMps: number): 'light' | 'moderate' | 'severe' {
+  if (dropMps >= KINEMATIC_SEV_THRESHOLD_MPS) return 'severe';
+  if (dropMps >= KINEMATIC_MOD_THRESHOLD_MPS) return 'moderate';
+  return 'light';
+}
+
+// ---------------------------------------------------------------------------
+// detectIncidents — pure-ish function (mutates carState.lastIncidentSessionTime)
+// ---------------------------------------------------------------------------
+
+export function detectIncidents(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: IncidentDetectorContext,
+): PublisherEvent[] {
+  const events: PublisherEvent[] = [];
+
+  if (!prev) return events;
+  if (!state.raceGreenFired) return events;
+
+  const opts = { rigId: ctx.rigId, raceSessionId: ctx.raceSessionId, frame: curr };
+
+  // Collect per-car speed deltas and off-track transitions in a single pass.
+  // We then do a second pass for contact detection using the collected data.
+  const speedDrops   = new Float64Array(CAR_COUNT); // positive = dropped
+  const offTrackEdge = new Uint8Array(CAR_COUNT);   // 1 if trackSurface -1 this frame
+
+  for (let i = 0; i < CAR_COUNT; i++) {
+    if (curr.carIdxPosition[i] <= 0) continue;
+
+    const prevSurface = prev.carIdxTrackSurface[i];
+    const currSurface = curr.carIdxTrackSurface[i];
+    const prevSpeed   = prev.carIdxSpeed[i];
+    const currSpeed   = curr.carIdxSpeed[i];
+
+    speedDrops[i]   = Math.max(0, prevSpeed - currSpeed);
+    offTrackEdge[i] = (prevSurface !== -1 && currSurface === -1) ? 1 : 0;
+  }
+
+  // First pass: OFF_TRACK and kinematic events.
+  for (let i = 0; i < CAR_COUNT; i++) {
+    if (curr.carIdxPosition[i] <= 0) continue;
+
+    const cs = getOrCreateCarState(state, i);
+    const now = curr.sessionTime;
+
+    // Cooldown check
+    if (cs.lastIncidentSessionTime !== undefined &&
+        now - cs.lastIncidentSessionTime < INCIDENT_COOLDOWN_SEC) {
+      continue;
+    }
+
+    const currSurface = curr.carIdxTrackSurface[i];
+    const drop        = speedDrops[i];
+    const pct         = curr.carIdxLapDistPct[i];
+    const lap         = curr.carIdxLapCompleted[i];
+
+    let incidentType: 'OFF_TRACK' | 'CONTACT' | 'LOSS_OF_CONTROL' | 'SPIN' | null = null;
+    let severity: 'light' | 'moderate' | 'severe' = 'light';
+
+    if (offTrackEdge[i]) {
+      incidentType = 'OFF_TRACK';
+      severity     = speedDropSeverity(drop);
+    } else if (currSurface === 1 && drop >= KINEMATIC_MOD_THRESHOLD_MPS) {
+      // Kinematic disturbance on-track and not pit road — candidate for CONTACT or LOC.
+      // The contact check (pairing with another disturbed car) happens below.
+      // For now tag as LOSS_OF_CONTROL; it may be upgraded to CONTACT in pass 2.
+      incidentType = 'LOSS_OF_CONTROL';
+      severity     = speedDropSeverity(drop);
+    }
+
+    if (!incidentType) continue;
+
+    const car = carRefFromRoster(state, i);
+    events.push(buildEvent('INCIDENT', car, {
+      severity,
+      type:         incidentType,
+      lap,
+      lapDistPct:   pct,
+      sector:       lapSector(pct),
+      trackSurface: curr.carIdxTrackSurface[i],
+    }, opts));
+    cs.lastIncidentSessionTime = now;
+  }
+
+  // Second pass: contact detection — find pairs of disturbed cars close together.
+  // For any pair that are both disturbed AND within CONTACT_PROXIMITY_LAP_PCT,
+  // emit (or upgrade) an INCIDENT of type CONTACT with otherCar populated.
+  // Only emit if neither car has recently emitted (cooldown already handled in
+  // first pass, but we need to avoid double-emit if LOSS_OF_CONTROL already fired).
+  const disturbed: number[] = [];
+  for (let i = 0; i < CAR_COUNT; i++) {
+    if (curr.carIdxPosition[i] > 0 &&
+        curr.carIdxTrackSurface[i] === 1 &&
+        speedDrops[i] >= CONTACT_DISTURBANCE_MPS) {
+      disturbed.push(i);
+    }
+  }
+
+  for (let ai = 0; ai < disturbed.length; ai++) {
+    for (let bi = ai + 1; bi < disturbed.length; bi++) {
+      const a = disturbed[ai];
+      const b = disturbed[bi];
+
+      let physDiff = curr.carIdxLapDistPct[a] - curr.carIdxLapDistPct[b];
+      if (physDiff >  0.5) physDiff -= 1.0;
+      if (physDiff < -0.5) physDiff += 1.0;
+      if (Math.abs(physDiff) > CONTACT_PROXIMITY_LAP_PCT) continue;
+
+      // Same-lap pair within proximity — emit CONTACT for both cars
+      for (const [self, other] of [[a, b], [b, a]]) {
+        const cs = getOrCreateCarState(state, self);
+        const now = curr.sessionTime;
+        // Only emit if not already in cooldown from a prior event this pass
+        if (cs.lastIncidentSessionTime !== undefined &&
+            now - cs.lastIncidentSessionTime < INCIDENT_COOLDOWN_SEC) {
+          continue;
+        }
+        const selfCar  = carRefFromRoster(state, self);
+        const otherCar = carRefFromRoster(state, other);
+        const pct      = curr.carIdxLapDistPct[self];
+        events.push(buildEvent('INCIDENT', selfCar, {
+          severity:     speedDropSeverity(speedDrops[self]),
+          type:         'CONTACT',
+          lap:          curr.carIdxLapCompleted[self],
+          lapDistPct:   pct,
+          sector:       lapSector(pct),
+          trackSurface: curr.carIdxTrackSurface[self],
+          otherCar,
+        }, opts));
+        cs.lastIncidentSessionTime = now;
+      }
+    }
+  }
+
+  return events;
+}

--- a/src/extensions/iracing/publisher/session-publisher/lap-completed-detector.ts
+++ b/src/extensions/iracing/publisher/session-publisher/lap-completed-detector.ts
@@ -42,23 +42,58 @@ export function detectLapCompleted(
   const events: PublisherEvent[] = [];
   const opts = { raceSessionId: ctx.raceSessionId, rigId: ctx.rigId, frame: curr };
 
+  // #196 PR-D: build a position→carIdx map for neighbour-interval computation.
+  // We only include cars with a valid position (> 0) and on the same lap or
+  // one lap ahead — cross-lap F2Time values are meaningless (≈ lapTime * lapDelta).
+  const posToCarIdx = new Map<number, number>();
+  for (let j = 0; j < CAR_COUNT; j++) {
+    const pos = curr.carIdxPosition[j];
+    if (pos > 0) posToCarIdx.set(pos, j);
+  }
+
   for (let i = 0; i < CAR_COUNT; i++) {
     const prevLaps = prev.carIdxLapCompleted[i];
     const currLaps = curr.carIdxLapCompleted[i];
 
     if (currLaps > prevLaps) {
       const car = carRefFromRoster(state, i);
-      if (!car) continue;
+
+      const pos = curr.carIdxPosition[i];
+
+      // Compute neighbour intervals using CarIdxF2Time (gap to car ahead) and
+      // by looking up the car behind's F2Time.  Skip cross-lap neighbours to
+      // avoid stale ~90-second values polluting the payload.
+      const aheadIdx  = posToCarIdx.get(pos - 1) ?? -1;
+      const behindIdx = posToCarIdx.get(pos + 1) ?? -1;
+
+      const sameLap = (a: number) =>
+        a >= 0 && curr.carIdxLapCompleted[a] === currLaps;
+
+      const intervalAheadSec  = (sameLap(aheadIdx) && aheadIdx >= 0)
+        ? Math.max(0, curr.carIdxF2Time[i])
+        : undefined;
+      const intervalBehindSec = (sameLap(behindIdx) && behindIdx >= 0)
+        ? Math.max(0, curr.carIdxF2Time[behindIdx])
+        : undefined;
+
+      const carAhead  = aheadIdx  >= 0 && intervalAheadSec  !== undefined
+        ? carRefFromRoster(state, aheadIdx)  : undefined;
+      const carBehind = behindIdx >= 0 && intervalBehindSec !== undefined
+        ? carRefFromRoster(state, behindIdx) : undefined;
 
       events.push(buildEvent(
         'LAP_COMPLETED',
         car,
         {
-          lapNumber:      currLaps,
-          lapTime:        curr.carIdxLastLapTime[i],
-          position:       curr.carIdxPosition[i],
-          classPosition:  curr.carIdxClassPosition[i],
-          gapToLeaderSec: curr.carIdxF2Time[i],
+          lapNumber:          currLaps,
+          lapTime:            curr.carIdxLastLapTime[i],
+          position:           pos,
+          classPosition:      curr.carIdxClassPosition[i],
+          gapToLeaderSec:     curr.carIdxF2Time[i],
+          intervalAheadSec,
+          intervalBehindSec,
+          carAhead,
+          carBehind,
         },
         opts,
       ));

--- a/src/extensions/iracing/publisher/session-publisher/orchestrator.ts
+++ b/src/extensions/iracing/publisher/session-publisher/orchestrator.ts
@@ -23,6 +23,8 @@ import { detectSessionLifecycle } from './session-lifecycle-detector';
 import { detectFlags } from './flag-detector';
 import { detectLapCompleted } from './lap-completed-detector';
 import { detectOvertakeAndBattle } from './overtake-battle-detector';
+import { detectPitLifecycle } from './pit-lifecycle-detector';
+import { detectIncidents } from './incident-detector';
 import { detectSafetyCarImminent } from './safety-car-imminent-detector';
 import { detectSessionLapPerformance } from './lap-performance-session';
 import { detectSessionTypeChange } from './session-type-detector';
@@ -131,6 +133,11 @@ export class SessionPublisherOrchestrator {
     events.push(...detectFlags(this.prevFrame, frame, this.state, ctx));
     events.push(...detectLapCompleted(this.prevFrame, frame, this.state, ctx));
     events.push(...detectOvertakeAndBattle(this.prevFrame, frame, this.state, ctx));
+    events.push(...detectPitLifecycle(this.prevFrame, frame, this.state, {
+      ...ctx,
+      playerCarIdx: this.playerCarIdx ?? -1,
+    }));
+    events.push(...detectIncidents(this.prevFrame, frame, this.state, ctx));
     // Composite (#181): consumes STOPPED_ON_TRACK from this tick.
     events.push(...detectSafetyCarImminent(this.prevFrame, frame, this.state, {
       ...ctx,

--- a/src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts
+++ b/src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts
@@ -42,6 +42,10 @@ const FALLBACK_LAP_TIME_SEC = 90;
 /** Gap (seconds of CarIdxF2Time) below which a chaser is treated as "at"
  * another car for lapped-traffic purposes. Roughly 100m at 50 m/s (~180 kph). */
 const TRAFFIC_PROXIMITY_GAP_SEC = 2.0;
+/** Exit threshold: latch is only released once the pair is this far apart (#196 hysteresis). */
+const TRAFFIC_EXIT_GAP_SEC = 3.5;
+/** Consecutive frames above TRAFFIC_EXIT_GAP_SEC before releasing the traffic latch. */
+const TRAFFIC_EXIT_MIN_FRAMES = 2;
 /** Consecutive session seconds without lapDistPct movement required before
  * STOPPED_ON_TRACK fires. */
 const STOPPED_ON_TRACK_MIN_DURATION_SEC = 2.0;
@@ -132,12 +136,16 @@ export function detectOvertakeAndBattle(
     const overtakenCar  = carRefFromRoster(state, displaced);
     if (!overtakeCar || !overtakenCar) continue;
 
+    const currClassPos = curr.carIdxClassPosition[i];
     const overtakePayload = {
       overtakingCarIdx: i,
       overtakenCar,
       newPosition:      currPos,
       lap:              curr.carIdxLapCompleted[i],
       lapDistPct:       curr.carIdxLapDistPct[i],
+      classPosition:    currClassPos,
+      forPosition:      currPos,
+      gapAfterSec:      Math.max(0, curr.carIdxF2Time[i]),
     };
 
     events.push(buildEvent('OVERTAKE', overtakeCar, overtakePayload, opts));
@@ -148,10 +156,7 @@ export function detectOvertakeAndBattle(
     }
 
     // Tier 2 (#97): OVERTAKE_FOR_CLASS — chaser just took the class lead.
-    // We emit this in addition to OVERTAKE_FOR_LEAD so a "lead for overall and
-    // class" pass produces all three (OVERTAKE, OVERTAKE_FOR_LEAD, OVERTAKE_FOR_CLASS).
     const prevClassPos = prev.carIdxClassPosition[i];
-    const currClassPos = curr.carIdxClassPosition[i];
     if (currClassPos === 1 && prevClassPos > 1) {
       events.push(buildEvent('OVERTAKE_FOR_CLASS', overtakeCar, overtakePayload, opts));
     }
@@ -205,18 +210,23 @@ export function detectOvertakeAndBattle(
         const engagedCar = carRefFromRoster(state, i);
         const leaderCarRef = carRefFromRoster(state, leaderIdx);
         if (engagedCar && leaderCarRef) {
-          events.push(buildEvent(
-            'BATTLE_ENGAGED',
-            engagedCar,
-            {
-              chaserCar:             engagedCar,
-              leaderCar:             leaderCarRef,
-              gapSec:                gap,
-              closingRateSecPerLap:  closingRate,
-              status:                STATUS_ENGAGED,
-            },
-            opts,
-          ));
+          const leaderPos = curr.carIdxPosition[leaderIdx];
+          const engagedPayload = {
+            chaserCar:            engagedCar,
+            leaderCar:            leaderCarRef,
+            gapSec:               gap,
+            closingRateSecPerLap: closingRate,
+            status:               STATUS_ENGAGED,
+            role:                 'engager' as const,
+            forPosition:          leaderPos,
+          };
+          // Engager perspective (chaser is the envelope car)
+          events.push(buildEvent('BATTLE_ENGAGED', engagedCar, engagedPayload, opts));
+          // Engaged perspective (leader is the envelope car)
+          events.push(buildEvent('BATTLE_ENGAGED', leaderCarRef, {
+            ...engagedPayload,
+            role: 'engaged' as const,
+          }, opts));
         }
       } else {
         // Already ENGAGED — keep stats fresh, reset broken counter
@@ -242,18 +252,21 @@ export function detectOvertakeAndBattle(
           const closingCar = carRefFromRoster(state, i);
           const closingLeaderRef = carRefFromRoster(state, leaderIdx);
           if (closingCar && closingLeaderRef) {
-            events.push(buildEvent(
-              'BATTLE_CLOSING',
-              closingCar,
-              {
-                chaserCar:             closingCar,
-                leaderCar:             closingLeaderRef,
-                gapSec:                gap,
-                closingRateSecPerLap:  closingRatePerLap,
-                status:                'CLOSING',
-              },
-              opts,
-            ));
+            const closingLeaderPos = curr.carIdxPosition[leaderIdx];
+            const closingPayload = {
+              chaserCar:            closingCar,
+              leaderCar:            closingLeaderRef,
+              gapSec:               gap,
+              closingRateSecPerLap: closingRatePerLap,
+              status:               'CLOSING' as const,
+              role:                 'engager' as const,
+              forPosition:          closingLeaderPos,
+            };
+            events.push(buildEvent('BATTLE_CLOSING', closingCar, closingPayload, opts));
+            events.push(buildEvent('BATTLE_CLOSING', closingLeaderRef, {
+              ...closingPayload,
+              role: 'engaged' as const,
+            }, opts));
             battle.closingAnnounced     = true;
             battle.closingRateSecPerLap = closingRatePerLap;
           }
@@ -275,18 +288,21 @@ export function detectOvertakeAndBattle(
         const brokenChaser  = carRefFromRoster(state, battle.chaserCarIdx);
         const brokenLeader  = carRefFromRoster(state, battle.leaderCarIdx);
         if (brokenCar && brokenChaser && brokenLeader) {
-          events.push(buildEvent(
-            'BATTLE_BROKEN',
-            brokenCar,
-            {
-              chaserCar:             brokenChaser,
-              leaderCar:             brokenLeader,
-              gapSec:                gap,
-              closingRateSecPerLap:  battle.closingRateSecPerLap,
-              status:                'BROKEN',
-            },
-            opts,
-          ));
+          const brokenLeaderPos = curr.carIdxPosition[battle.leaderCarIdx];
+          const brokenPayload = {
+            chaserCar:            brokenChaser,
+            leaderCar:            brokenLeader,
+            gapSec:               gap,
+            closingRateSecPerLap: battle.closingRateSecPerLap,
+            status:               'BROKEN' as const,
+            role:                 'engager' as const,
+            forPosition:          brokenLeaderPos,
+          };
+          events.push(buildEvent('BATTLE_BROKEN', brokenChaser, brokenPayload, opts));
+          events.push(buildEvent('BATTLE_BROKEN', brokenLeader, {
+            ...brokenPayload,
+            role: 'engaged' as const,
+          }, opts));
         }
         state.activeBattles.delete(key);
       }
@@ -311,156 +327,237 @@ export function detectOvertakeAndBattle(
   //   BEING_LAPPED         — from the lapped car's perspective (fewer laps)
   //
   // Latched per pair via state.trafficAnnouncements using prefixed keys:
-  //   'la:<pairKey>'  — LAPPED_TRAFFIC_AHEAD announced
-  //   'bl:<pairKey>'  — BEING_LAPPED announced
-  // Both are cleared when the cars move more than TRAFFIC_PROXIMITY_GAP_SEC
-  // apart physically.
-  // -------------------------------------------------------------------------
-  const seenTrafficPairs = new Set<string>();
-
-  for (let i = 0; i < CAR_COUNT; i++) {
-    if (curr.carIdxPosition[i] <= 0) continue;
-    if (curr.carIdxOnPitRoad[i] !== 0) continue;
-    const lapI = curr.carIdxLapCompleted[i];
-    const pctI = curr.carIdxLapDistPct[i];
-
-    for (let j = i + 1; j < CAR_COUNT; j++) {
-      if (curr.carIdxPosition[j] <= 0) continue;
-      if (curr.carIdxOnPitRoad[j] !== 0) continue;
-      const lapJ = curr.carIdxLapCompleted[j];
-
-      // Only interested in cars on different laps.
-      if (lapI === lapJ) continue;
-
-      const pctJ = curr.carIdxLapDistPct[j];
-
-      // Physical track gap as a fraction of the lap, normalised to [−0.5, 0.5]
-      // so that the start/finish line wrap-around is handled correctly.
-      let physDiff = pctI - pctJ;
-      if (physDiff >  0.5) physDiff -= 1.0;
-      if (physDiff < -0.5) physDiff += 1.0;
-
-      // Convert fractional gap to approximate seconds using the last known
-      // lap time (fall back to FALLBACK_LAP_TIME_SEC when unavailable).
-      const lapRef =
-        curr.carIdxLastLapTime[i] > 0 ? curr.carIdxLastLapTime[i] :
-        curr.carIdxLastLapTime[j] > 0 ? curr.carIdxLastLapTime[j] :
-        FALLBACK_LAP_TIME_SEC;
-      const gapSec = Math.abs(physDiff) * lapRef;
-
-      if (gapSec > TRAFFIC_PROXIMITY_GAP_SEC) continue;
-
-      // Determine which car is lapping (more completed laps) and which is
-      // being lapped (fewer completed laps).
-      const lapperIdx = lapI > lapJ ? i : j;
-      const lappedIdx  = lapI > lapJ ? j : i;
-
-      const pairKey = battleKey(lapperIdx, lappedIdx);
-      const laKey   = `la:${pairKey}`;
-      const blKey   = `bl:${pairKey}`;
-      seenTrafficPairs.add(laKey);
-      seenTrafficPairs.add(blKey);
-
-      // Approximate distance in metres at a nominal 50 m/s racing pace.
-      const approxDistanceMeters = Math.round(gapSec * 50);
-
-      // LAPPED_TRAFFIC_AHEAD — fired from the lapper's perspective.
-      if (!state.trafficAnnouncements.has(laKey)) {
-        const lapperCar   = carRefFromRoster(state, lapperIdx);
-        const lappedCar   = carRefFromRoster(state, lappedIdx);
-        if (lapperCar && lappedCar) {
-          events.push(buildEvent(
-            'LAPPED_TRAFFIC_AHEAD',
-            lapperCar,
-            {
-              lappedCar,
-              distanceMeters: approxDistanceMeters,
-            },
-            opts,
-          ));
-          state.trafficAnnouncements.set(laKey, 'LAPPED_AHEAD');
-        }
-      }
-
-      // BEING_LAPPED — fired from the lapped car's perspective.
-      if (!state.trafficAnnouncements.has(blKey)) {
-        const lappedCar   = carRefFromRoster(state, lappedIdx);
-        const lappingCar  = carRefFromRoster(state, lapperIdx);
-        if (lappedCar && lappingCar) {
-          events.push(buildEvent(
-            'BEING_LAPPED',
-            lappedCar,
-            {
-              lappingCar,
-              distanceMeters: approxDistanceMeters,
-            },
-            opts,
-          ));
-          state.trafficAnnouncements.set(blKey, 'BEING_LAPPED');
-        }
-      }
-    }
-  }
-
-  // Clear traffic announcements for pairs that are no longer physically close.
-  for (const key of Array.from(state.trafficAnnouncements.keys())) {
-    if (!seenTrafficPairs.has(key)) {
-      state.trafficAnnouncements.delete(key);
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Step 5: STOPPED_ON_TRACK (#97)
+  //   'la:<pairKey>'  — LAPPED_TRAFFIC_AHEAD announced (entered)
+  //   'bl:<pairKey>'  — BEING_LAPPED announced (entered)
   //
-  // A car is considered stopped when its lapDistPct has not changed by more
-  // than STOPPED_MOVEMENT_EPSILON AND it is off pit road. Once that state has
-  // persisted for STOPPED_ON_TRACK_MIN_DURATION_SEC, fire the event once.
+  // #196 hysteresis: latches are only released after TRAFFIC_EXIT_MIN_FRAMES
+  // consecutive frames above TRAFFIC_EXIT_GAP_SEC (not TRAFFIC_PROXIMITY_GAP_SEC).
+  // A 'exited' event is emitted when the latch releases.
+  //
+  // #196 pre-green guard: Step 4 and Step 5 are skipped before RACE_GREEN.
   // -------------------------------------------------------------------------
-  for (let i = 0; i < CAR_COUNT; i++) {
-    const cs = getOrCreateCarState(state, i);
-    const onPit = curr.carIdxOnPitRoad[i] !== 0;
-    const currPos = curr.carIdxPosition[i];
+  if (state.raceGreenFired) {
+    const seenTrafficPairs = new Set<string>();
 
-    if (onPit || currPos <= 0) {
-      cs.stoppedStartSessionTime = null;
-      cs.isStoppedOnTrack = false;
-      continue;
-    }
+    for (let i = 0; i < CAR_COUNT; i++) {
+      if (curr.carIdxPosition[i] <= 0) continue;
+      if (curr.carIdxOnPitRoad[i] !== 0) continue;
+      const lapI = curr.carIdxLapCompleted[i];
+      const pctI = curr.carIdxLapDistPct[i];
 
-    const prevPct = prev.carIdxLapDistPct[i];
-    const currPct = curr.carIdxLapDistPct[i];
-    const moved   = Math.abs(currPct - prevPct) > STOPPED_MOVEMENT_EPSILON;
+      for (let j = i + 1; j < CAR_COUNT; j++) {
+        if (curr.carIdxPosition[j] <= 0) continue;
+        if (curr.carIdxOnPitRoad[j] !== 0) continue;
+        const lapJ = curr.carIdxLapCompleted[j];
 
-    if (moved) {
-      cs.stoppedStartSessionTime = null;
-      cs.isStoppedOnTrack = false;
-      continue;
-    }
+        // Only interested in cars on different laps.
+        if (lapI === lapJ) continue;
 
-    if (cs.stoppedStartSessionTime === null) {
-      // The car was not moving between prev and curr, so the stop began at
-      // prev.sessionTime at the latest. Seed from prev so the duration check
-      // below includes the window we've just observed.
-      cs.stoppedStartSessionTime = prev.sessionTime;
-    }
+        const pctJ = curr.carIdxLapDistPct[j];
 
-    const stoppedFor = curr.sessionTime - cs.stoppedStartSessionTime;
-    if (stoppedFor >= STOPPED_ON_TRACK_MIN_DURATION_SEC && !cs.isStoppedOnTrack) {
-      const stoppedCar = carRefFromRoster(state, i);
-      if (stoppedCar) {
-        cs.isStoppedOnTrack = true;
-        events.push(buildEvent(
-          'STOPPED_ON_TRACK',
-          stoppedCar,
-          {
-            lapDistPct:         currPct,
-            stoppedDurationSec: stoppedFor,
-          },
-          opts,
-        ));
+        // Physical track gap as a fraction of the lap, normalised to [−0.5, 0.5]
+        // so that the start/finish line wrap-around is handled correctly.
+        let physDiff = pctI - pctJ;
+        if (physDiff >  0.5) physDiff -= 1.0;
+        if (physDiff < -0.5) physDiff += 1.0;
+
+        // Convert fractional gap to approximate seconds using the last known
+        // lap time (fall back to FALLBACK_LAP_TIME_SEC when unavailable).
+        const lapRef =
+          curr.carIdxLastLapTime[i] > 0 ? curr.carIdxLastLapTime[i] :
+          curr.carIdxLastLapTime[j] > 0 ? curr.carIdxLastLapTime[j] :
+          FALLBACK_LAP_TIME_SEC;
+        const gapSec = Math.abs(physDiff) * lapRef;
+
+        // Determine which car is lapping (more completed laps) and which is
+        // being lapped (fewer completed laps).
+        const lapperIdx = lapI > lapJ ? i : j;
+        const lappedIdx  = lapI > lapJ ? j : i;
+
+        const pairKey = battleKey(lapperIdx, lappedIdx);
+        const laKey   = `la:${pairKey}`;
+        const blKey   = `bl:${pairKey}`;
+
+        // Approximate distance in metres at a nominal 50 m/s racing pace.
+        const approxDistanceMeters = Math.round(gapSec * 50);
+
+        if (gapSec <= TRAFFIC_PROXIMITY_GAP_SEC) {
+          seenTrafficPairs.add(laKey);
+          seenTrafficPairs.add(blKey);
+          // Reset any exit-hysteresis counter since the pair is within range again.
+          state.trafficExitFrames.delete(laKey);
+          state.trafficExitFrames.delete(blKey);
+
+          // LAPPED_TRAFFIC_AHEAD — fired from the lapper's perspective.
+          if (!state.trafficAnnouncements.has(laKey)) {
+            const lapperCar = carRefFromRoster(state, lapperIdx);
+            const lappedCar = carRefFromRoster(state, lappedIdx);
+            if (lapperCar && lappedCar) {
+              events.push(buildEvent(
+                'LAPPED_TRAFFIC_AHEAD',
+                lapperCar,
+                { lappedCar, distanceMeters: approxDistanceMeters, state: 'entered', kind: 'edge' },
+                opts,
+              ));
+              state.trafficAnnouncements.set(laKey, 'LAPPED_AHEAD');
+            }
+          }
+
+          // BEING_LAPPED — fired from the lapped car's perspective.
+          if (!state.trafficAnnouncements.has(blKey)) {
+            const lappedCar  = carRefFromRoster(state, lappedIdx);
+            const lappingCar = carRefFromRoster(state, lapperIdx);
+            if (lappedCar && lappingCar) {
+              events.push(buildEvent(
+                'BEING_LAPPED',
+                lappedCar,
+                { lappingCar, distanceMeters: approxDistanceMeters, state: 'entered', kind: 'edge' },
+                opts,
+              ));
+              state.trafficAnnouncements.set(blKey, 'BEING_LAPPED');
+            }
+          }
+        }
+        // If gapSec > TRAFFIC_EXIT_GAP_SEC the hysteresis cleanup below handles exit.
       }
     }
-  }
+
+    // -----------------------------------------------------------------------
+    // Hysteresis-based exit: release latches that have been above the exit
+    // threshold for TRAFFIC_EXIT_MIN_FRAMES consecutive frames.
+    // -----------------------------------------------------------------------
+    for (const [key] of Array.from(state.trafficAnnouncements.entries())) {
+      if (seenTrafficPairs.has(key)) continue; // still within enter range — keep
+
+      const n = (state.trafficExitFrames.get(key) ?? 0) + 1;
+      if (n >= TRAFFIC_EXIT_MIN_FRAMES) {
+        // Emit an 'exited' edge event before releasing the latch.
+        const isLa = key.startsWith('la:');
+        const pairKeyRaw = key.slice(3);
+        const [aStr, bStr] = pairKeyRaw.split('-');
+        const lapperIdx2 = isLa ? parseInt(aStr, 10) : parseInt(bStr, 10);
+        const lappedIdx2 = isLa ? parseInt(bStr, 10) : parseInt(aStr, 10);
+
+        if (isLa) {
+          const lapperCar = carRefFromRoster(state, lapperIdx2);
+          const lappedCar = carRefFromRoster(state, lappedIdx2);
+          if (lapperCar && lappedCar) {
+            events.push(buildEvent(
+              'LAPPED_TRAFFIC_AHEAD',
+              lapperCar,
+              { lappedCar, distanceMeters: 0, state: 'exited', kind: 'edge' },
+              opts,
+            ));
+          }
+        } else {
+          const lappedCar  = carRefFromRoster(state, lappedIdx2);
+          const lappingCar = carRefFromRoster(state, lapperIdx2);
+          if (lappedCar && lappingCar) {
+            events.push(buildEvent(
+              'BEING_LAPPED',
+              lappedCar,
+              { lappingCar, distanceMeters: 0, state: 'exited', kind: 'edge' },
+              opts,
+            ));
+          }
+        }
+
+        state.trafficAnnouncements.delete(key);
+        state.trafficExitFrames.delete(key);
+      } else {
+        state.trafficExitFrames.set(key, n);
+      }
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 5: STOPPED_ON_TRACK (#97)
+    //
+    // A car is considered stopped when its lapDistPct has not changed by more
+    // than STOPPED_MOVEMENT_EPSILON AND it is off pit road. Once that state has
+    // persisted for STOPPED_ON_TRACK_MIN_DURATION_SEC, fire once on entry and
+    // once on exit. Pre-green guard: only runs after raceGreenFired.
+    // -------------------------------------------------------------------------
+    for (let i = 0; i < CAR_COUNT; i++) {
+      const cs = getOrCreateCarState(state, i);
+      const onPit = curr.carIdxOnPitRoad[i] !== 0;
+      const currPos = curr.carIdxPosition[i];
+
+      if (onPit || currPos <= 0) {
+        if (cs.isStoppedOnTrack) {
+          // Car entered pit road — emit exit
+          const stoppedCar = carRefFromRoster(state, i);
+          if (stoppedCar) {
+            events.push(buildEvent(
+              'STOPPED_ON_TRACK',
+              stoppedCar,
+              {
+                lapDistPct:         cs.lapDistPct,
+                stoppedDurationSec: cs.stoppedStartSessionTime !== null
+                  ? curr.sessionTime - cs.stoppedStartSessionTime : 0,
+                state: 'exited',
+                kind:  'edge',
+              },
+              opts,
+            ));
+          }
+        }
+        cs.stoppedStartSessionTime = null;
+        cs.isStoppedOnTrack = false;
+        continue;
+      }
+
+      const prevPct = prev.carIdxLapDistPct[i];
+      const currPct = curr.carIdxLapDistPct[i];
+      const moved   = Math.abs(currPct - prevPct) > STOPPED_MOVEMENT_EPSILON;
+
+      if (moved) {
+        if (cs.isStoppedOnTrack) {
+          // Car started moving — emit exited edge
+          const stoppedCar = carRefFromRoster(state, i);
+          if (stoppedCar) {
+            events.push(buildEvent(
+              'STOPPED_ON_TRACK',
+              stoppedCar,
+              {
+                lapDistPct:         currPct,
+                stoppedDurationSec: cs.stoppedStartSessionTime !== null
+                  ? curr.sessionTime - cs.stoppedStartSessionTime : 0,
+                state: 'exited',
+                kind:  'edge',
+              },
+              opts,
+            ));
+          }
+          cs.isStoppedOnTrack = false;
+        }
+        cs.stoppedStartSessionTime = null;
+        continue;
+      }
+
+      if (cs.stoppedStartSessionTime === null) {
+        cs.stoppedStartSessionTime = prev.sessionTime;
+      }
+
+      const stoppedFor = curr.sessionTime - cs.stoppedStartSessionTime;
+      if (stoppedFor >= STOPPED_ON_TRACK_MIN_DURATION_SEC && !cs.isStoppedOnTrack) {
+        const stoppedCar = carRefFromRoster(state, i);
+        if (stoppedCar) {
+          cs.isStoppedOnTrack = true;
+          events.push(buildEvent(
+            'STOPPED_ON_TRACK',
+            stoppedCar,
+            {
+              lapDistPct:         currPct,
+              stoppedDurationSec: stoppedFor,
+              state: 'entered',
+              kind:  'edge',
+            },
+            opts,
+          ));
+        }
+      }
+    }
+  } // end if (state.raceGreenFired)
 
   // -------------------------------------------------------------------------
   // Step 4: Update carState positions for next call

--- a/src/extensions/iracing/publisher/session-publisher/pit-lifecycle-detector.ts
+++ b/src/extensions/iracing/publisher/session-publisher/pit-lifecycle-detector.ts
@@ -1,0 +1,193 @@
+/**
+ * pit-lifecycle-detector.ts — Issue #198 (PR-B for #196)
+ *
+ * Session-wide pit lifecycle detection for all 64 car slots.
+ *
+ * Emits:
+ *   PIT_ENTRY          — CarIdxOnPitRoad false→true
+ *   PIT_STATIONARY     — car enters pit stall (CarIdxTrackSurface === 2)
+ *   PIT_STOP_COMPLETED — car leaves pit stall (CarIdxTrackSurface 2→anything else)
+ *   PIT_EXIT           — CarIdxOnPitRoad true→false
+ *
+ * Design notes:
+ *  - Per-car pit state is stored on CarState (added to session-state interface).
+ *  - stopType is derived from SessionFlags at the moment of PIT_ENTRY:
+ *      yellow/SC flags  → 'sc'
+ *      red flag         → 'red'
+ *      green/none       → 'green'
+ *  - Fuel/tire details are only populated for the player car via the
+ *    driver-publisher pit-incident-detector; this file stores 0/false stubs
+ *    so that the session-wide event still carries a consistent wire shape.
+ *  - Gap-to-neighbours at entry uses CarIdxF2Time (within-lap only; may be
+ *    inaccurate across lap boundaries — consumers should treat as indicative).
+ *  - iRacing TrackSurface values:
+ *      -1 = off track
+ *       0 = not in world
+ *       1 = on track
+ *       2 = in pit stall (stationary)
+ *       3 = approaching pits
+ *       4 = pit lane (moving)
+ */
+
+import type { TelemetryFrame, SessionState } from '../session-state';
+import { getOrCreateCarState, carRefFromRoster, buildEvent } from '../session-state';
+import type { PublisherEvent } from '../event-types';
+
+export interface PitLifecycleContext {
+  rigId: string;
+  raceSessionId: string;
+  /** playerCarIdx — from the iRacing session data. */
+  playerCarIdx: number;
+}
+
+const CAR_COUNT = 64;
+
+/** iRacing SessionFlags bitmask values relevant to pit stop type. */
+const FLAG_YELLOW     = 0x0010;
+const FLAG_YELLOW_WAVING = 0x0020;
+const FLAG_RED        = 0x0100;
+const FLAG_SAFETY_CAR_YELLOW = 0x0200;
+
+function deriveStopType(sessionFlags: number): 'green' | 'sc' | 'red' | 'unknown' {
+  if (sessionFlags & FLAG_RED) return 'red';
+  if (sessionFlags & (FLAG_YELLOW | FLAG_YELLOW_WAVING | FLAG_SAFETY_CAR_YELLOW)) return 'sc';
+  if (sessionFlags !== 0) return 'green';
+  return 'unknown';
+}
+
+// ---------------------------------------------------------------------------
+// detectPitLifecycle — pure-ish function (mutates carState)
+// ---------------------------------------------------------------------------
+
+export function detectPitLifecycle(
+  prev: TelemetryFrame | null,
+  curr: TelemetryFrame,
+  state: SessionState,
+  ctx: PitLifecycleContext,
+): PublisherEvent[] {
+  const events: PublisherEvent[] = [];
+
+  if (!prev) return events;
+
+  // #196: only emit pit events after the race has gone green
+  if (!state.raceGreenFired) return events;
+
+  const opts = { rigId: ctx.rigId, raceSessionId: ctx.raceSessionId, frame: curr };
+
+  for (let i = 0; i < CAR_COUNT; i++) {
+    if (curr.carIdxPosition[i] <= 0 && prev.carIdxPosition[i] <= 0) {
+      // Car not in world on either frame — skip
+      continue;
+    }
+
+    const cs = getOrCreateCarState(state, i);
+
+    const prevOnPit  = prev.carIdxOnPitRoad[i] !== 0;
+    const currOnPit  = curr.carIdxOnPitRoad[i] !== 0;
+    const prevSurface = prev.carIdxTrackSurface[i];
+    const currSurface = curr.carIdxTrackSurface[i];
+
+    // ------------------------------------------------------------------
+    // PIT_ENTRY: off pit road → on pit road
+    // ------------------------------------------------------------------
+    if (!prevOnPit && currOnPit) {
+      const car = carRefFromRoster(state, i);
+      if (car) {
+        const pos     = curr.carIdxPosition[i];
+        const lapGap  = curr.carIdxF2Time[i];
+        // Find car immediately ahead / behind in race position
+        let aheadIdx = -1;
+        let behindIdx = -1;
+        const entryPos = curr.carIdxPosition[i];
+        for (let j = 0; j < CAR_COUNT; j++) {
+          if (j === i) continue;
+          if (curr.carIdxPosition[j] <= 0) continue;
+          const jPos = curr.carIdxPosition[j];
+          if (jPos === entryPos - 1) aheadIdx = j;
+          if (jPos === entryPos + 1) behindIdx = j;
+        }
+        const carAhead  = aheadIdx  >= 0 ? carRefFromRoster(state, aheadIdx)  : undefined;
+        const carBehind = behindIdx >= 0 ? carRefFromRoster(state, behindIdx) : undefined;
+
+        const stopType = deriveStopType(curr.sessionFlags ?? 0);
+
+        events.push(buildEvent('PIT_ENTRY', car, {
+          entryLap:          curr.carIdxLapCompleted[i],
+          position:          pos,
+          gapToLeaderSec:    lapGap,
+          gapToCarAheadSec:  aheadIdx  >= 0 ? Math.max(0, curr.carIdxF2Time[aheadIdx])  : undefined,
+          gapToCarBehindSec: behindIdx >= 0 ? Math.max(0, curr.carIdxF2Time[behindIdx]) : undefined,
+          carAhead:          carAhead  ?? undefined,
+          carBehind:         carBehind ?? undefined,
+          stopType,
+        }, opts));
+
+        cs.pitEntrySessionTime = curr.sessionTime;
+        cs.pitEntryPosition    = pos;
+        cs.pitStopType         = stopType;
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // PIT_STATIONARY: car enters pit stall (trackSurface transitions to 2)
+    // ------------------------------------------------------------------
+    if (prevSurface !== 2 && currSurface === 2) {
+      const car = carRefFromRoster(state, i);
+      if (car) {
+        events.push(buildEvent('PIT_STATIONARY', car, {
+          arrivalSessionTime: curr.sessionTime,
+          fuelLevelOnEntry:   0, // player enrichment handled by driver-publisher
+        }, opts));
+        cs.stallArrivalSessionTime = curr.sessionTime;
+        cs.stallFuelOnEntry        = 0;
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // PIT_STOP_COMPLETED: car leaves pit stall (trackSurface 2 → other)
+    // ------------------------------------------------------------------
+    if (prevSurface === 2 && currSurface !== 2) {
+      const car = carRefFromRoster(state, i);
+      if (car) {
+        const stallMs = cs.stallArrivalSessionTime !== null
+          ? Math.round((curr.sessionTime - cs.stallArrivalSessionTime) * 1000)
+          : 0;
+
+        events.push(buildEvent('PIT_STOP_COMPLETED', car, {
+          stationaryMs:          stallMs,
+          stopType:              cs.pitStopType ?? 'unknown',
+          fuelAdded:             0,     // player enrichment in driver-publisher
+          tiresChanged:          false, // player enrichment in driver-publisher
+          exitPosition:          curr.carIdxPosition[i] > 0 ? curr.carIdxPosition[i] : 0,
+          deltaVsCarAheadSec:    undefined,
+        }, opts));
+
+        cs.stallArrivalSessionTime = null;
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // PIT_EXIT: on pit road → off pit road
+    // ------------------------------------------------------------------
+    if (prevOnPit && !currOnPit) {
+      const car = carRefFromRoster(state, i);
+      if (car) {
+        const exitPos    = curr.carIdxPosition[i];
+        const entryPos   = cs.pitEntryPosition ?? exitPos;
+        const posLost    = Math.max(0, exitPos - entryPos);
+
+        events.push(buildEvent('PIT_EXIT', car, {
+          exitLap:        curr.carIdxLapCompleted[i],
+          newPosition:    exitPos,
+          positionsLost:  posLost,
+        }, opts));
+
+        cs.pitEntrySessionTime = null;
+        cs.pitEntryPosition    = null;
+        cs.pitStopType         = null;
+      }
+    }
+  }
+
+  return events;
+}

--- a/src/extensions/iracing/publisher/session-publisher/safety-car-imminent-detector.ts
+++ b/src/extensions/iracing/publisher/session-publisher/safety-car-imminent-detector.ts
@@ -53,12 +53,18 @@ export function detectSafetyCarImminent(
   ctx: SafetyCarImminentContext,
 ): PublisherEvent[] {
   const events: PublisherEvent[] = [];
+
+  // #196 pre-green guard — suppress before race has gone green.
+  if (!state.raceGreenFired) return events;
+
   const now = curr.sessionTime;
 
-  // ---- Ingest this tick's STOPPED_ON_TRACK events ----
+  // ---- Ingest this tick's STOPPED_ON_TRACK 'entered' events only ----
   for (const ev of ctx.emittedThisTick) {
     if (ev.type !== 'STOPPED_ON_TRACK') continue;
     const p = ev.payload as StoppedOnTrackPayload;
+    // Only count rising-edge events; ignore 'exited' and 'refresh' kinds.
+    if (p.state === 'exited') continue;
     state.recentStoppedOnTrackEvents.push({
       sessionTime: now,
       carIdx:      ev.car.carIdx,

--- a/src/extensions/iracing/publisher/session-publisher/session-lifecycle-detector.ts
+++ b/src/extensions/iracing/publisher/session-publisher/session-lifecycle-detector.ts
@@ -118,11 +118,13 @@ export function detectSessionLifecycle(
     if (currState === SESSION_STATE.Racing && (curr.sessionFlags & FLAG_GREEN) !== 0) {
       const startType = prevState === SESSION_STATE.ParadeLaps ? 'rolling' : 'standing';
       events.push(buildEvent('RACE_GREEN', nocar, { startType }, opts));
+      state.raceGreenFired = true;
     }
 
     // RACE_CHECKERED — transition TO Checkered state
-    if (currState === SESSION_STATE.Checkered) {
+    if (currState === SESSION_STATE.Checkered && !state.checkeredFired) {
       events.push(buildEvent('RACE_CHECKERED', nocar, {}, opts));
+      state.checkeredFired = true;
     }
 
     // SESSION_ENDED — transition TO CoolDown
@@ -133,13 +135,14 @@ export function detectSessionLifecycle(
 
   // -------------------------------------------------------------------------
   // RACE_CHECKERED — flag bit fires before/without a state transition
-  // Guard: only emit once; skip if already emitted above via state transition.
+  // Guard: only emit once via the dedicated checkeredFired latch.
   // -------------------------------------------------------------------------
-  const checkeredAlreadyFired = state.lastSessionState >= SESSION_STATE.Checkered;
-  if (!checkeredAlreadyFired && (curr.sessionFlags & FLAG_CHECKERED) !== 0) {
+  if (!state.checkeredFired && (curr.sessionFlags & FLAG_CHECKERED) !== 0) {
+    // Only emit if not already emitted via the state-transition branch above
     const alreadyEmittedViaState = currState === SESSION_STATE.Checkered && prevState !== SESSION_STATE.Checkered;
     if (!alreadyEmittedViaState) {
       events.push(buildEvent('RACE_CHECKERED', nocar, {}, opts));
+      state.checkeredFired = true;
     }
   }
 

--- a/src/extensions/iracing/publisher/session-state.ts
+++ b/src/extensions/iracing/publisher/session-state.ts
@@ -275,6 +275,20 @@ export interface CarState {
   overallPositionHistory: number[];
   /** Stint lap times (seconds) — accumulated since the start of the current stint. */
   stintLapTimes: number[];
+
+  // ---- Pit lifecycle fields (#198 PR-B) ----
+  /** SessionTime when the car entered pit road (PIT_ENTRY edge). Null when off pit road. */
+  pitEntrySessionTime: number | null;
+  /** Race-condition stop type determined at PIT_ENTRY. */
+  pitStopType: 'green' | 'sc' | 'red' | 'unknown' | null;
+  /** SessionTime when the car first stopped in the pit stall (trackSurface 2). */
+  stallArrivalSessionTime: number | null;
+  /** FuelLevel (litres) when the car arrived in the stall (player car only). */
+  stallFuelOnEntry: number;
+
+  // ---- Incident tracking (#201 PR-E) ----
+  /** SessionTime of the most recent INCIDENT emission for this car (-Infinity = never). */
+  lastIncidentSessionTime: number | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -395,6 +409,17 @@ export interface SessionState {
   }>;
   /** sessionTime of the most recent SAFETY_CAR_IMMINENT emission (-Infinity = never). */
   lastSafetyCarImminentEmittedAt: number;
+
+  // ---- #196 fixes ----
+  /** True once RACE_GREEN has been emitted for this session.
+   *  Detectors use this to suppress pre-green state-based emissions
+   *  (STOPPED_ON_TRACK, LAPPED_TRAFFIC_AHEAD, BEING_LAPPED, SAFETY_CAR_IMMINENT). */
+  raceGreenFired: boolean;
+  /** Per-pair count of consecutive frames that a previously-latched traffic pair
+   *  has been above the exit-hysteresis threshold. Keyed like trafficAnnouncements. */
+  trafficExitFrames: Map<string, number>;
+  /** Whether RACE_CHECKERED has been emitted this session (prevents 53x flood). */
+  checkeredFired: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -435,6 +460,11 @@ function makeDefaultCarState(): CarState {
     classPositionHistory: [],
     overallPositionHistory: [],
     stintLapTimes: [],
+    pitEntrySessionTime: null,
+    pitStopType: null,
+    stallArrivalSessionTime: null,
+    stallFuelOnEntry: 0,
+    lastIncidentSessionTime: undefined,
   };
 }
 
@@ -478,6 +508,9 @@ export function createSessionState(raceSessionId: string, sessionUniqueId: numbe
     lastEngineWarnings: 0,
     recentStoppedOnTrackEvents: [],
     lastSafetyCarImminentEmittedAt: -Infinity,
+    raceGreenFired: false,
+    trafficExitFrames: new Map(),
+    checkeredFired: false,
   };
 }
 
@@ -497,16 +530,25 @@ export function battleKey(carA: number, carB: number): string {
 }
 
 /**
- * Returns a PublisherCarRef for the given carIdx, resolved from the session roster.
- * Returns `undefined` when the car is not yet in the roster so that callers
- * can skip emitting events without class context.
+ * Returns a `PublisherCarRef` for the given carIdx.
+ *
+ * If the roster entry is missing (e.g. the SDK's session YAML hasn't been
+ * parsed yet), a minimal ref carrying only `carIdx` is returned.  Consumers
+ * that need richer identity (name, class) should check whether `driverName`
+ * is present and decide whether to defer the event.  Callers can rely on
+ * this function **never** returning `undefined`, which eliminates the large
+ * number of `if (!carRef) continue` guards that were suppressing events
+ * before the roster was populated (#196 PR-C).
  */
 export function carRefFromRoster(
   state: SessionState,
   carIdx: number,
-): PublisherCarRef | undefined {
+): PublisherCarRef {
   const ref = state.knownRoster.get(carIdx);
-  if (!ref) return undefined;
+  if (!ref) {
+    // Roster not yet populated — return a minimal stub so events are not lost.
+    return { carIdx, carNumber: '', driverName: '', teamName: '', carClassShortName: '', carClassId: 0 };
+  }
   return {
     carIdx,
     carNumber:         ref.carNumber,


### PR DESCRIPTION
Closes #196, closes #197, closes #198, closes #199, closes #200, closes #201

## Summary

Addresses all five quality issues from issue #196 — a 69-min, 54-car GT3 race produced 40,993 publisher events of which ~88% were state-based flood events and 0 were pit lifecycle events.

---

## PR-A — Flood Suppression (#197)

- Added `raceGreenFired`, `checkeredFired`, `trafficExitFrames` to `SessionState`
- Gate traffic / stopped / safety-car-imminent detection behind `raceGreenFired`
- Fixed `RACE_CHECKERED` 53x repeat with `checkeredFired` latch
- Traffic latch now uses hysteresis (requires `TRAFFIC_EXIT_MIN_FRAMES = 2` consecutive frames above `TRAFFIC_EXIT_GAP_SEC = 3.5 s`) before releasing
- All traffic/stopped events emit `state: 'entered' | 'exited'` + `kind: 'edge'`

## PR-B — Pit Lifecycle (#198)

- New `session-publisher/pit-lifecycle-detector.ts`: emits `PIT_ENTRY`, `PIT_STATIONARY`, `PIT_STOP_COMPLETED`, `PIT_EXIT` for all 64 cars
- `PitEntryPayload` extended with `stopType`, `carAhead/Behind`, `gapToCarAheadSec/BehindSec`
- New `PitStationaryPayload` and `PitStopCompletedPayload` types
- Wired into session orchestrator

## PR-C — Empty Battle Payloads (#199)

- `carRefFromRoster` now always returns a `PublisherCarRef` (stub with empty strings if car not in roster) instead of `undefined`
- `OvertakePayload` gains `classPosition`, `forPosition`, `gapAfterSec`
- `BattlePayload` gains `role: 'engager' | 'engaged'` and `forPosition`
- `BATTLE_ENGAGED/CLOSING/BROKEN` emit two events per trigger (one per car, dual-perspective)

## PR-D — Lap Intervals (#200)

- `LapCompletedPayload` gains `intervalAheadSec`, `intervalBehindSec`, `carAhead`, `carBehind`
- `detectLapCompleted` builds `posToCarIdx` map and computes per-car neighbour gaps on every lap completion

## PR-E — Incident Detection (#201)

- New `session-publisher/incident-detector.ts`: emits `INCIDENT` for all 64 cars
- Three detection triggers: `OFF_TRACK` (trackSurface edge), `LOSS_OF_CONTROL` (kinematic discontinuity ≥ 10 m/s speed drop on track), `CONTACT` (two-car proximity with simultaneous disturbance)
- Per-car cooldown of 8 s (`INCIDENT_COOLDOWN_SEC`)
- `INCIDENT` added to `PublisherEventType`, `EventPayloadMap`, `HIGH_PRIORITY_EVENTS`

---

## Tests

All **1016 tests** pass. Updated 5 existing test files to align with new contracts:
- `overtake-battle-detector.test.ts` — `raceGreenFired = true` in `makeState()`, dual-perspective BATTLE_CLOSING expects 2 events, hysteresis re-fire test uses 2 wide frames
- `safety-car-imminent-detector.test.ts` — `raceGreenFired = true` in `beforeEach`
- `session-lifecycle-detector.test.ts` — `checkeredFired = true` in duplicate-checkered test
- `session-state.test.ts` — `carRefFromRoster` now returns stub instead of `undefined`
- `snapshot-emitter.ts` — roster check switched to `state.knownRoster.has()` instead of null-check on stub
