### PR TITLE
chore: bump version to 0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "director",
-  "version": "0.3.3",
+  "version": "0.3.6",
   "description": "Sim RaceCenter Director UI App",
   "main": "dist-electron/main/main.js",
   "scripts": {


### PR DESCRIPTION
Bumps `package.json` version to `0.3.6` to reflect the changes shipped in PR #204 (per-host OBS scene curation, closes #203).

After this merges, tag the release commit with `v0.3.6`.