### PR TITLE
feat(obs): per-host scene curation with descriptions (closes #203)

### DIFF
--- a/src/extensions/obs/package.json
+++ b/src/extensions/obs/package.json
@@ -4,14 +4,14 @@
   "main": "index.js",
   "displayName": "OBS Studio Integration",
   "description": "Provides OBS Studio scene switching and status monitoring.",
-  "aiContext": "The OBS extension switches the active OBS Studio video scene.\n- obs.switchScene: changes the active scene. sceneName must exactly match one of the valid scene names listed in ALL VALID OBS SCENES — never invent scene names. Always follow with a system.wait step of at least 1000ms to allow the scene to render before the next action.",
+  "aiContext": "The OBS extension switches the active OBS Studio video scene.\n- obs.switchScene: changes the active scene. sceneName MUST exactly match one of the names in ALL VALID OBS SCENES — never invent scene names.\n- Each scene in ALL VALID OBS SCENES carries a 'description' written by the Director operator explaining when the scene is appropriate (e.g. 'single-driver only', 'multi-car wide shot during pace lap', 'use after a driver swap'). You MUST select a scene whose description fits the current race context (number of drivers in the car, session type, on-track situation). If no scene's description fits, prefer NOT switching rather than picking a mismatched scene.\n- Always follow obs.switchScene with a system.wait step of at least 1000ms to allow the scene to render before the next action.",
   "contributes": {
     "intents": [
       {
         "intent": "obs.switchScene",
         "title": "Switch OBS Scene",
         "category": "broadcast",
-        "description": "Changes the active OBS Studio scene. sceneName must exactly match a scene name from ALL VALID OBS SCENES. Always follow with a system.wait step of at least 1000ms.",
+        "description": "Changes the active OBS Studio scene. sceneName must exactly match a scene name from ALL VALID OBS SCENES. Pick a scene whose operator-provided description matches the current race context. Always follow with a system.wait step of at least 1000ms.",
         "schema": {
           "type": "object",
           "properties": {

--- a/src/extensions/obs/renderer/Panel.tsx
+++ b/src/extensions/obs/renderer/Panel.tsx
@@ -1,14 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import { Activity, Aperture, AlertTriangle, Plug, PlugZap, Settings, Save } from 'lucide-react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { Activity, Aperture, AlertTriangle, Plug, PlugZap, Settings, Save, Sparkles, Eye, EyeOff } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
 import { useSetPageHeader } from '../../../renderer/contexts/PageHeaderContext';
 
+type SceneCuration = { name: string; included: boolean; description: string };
+
 export const ObsPanel = () => {
-  const [activeTab, setActiveTab] = useState<'status' | 'settings'>('status');
+  const [activeTab, setActiveTab] = useState<'status' | 'scenes' | 'settings'>('status');
   const [connected, setConnected] = useState(false);
   const [missingScenes, setMissingScenes] = useState<string[]>([]);
   const [availableScenes, setAvailableScenes] = useState<string[]>([]);
@@ -22,6 +25,9 @@ export const ObsPanel = () => {
   const [autoConnect, setAutoConnect] = useState(false);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [saveMessage, setSaveMessage] = useState('');
+
+  // Issue #203: per-host scene curation
+  const [curations, setCurations] = useState<SceneCuration[]>([]);
 
   // Push header into the global app bar
   useSetPageHeader({
@@ -51,6 +57,63 @@ export const ObsPanel = () => {
     const interval = setInterval(checkStatus, 2000);
     return () => clearInterval(interval);
   }, []);
+
+  // Issue #203: poll scene curations (reconciled in main when GetSceneList runs)
+  const refreshCurations = useCallback(async () => {
+    if (window.electronAPI?.obsGetSceneCurations) {
+      try {
+        const list = await window.electronAPI.obsGetSceneCurations();
+        setCurations(list || []);
+      } catch (e) {
+        console.error('Failed to load OBS scene curations', e);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshCurations();
+    const i = setInterval(refreshCurations, 2000);
+    return () => clearInterval(i);
+  }, [refreshCurations]);
+
+  const handleToggleIncluded = async (name: string, included: boolean) => {
+    const existing = curations.find((c) => c.name === name);
+    const description = existing?.description ?? '';
+    setCurations((prev) => {
+      const found = prev.some((c) => c.name === name);
+      if (found) return prev.map((c) => (c.name === name ? { ...c, included } : c));
+      return [...prev, { name, included, description }];
+    });
+    try {
+      await window.electronAPI.obsSetSceneCuration({ name, included, description });
+    } catch (e) {
+      console.error('Failed to save scene curation', e);
+      refreshCurations();
+    }
+  };
+
+  const handleDescriptionBlur = async (name: string, description: string) => {
+    const existing = curations.find((c) => c.name === name);
+    const included = existing?.included ?? false;
+    if (existing && existing.description === description) return;
+    try {
+      await window.electronAPI.obsSetSceneCuration({ name, included, description });
+    } catch (e) {
+      console.error('Failed to save scene description', e);
+      refreshCurations();
+    }
+  };
+
+  const handleBulkInclude = async (included: boolean) => {
+    setCurations((prev) => prev.map((c) => ({ ...c, included })));
+    try {
+      await window.electronAPI.obsBulkSetIncluded(included);
+    } catch (e) {
+      console.error('Failed bulk include', e);
+    } finally {
+      refreshCurations();
+    }
+  };
 
   // Load config once
   useEffect(() => {
@@ -134,6 +197,16 @@ export const ObsPanel = () => {
             Status
           </button>
           <button
+            onClick={() => setActiveTab('scenes')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              activeTab === 'scenes'
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-muted-foreground hover:bg-white/10'
+            }`}
+          >
+            Scenes
+          </button>
+          <button
             onClick={() => setActiveTab('settings')}
             className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
               activeTab === 'settings'
@@ -147,7 +220,7 @@ export const ObsPanel = () => {
       </div>
 
       <div className="flex-1">
-        {activeTab === 'status' ? (
+        {activeTab === 'status' && (
           <div className="space-y-6">
             {/* Connection banner */}
             <div className="flex justify-between items-center bg-card p-4 rounded-lg border border-border">
@@ -253,8 +326,72 @@ export const ObsPanel = () => {
               </CardContent>
             </Card>
           </div>
-        ) : (
-          /* Settings tab */
+        )}
+
+        {activeTab === 'scenes' && (
+          <div className="space-y-6">
+            <div className="bg-secondary/10 border border-secondary/40 rounded-lg p-4 flex items-start gap-3">
+              <Sparkles className="w-5 h-5 text-secondary mt-0.5" />
+              <div className="text-sm text-secondary-foreground/90">
+                <p className="font-bold uppercase font-rajdhani tracking-wider text-secondary mb-1">Scene Curation</p>
+                <p>
+                  Race Control's planner only sees scenes you <strong>include</strong>. New scenes default to
+                  <strong> excluded</strong>. Add a short description so the planner knows when to use each scene
+                  (e.g. "single-driver shot", "multi-car wide during pace lap"). Changes save automatically.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground font-rajdhani uppercase tracking-wider">
+                {curations.length} scene{curations.length === 1 ? '' : 's'}
+                {host ? ` for ${host}` : ''}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleBulkInclude(true)}
+                  disabled={curations.length === 0}
+                >
+                  <Eye className="w-4 h-4 mr-2" />
+                  Include all
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleBulkInclude(false)}
+                  disabled={curations.length === 0}
+                >
+                  <EyeOff className="w-4 h-4 mr-2" />
+                  Exclude all
+                </Button>
+              </div>
+            </div>
+
+            {curations.length === 0 ? (
+              <Card className="bg-card border-border">
+                <CardContent className="p-6 text-sm text-muted-foreground italic">
+                  {connected ? 'No scenes available from OBS yet.' : 'Connect to OBS to discover scenes.'}
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="space-y-3">
+                {curations.map((c) => (
+                  <SceneCurationRow
+                    key={c.name}
+                    curation={c}
+                    isActive={currentScene === c.name}
+                    onToggle={(included) => handleToggleIncluded(c.name, included)}
+                    onDescriptionBlur={(desc) => handleDescriptionBlur(c.name, desc)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'settings' && (
           <Card className="bg-card border-border">
             <CardHeader>
               <CardTitle className="text-muted-foreground text-sm uppercase font-rajdhani tracking-widest">
@@ -318,5 +455,59 @@ export const ObsPanel = () => {
         )}
       </div>
     </div>
+  );
+};
+
+type SceneCurationRowProps = {
+  curation: SceneCuration;
+  isActive: boolean;
+  onToggle: (included: boolean) => void;
+  onDescriptionBlur: (description: string) => void;
+};
+
+const SceneCurationRow: React.FC<SceneCurationRowProps> = ({ curation, isActive, onToggle, onDescriptionBlur }) => {
+  const [description, setDescription] = useState(curation.description);
+
+  // Sync local state when the prop changes externally (e.g. bulk toggle or refresh)
+  useEffect(() => {
+    setDescription(curation.description);
+  }, [curation.description]);
+
+  return (
+    <Card className={`bg-card border-border ${isActive ? 'ring-1 ring-primary/50' : ''}`}>
+      <CardContent className="p-4">
+        <div className="flex items-start gap-4">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-2">
+              <span className="font-bold uppercase font-rajdhani tracking-wider text-foreground truncate">
+                {curation.name}
+              </span>
+              {isActive && (
+                <span className="text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded bg-primary/20 text-primary border border-primary/40">
+                  Live
+                </span>
+              )}
+            </div>
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              onBlur={() => onDescriptionBlur(description)}
+              placeholder={curation.included
+                ? 'Describe when the planner should use this scene (e.g. "single-driver close-up", "wide pace-lap shot").'
+                : 'Include this scene to add a description.'}
+              disabled={!curation.included}
+              rows={2}
+              className="bg-background border-border resize-none text-sm"
+            />
+          </div>
+          <div className="flex flex-col items-center gap-2 pt-1">
+            <Switch checked={curation.included} onCheckedChange={onToggle} />
+            <span className="text-[10px] uppercase tracking-widest text-muted-foreground font-rajdhani">
+              {curation.included ? 'Included' : 'Excluded'}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 };

--- a/src/main/config-service.ts
+++ b/src/main/config-service.ts
@@ -3,6 +3,17 @@ import Store from 'electron-store';
 import { safeStorage } from 'electron';
 import { randomUUID } from 'crypto';
 
+/**
+ * Per-scene curation entry stored under `obs.sceneCurations[host]` (issue #203).
+ * `included = true` means the scene is exposed to Race Control with its `description`.
+ * New scenes default to `included: false`. Stale scenes are removed.
+ */
+export interface ObsSceneCuration {
+  name: string;
+  included: boolean;
+  description: string;
+}
+
 interface AppConfig {
   youtube: {
     enabled: boolean;
@@ -14,6 +25,12 @@ interface AppConfig {
     host?: string;
     password?: string;
     autoConnect?: boolean;
+    /**
+     * Per-host scene curation (issue #203). Key = OBS host string (matches `host`).
+     * Only included scenes are exposed to Race Control via the check-in payload.
+     * Stale scenes (no longer present in OBS) are removed on the next reconciliation.
+     */
+    sceneCurations?: Record<string, ObsSceneCuration[]>;
   };
   iracing: {
     enabled: boolean;
@@ -46,7 +63,10 @@ const schema = {
       enabled: { type: 'boolean', default: true },
       host: { type: 'string' },
       password: { type: 'string' },
-      autoConnect: { type: 'boolean', default: false }
+      autoConnect: { type: 'boolean', default: false },
+      // sceneCurations: Record<host, ObsSceneCuration[]> — issue #203.
+      // Schema kept loose (object); per-entry shape is enforced in ObsService.
+      sceneCurations: { type: 'object', default: {} },
     },
     default: {}
   },

--- a/src/main/director-types.ts
+++ b/src/main/director-types.ts
@@ -266,6 +266,17 @@ export interface CameraGroup {
   groupName: string;
 }
 
+/**
+ * Operator-curated OBS scene exposed to Race Control (issue #203).
+ * `description` explains when the scene is appropriate (driver count, session
+ * type, on-track situation) so the AI Planner can pick a fit-for-purpose scene
+ * instead of any arbitrary scene name.
+ */
+export interface SceneCapability {
+  name: string;
+  description: string;
+}
+
 /** Driver discovered at runtime from the simulator session. */
 export interface CapabilityDriver {
   carNumber: string;
@@ -279,8 +290,13 @@ export interface DirectorCapabilities {
   connections: Record<string, ConnectionHealth>;
   /** iRacing camera groups cached from the SDK at check-in time. */
   cameraGroups?: CameraGroup[];
-  /** Available OBS scenes discovered via GetSceneList at check-in time. */
-  scenes?: string[];
+  /**
+   * Operator-curated OBS scenes exposed to Race Control (issue #203).
+   * Each entry carries a free-text `description` so the Planner can choose
+   * a scene that fits the current race context (driver count, session type,
+   * on-track situation). Only opted-in scenes for the connected host are included.
+   */
+  scenes?: SceneCapability[];
   /** Drivers in the current simulator session at check-in time. */
   drivers?: CapabilityDriver[];
   /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -236,12 +236,13 @@ app.on('ready', () => {
       && stableForMs != null
       && stableForMs >= IDENTITY_STABILITY_MS;
 
-    // #192: use extensionHost.getObsScenes() — populated by the obs.scenes event cache
-    // maintained in the extension host. Warn when OBS is connected but scenes are empty
-    // so regressions are visible in logs without needing to inspect the check-in payload.
-    const scenes: string[] = extensionHost.getObsScenes();
+    // #192 / #203: source of truth for scenes is the operator-curated list maintained
+    // by ObsService. Only scenes the operator has opted in (per OBS host) are exposed
+    // to Race Control, each with a description that lets the Planner pick a scene
+    // that fits the current race context.
+    const scenes = obsService.getIncludedSceneCapabilities();
     if (scenes.length === 0 && connections['director-obs']?.connected) {
-      console.warn('[Capabilities] OBS is connected but scene list is empty — check-in will report no scenes. Verify OBS scene fetch succeeded.');
+      console.warn('[Capabilities] OBS is connected but no scenes are opted-in — check-in will report no scenes. Visit the OBS panel to curate scenes.');
     }
 
     // #112: only include broadcast intents — exclude operational/query
@@ -622,6 +623,21 @@ app.on('ready', () => {
 
   ipcMain.handle('obs:save-settings', async (event, settings: { host: string; password?: string; autoConnect: boolean }) => {
     obsService.saveConfig(settings.host, settings.password, settings.autoConnect);
+    return true;
+  });
+
+  // Issue #203: per-host scene curation
+  ipcMain.handle('obs:get-scene-curations', () => {
+    return obsService.getSceneCurations();
+  });
+
+  ipcMain.handle('obs:set-scene-curation', (_event, curation: { name: string; included: boolean; description: string }) => {
+    obsService.setSceneCuration(curation);
+    return true;
+  });
+
+  ipcMain.handle('obs:bulk-set-included', (_event, included: boolean) => {
+    obsService.bulkSetIncluded(included);
     return true;
   });
 

--- a/src/main/modules/obs-core/obs-service.curation.test.ts
+++ b/src/main/modules/obs-core/obs-service.curation.test.ts
@@ -33,14 +33,12 @@ vi.mock('../../config-service', async () => {
 
 import { ObsService } from './obs-service';
 
-type Svc = ObsService & {
-  availableScenes: string[];
-  currentHost?: string;
-  reconcileSceneCurations: () => void;
-};
+// Cast to any to access private fields in tests without collapsing the type.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TestSvc = ObsService & Record<string, any>;
 
-const newService = (host: string, scenes: string[]): Svc => {
-  const svc = new ObsService() as Svc;
+const newService = (host: string, scenes: string[]): TestSvc => {
+  const svc = new ObsService() as TestSvc;
   svc.currentHost = host;
   svc.availableScenes = scenes;
   return svc;
@@ -141,7 +139,7 @@ describe('ObsService scene curation (issue #203)', () => {
   });
 
   it('getSceneCurations returns empty when no host is set', () => {
-    const svc = new ObsService() as Svc;
+    const svc = new ObsService() as TestSvc;
     expect(svc.getSceneCurations()).toEqual([]);
   });
 });

--- a/src/main/modules/obs-core/obs-service.curation.test.ts
+++ b/src/main/modules/obs-core/obs-service.curation.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for issue #203: per-host scene curation.
+ *
+ * Covers reconciliation behavior, per-host isolation, IPC-style mutators,
+ * and the capability filter exposed to the check-in payload.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Stub electron BEFORE importing ObsService — config-service touches `app`.
+vi.mock('electron', () => ({
+  app: { getPath: () => process.cwd() },
+}));
+
+// Mock telemetry to keep the service quiet.
+vi.mock('../../telemetry-service', () => ({
+  telemetryService: {
+    trackEvent: vi.fn(),
+    trackException: vi.fn(),
+    trackDependency: vi.fn(),
+  },
+}));
+
+// In-memory config store used by both the service and the test assertions.
+const store: Record<string, any> = {};
+vi.mock('../../config-service', async () => {
+  return {
+    configService: {
+      get: vi.fn((key: string) => store[key]),
+      set: vi.fn((key: string, value: any) => { store[key] = value; }),
+    },
+  };
+});
+
+import { ObsService } from './obs-service';
+
+type Svc = ObsService & {
+  availableScenes: string[];
+  currentHost?: string;
+  reconcileSceneCurations: () => void;
+};
+
+const newService = (host: string, scenes: string[]): Svc => {
+  const svc = new ObsService() as Svc;
+  svc.currentHost = host;
+  svc.availableScenes = scenes;
+  return svc;
+};
+
+describe('ObsService scene curation (issue #203)', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+    store.obs = {};
+  });
+
+  it('reconcile adds new scenes as excluded by default', () => {
+    const svc = newService('ws://host-a:4455', ['Race', 'Replay']);
+    svc.reconcileSceneCurations();
+    const list = svc.getSceneCurations();
+    expect(list).toEqual([
+      { name: 'Race', included: false, description: '' },
+      { name: 'Replay', included: false, description: '' },
+    ]);
+  });
+
+  it('reconcile preserves existing inclusion + description', () => {
+    store.obs = {
+      sceneCurations: {
+        'ws://host-a:4455': [
+          { name: 'Race', included: true, description: 'main shot' },
+        ],
+      },
+    };
+    const svc = newService('ws://host-a:4455', ['Race', 'Replay']);
+    svc.reconcileSceneCurations();
+    const list = svc.getSceneCurations();
+    expect(list).toEqual([
+      { name: 'Race', included: true, description: 'main shot' },
+      { name: 'Replay', included: false, description: '' },
+    ]);
+  });
+
+  it('reconcile removes stale scenes immediately', () => {
+    store.obs = {
+      sceneCurations: {
+        'ws://host-a:4455': [
+          { name: 'Race', included: true, description: 'main shot' },
+          { name: 'Gone', included: true, description: 'will be removed' },
+        ],
+      },
+    };
+    const svc = newService('ws://host-a:4455', ['Race']);
+    svc.reconcileSceneCurations();
+    expect(svc.getSceneCurations()).toEqual([
+      { name: 'Race', included: true, description: 'main shot' },
+    ]);
+  });
+
+  it('curations are isolated per host', () => {
+    const a = newService('ws://host-a:4455', ['Race']);
+    const b = newService('ws://host-b:4455', ['Garage']);
+    a.reconcileSceneCurations();
+    b.reconcileSceneCurations();
+    a.setSceneCuration({ name: 'Race', included: true, description: 'A only' });
+    expect(a.getSceneCurations()).toEqual([
+      { name: 'Race', included: true, description: 'A only' },
+    ]);
+    expect(b.getSceneCurations()).toEqual([
+      { name: 'Garage', included: false, description: '' },
+    ]);
+  });
+
+  it('setSceneCuration ignores names not in availableScenes', () => {
+    const svc = newService('ws://host-a:4455', ['Race']);
+    svc.reconcileSceneCurations();
+    svc.setSceneCuration({ name: 'Phantom', included: true, description: 'nope' });
+    expect(svc.getSceneCurations().find(c => c.name === 'Phantom')).toBeUndefined();
+  });
+
+  it('bulkSetIncluded toggles all live scenes', () => {
+    const svc = newService('ws://host-a:4455', ['Race', 'Replay']);
+    svc.reconcileSceneCurations();
+    svc.setSceneCuration({ name: 'Race', included: true, description: 'desc' });
+    svc.bulkSetIncluded(false);
+    expect(svc.getSceneCurations().every(c => !c.included)).toBe(true);
+    // Description preserved through bulk toggle.
+    expect(svc.getSceneCurations().find(c => c.name === 'Race')?.description).toBe('desc');
+    svc.bulkSetIncluded(true);
+    expect(svc.getSceneCurations().every(c => c.included)).toBe(true);
+  });
+
+  it('getIncludedSceneCapabilities returns only included scenes with descriptions', () => {
+    const svc = newService('ws://host-a:4455', ['Race', 'Replay', 'Garage']);
+    svc.reconcileSceneCurations();
+    svc.setSceneCuration({ name: 'Race', included: true, description: 'main shot' });
+    svc.setSceneCuration({ name: 'Replay', included: true, description: '' });
+    svc.setSceneCuration({ name: 'Garage', included: false, description: 'unused' });
+    expect(svc.getIncludedSceneCapabilities()).toEqual([
+      { name: 'Race', description: 'main shot' },
+      { name: 'Replay', description: '' },
+    ]);
+  });
+
+  it('getSceneCurations returns empty when no host is set', () => {
+    const svc = new ObsService() as Svc;
+    expect(svc.getSceneCurations()).toEqual([]);
+  });
+});

--- a/src/main/modules/obs-core/obs-service.ts
+++ b/src/main/modules/obs-core/obs-service.ts
@@ -1,6 +1,6 @@
 import OBSWebSocket from 'obs-websocket-js';
 import { telemetryService } from '../../telemetry-service';
-import { configService } from '../../config-service';
+import { configService, ObsSceneCuration } from '../../config-service';
 
 export class ObsService {
     private obs: OBSWebSocket;
@@ -133,9 +133,105 @@ export class ObsService {
             this.availableScenes = (response.scenes as any[]).map((s: any) => s.sceneName) as string[];
             this.currentScene = (response as any).currentProgramSceneName || '';
             console.log('[ObsService] Fetched scenes', this.availableScenes, 'current:', this.currentScene);
+            this.reconcileSceneCurations();
         } catch (error) {
             console.error('[ObsService] Failed to fetch scenes', error);
         }
+    }
+
+    /**
+     * Issue #203: reconcile the per-host scene-curation list against the live scenes
+     * returned by OBS. New scenes are added with `included: false` (opt-in by default).
+     * Stale scenes (no longer present in OBS) are removed immediately to keep storage simple.
+     */
+    private reconcileSceneCurations(): void {
+        if (!this.currentHost) return;
+        const obsConfig = (configService.get('obs') || {}) as any;
+        const all: Record<string, ObsSceneCuration[]> = obsConfig.sceneCurations || {};
+        const existing = all[this.currentHost] || [];
+        const byName = new Map(existing.map(c => [c.name, c]));
+
+        const next: ObsSceneCuration[] = this.availableScenes.map(name => {
+            const prev = byName.get(name);
+            return prev
+                ? { name, included: prev.included, description: prev.description }
+                : { name, included: false, description: '' };
+        });
+
+        // Only persist if changed (avoid unnecessary disk writes).
+        if (curationsEqual(existing, next)) return;
+
+        all[this.currentHost] = next;
+        obsConfig.sceneCurations = all;
+        configService.set('obs', obsConfig);
+        console.log(`[ObsService] Reconciled ${next.length} scene curations for ${this.currentHost}`);
+    }
+
+    /**
+     * Returns the curation list for the currently connected host.
+     * Always reflects the latest OBS scene list (reconciled on fetch).
+     */
+    public getSceneCurations(): ObsSceneCuration[] {
+        if (!this.currentHost) return [];
+        const obsConfig = (configService.get('obs') || {}) as any;
+        const all: Record<string, ObsSceneCuration[]> = obsConfig.sceneCurations || {};
+        return all[this.currentHost] ? [...all[this.currentHost]] : [];
+    }
+
+    /**
+     * Persist a single scene curation entry for the current host.
+     * The scene must currently exist in `availableScenes`; otherwise the call is ignored
+     * (stale entries are removed by reconciliation).
+     */
+    public setSceneCuration(curation: ObsSceneCuration): void {
+        if (!this.currentHost) return;
+        if (!this.availableScenes.includes(curation.name)) {
+            console.warn(`[ObsService] setSceneCuration ignored — '${curation.name}' is not a live scene`);
+            return;
+        }
+        const obsConfig = (configService.get('obs') || {}) as any;
+        const all: Record<string, ObsSceneCuration[]> = obsConfig.sceneCurations || {};
+        const list = all[this.currentHost] ? [...all[this.currentHost]] : [];
+        const idx = list.findIndex(c => c.name === curation.name);
+        const next: ObsSceneCuration = {
+            name: curation.name,
+            included: !!curation.included,
+            description: curation.description ?? '',
+        };
+        if (idx >= 0) list[idx] = next; else list.push(next);
+        all[this.currentHost] = list;
+        obsConfig.sceneCurations = all;
+        configService.set('obs', obsConfig);
+    }
+
+    /** Bulk-toggle the `included` flag for every live scene on the current host. */
+    public bulkSetIncluded(included: boolean): void {
+        if (!this.currentHost) return;
+        const obsConfig = (configService.get('obs') || {}) as any;
+        const all: Record<string, ObsSceneCuration[]> = obsConfig.sceneCurations || {};
+        const existing = all[this.currentHost] || [];
+        const byName = new Map(existing.map(c => [c.name, c]));
+        const next: ObsSceneCuration[] = this.availableScenes.map(name => {
+            const prev = byName.get(name);
+            return {
+                name,
+                included,
+                description: prev?.description ?? '',
+            };
+        });
+        all[this.currentHost] = next;
+        obsConfig.sceneCurations = all;
+        configService.set('obs', obsConfig);
+    }
+
+    /**
+     * Returns the scenes the operator has opted in for the current host, each with its
+     * description. Used by the capabilities builder to populate the check-in payload.
+     */
+    public getIncludedSceneCapabilities(): Array<{ name: string; description: string }> {
+        return this.getSceneCurations()
+            .filter(c => c.included && this.availableScenes.includes(c.name))
+            .map(c => ({ name: c.name, description: c.description }));
     }
 
     public async switchScene(sceneName: string) {
@@ -203,4 +299,16 @@ export class ObsService {
         }
         return this.availableScenes;
     }
+}
+
+function curationsEqual(a: ObsSceneCuration[], b: ObsSceneCuration[]): boolean {
+    if (a.length !== b.length) return false;
+    const byName = new Map(a.map(c => [c.name, c]));
+    for (const item of b) {
+        const prev = byName.get(item.name);
+        if (!prev) return false;
+        if (prev.included !== item.included) return false;
+        if (prev.description !== item.description) return false;
+    }
+    return true;
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -49,6 +49,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   obsDisconnect: () => ipcRenderer.invoke('obs:disconnect'),
   obsGetConfig: () => ipcRenderer.invoke('obs:get-config'),
   obsSaveSettings: (settings: { host: string; password?: string; autoConnect: boolean }) => ipcRenderer.invoke('obs:save-settings', settings),
+  // Issue #203: per-host scene curation
+  obsGetSceneCurations: () => ipcRenderer.invoke('obs:get-scene-curations'),
+  obsSetSceneCuration: (curation: { name: string; included: boolean; description: string }) => ipcRenderer.invoke('obs:set-scene-curation', curation),
+  obsBulkSetIncluded: (included: boolean) => ipcRenderer.invoke('obs:bulk-set-included', included),
   
   // Discord API
   discordGetStatus: () => ipcRenderer.invoke('discord:get-status'),

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -196,6 +196,10 @@ export interface IElectronAPI {
   obsDisconnect: () => Promise<void>;
   obsGetConfig: () => Promise<{ host: string; passwordSet: boolean; autoConnect: boolean }>;
   obsSaveSettings: (settings: { host: string; password?: string; autoConnect: boolean }) => Promise<boolean>;
+  // Issue #203: per-host scene curation
+  obsGetSceneCurations: () => Promise<Array<{ name: string; included: boolean; description: string }>>;
+  obsSetSceneCuration: (curation: { name: string; included: boolean; description: string }) => Promise<boolean>;
+  obsBulkSetIncluded: (included: boolean) => Promise<boolean>;
   discordGetStatus: () => Promise<{ connected: boolean; channelName?: string; lastMessage?: string; messagesSent: number }>;
   discordConnect: (token?: string, channelId?: string) => Promise<void>;
   discordDisconnect: () => Promise<void>;

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -15,6 +15,8 @@
   ],
   "exclude": [
     "src/extensions/**/renderer/*",
-    "src/extensions/**/renderer/**/*"
+    "src/extensions/**/renderer/**/*",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
Closes #203. Coordinates with racecontrol#347.

## What

Operators can now curate which OBS scenes Race Control's planner sees, **per OBS host**, and attach a free-text description explaining when each scene is appropriate.

## UX

A new **Scenes** tab on the OBS panel:

- One row per scene currently in OBS — name, included toggle, description textarea, "Live" badge when active.
- New scenes default to **excluded** (opt-in).
- Stale scenes (no longer in OBS) are **removed immediately** on the next `GetSceneList` poll — kept simple per #203 discussion.
- **Auto-saves** on toggle change and on description blur — no Save button.
- Bulk **Include all** / **Exclude all** buttons.
- Curations are stored per OBS host string (e.g. `ws://localhost:4455` vs `ws://studio-pc:4455` are independent).

## Wire shape (capabilities sent on check-in)

`DirectorCapabilities.scenes` changed:

```diff
- scenes?: string[];
+ scenes?: Array<{ name: string; description: string }>;
```

Race Control side coordinated in margic/racecontrol#347 (OpenAPI fragment + Planner prompt update + backward-compat plan).

## Files

- `src/main/config-service.ts` — `ObsSceneCuration` interface + `obs.sceneCurations` field keyed by host.
- `src/main/modules/obs-core/obs-service.ts` — owns curation state. `reconcileSceneCurations()` runs after each `GetSceneList`. New: `getSceneCurations`, `setSceneCuration`, `bulkSetIncluded`, `getIncludedSceneCapabilities`.
- `src/main/director-types.ts` — `SceneCapability` interface; `scenes` field is now `SceneCapability[]`.
- `src/main/main.ts` — capabilities builder reads from `obsService.getIncludedSceneCapabilities()` (bypassing the extension-host scene cache). 3 new IPC handlers.
- `src/main/preload.ts` + `src/renderer/types.d.ts` — IPC bindings.
- `src/extensions/obs/renderer/Panel.tsx` — Scenes tab + `SceneCurationRow` component.
- `src/extensions/obs/package.json` — `aiContext` + `obs.switchScene` intent description updated so the planner knows to consult each scene's description and prefer a no-op over a mismatched scene.

## Tests

- New `src/main/modules/obs-core/obs-service.curation.test.ts` (8 tests) covers: default-excluded, preserved-on-rediscover, immediate-stale-removal, per-host isolation, ignore-unknown-scene, bulk toggle preserves descriptions, capability filter, no-host fallback.
- Full suite: **1024/1024 passing**.

## Notes

- `ObsService` is the source of truth for curation, not the extension `cachedObsScenes`. The capabilities builder calls it directly so descriptions flow into check-in without round-tripping the extension event bus.
- electron-store schema for `sceneCurations` is kept loose (`type: 'object'`) — per-entry shape is enforced in code. A deep `additionalProperties` schema collided with `electron-store`'s `Schema<T>` `as const` typing; runtime validation in `ObsService` covers it.