### PR TITLE
fix(#206, #207): re-check-in on session type change; battle detection fixes

### DIFF
--- a/src/extensions/iracing/publisher/__tests__/overtake-battle-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/overtake-battle-detector.test.ts
@@ -893,3 +893,272 @@ describe('STOPPED_ON_TRACK', () => {
     expect(state.carStates.get(0)?.stoppedStartSessionTime).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #207 Bug 3: BATTLE_BROKEN must include durationSec
+// ---------------------------------------------------------------------------
+
+describe('BATTLE_BROKEN — durationSec (#207 Bug 3)', () => {
+  function engageBattleAt(engageSessionTime: number) {
+    const state = makeState();
+    const base = makeFrame({
+      sessionTime: engageSessionTime - 0.2,
+      cars: [{ carIdx: 0, position: 1 }, { carIdx: 1, position: 2 }],
+    });
+    detect(null, base, state);
+
+    const f1 = cloneFrame(base);
+    f1.sessionTime = engageSessionTime - 0.1;
+    f1.carIdxF2Time[1] = 0.8;
+    detect(base, f1, state);
+
+    const f2 = cloneFrame(f1);
+    f2.sessionTime = engageSessionTime;
+    f2.carIdxF2Time[1] = 0.7;
+    detect(f1, f2, state);
+
+    return { state, lastFrame: f2 };
+  }
+
+  it('includes durationSec in BATTLE_BROKEN payload', () => {
+    const { state, lastFrame } = engageBattleAt(100);
+    let prev = lastFrame;
+    let brokenEvent: any;
+    for (let i = 0; i < 3; i++) {
+      const curr = cloneFrame(prev);
+      curr.sessionTime = prev.sessionTime + 1;
+      curr.carIdxF2Time[1] = 2.5;
+      const events = detect(prev, curr, state);
+      brokenEvent = events.find(e => e.type === 'BATTLE_BROKEN') ?? brokenEvent;
+      prev = curr;
+    }
+    expect(brokenEvent).toBeDefined();
+    expect(typeof (brokenEvent.payload as any).durationSec).toBe('number');
+    // Battle engaged at sessionTime 100; broken frame 3 is at sessionTime 103
+    expect((brokenEvent.payload as any).durationSec).toBeGreaterThanOrEqual(1);
+  });
+
+  it('durationSec reflects elapsed sessionTime from engagedAt', () => {
+    const { state, lastFrame } = engageBattleAt(500);
+    // Advance 30 seconds before breaking
+    let prev = lastFrame;
+    for (let i = 0; i < 20; i++) {
+      const curr = cloneFrame(prev);
+      curr.sessionTime = prev.sessionTime + 1.5;
+      curr.carIdxF2Time[1] = 0.9; // still engaged
+      detect(prev, curr, state);
+      prev = curr;
+    }
+    // Now break the battle
+    let brokenEvent: any;
+    for (let i = 0; i < 3; i++) {
+      const curr = cloneFrame(prev);
+      curr.sessionTime = prev.sessionTime + 1;
+      curr.carIdxF2Time[1] = 2.5;
+      const events = detect(prev, curr, state);
+      brokenEvent = events.find(e => e.type === 'BATTLE_BROKEN') ?? brokenEvent;
+      prev = curr;
+    }
+    // durationSec should be ~30 (20 frames × 1.5s) + a few frames to break
+    expect((brokenEvent.payload as any).durationSec).toBeGreaterThan(25);
+  });
+
+  it('both engager and engaged perspectives include durationSec', () => {
+    const { state, lastFrame } = engageBattleAt(100);
+    let prev = lastFrame;
+    const allBroken: any[] = [];
+    for (let i = 0; i < 3; i++) {
+      const curr = cloneFrame(prev);
+      curr.sessionTime = prev.sessionTime + 1;
+      curr.carIdxF2Time[1] = 2.5;
+      const events = detect(prev, curr, state);
+      allBroken.push(...events.filter(e => e.type === 'BATTLE_BROKEN'));
+      prev = curr;
+    }
+    // Two events: engager + engaged
+    expect(allBroken).toHaveLength(2);
+    for (const ev of allBroken) {
+      expect(typeof (ev.payload as any).durationSec).toBe('number');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #207 Bug 2: BATTLE_BROKEN must fire at checkered flag for active battles
+// ---------------------------------------------------------------------------
+
+describe('BATTLE_BROKEN — checkered flag flush (#207 Bug 2)', () => {
+  function engagedBattleState() {
+    const state = makeState();
+    const base = makeFrame({
+      sessionTime: 100,
+      cars: [{ carIdx: 0, position: 1 }, { carIdx: 1, position: 2 }],
+    });
+    detect(null, base, state);
+    const f1 = cloneFrame(base);
+    f1.sessionTime = 100.1;
+    f1.carIdxF2Time[1] = 0.8;
+    detect(base, f1, state);
+    const f2 = cloneFrame(f1);
+    f2.sessionTime = 100.2;
+    f2.carIdxF2Time[1] = 0.7;
+    detect(f1, f2, state);
+    return { state, lastFrame: f2 };
+  }
+
+  it('emits BATTLE_BROKEN for each engaged battle when checkeredFired is set', () => {
+    const { state, lastFrame } = engagedBattleState();
+    expect(state.activeBattles.size).toBe(1);
+
+    // Simulate checkered flag
+    state.checkeredFired = true;
+
+    const next = cloneFrame(lastFrame);
+    next.sessionTime = 110;
+    next.carIdxF2Time[1] = 0.7; // still close — but checkered overrides
+    const events = detect(lastFrame, next, state);
+
+    const broken = events.filter(e => e.type === 'BATTLE_BROKEN');
+    expect(broken.length).toBeGreaterThanOrEqual(2); // engager + engaged
+    expect(broken.every(e => (e.payload as any).status === 'BROKEN')).toBe(true);
+  });
+
+  it('clears activeBattles after checkered flush', () => {
+    const { state, lastFrame } = engagedBattleState();
+    state.checkeredFired = true;
+    const next = cloneFrame(lastFrame);
+    next.sessionTime = 110;
+    detect(lastFrame, next, state);
+    expect(state.activeBattles.size).toBe(0);
+  });
+
+  it('checkered flush only happens once (checkeredBattlesFlushed flag)', () => {
+    const { state, lastFrame } = engagedBattleState();
+    state.checkeredFired = true;
+
+    const f1 = cloneFrame(lastFrame);
+    f1.sessionTime = 110;
+    const events1 = detect(lastFrame, f1, state);
+    const broken1 = events1.filter(e => e.type === 'BATTLE_BROKEN').length;
+    expect(broken1).toBeGreaterThanOrEqual(2);
+    expect(state.checkeredBattlesFlushed).toBe(true);
+
+    // Second call — no more battles to flush
+    const f2 = cloneFrame(f1);
+    f2.sessionTime = 111;
+    const events2 = detect(f1, f2, state);
+    expect(events2.filter(e => e.type === 'BATTLE_BROKEN')).toHaveLength(0);
+  });
+
+  it('BATTLE_BROKEN on checkered includes durationSec', () => {
+    const { state, lastFrame } = engagedBattleState();
+    state.checkeredFired = true;
+    const next = cloneFrame(lastFrame);
+    next.sessionTime = 200;
+    const events = detect(lastFrame, next, state);
+    const broken = events.filter(e => e.type === 'BATTLE_BROKEN');
+    for (const ev of broken) {
+      expect(typeof (ev.payload as any).durationSec).toBe('number');
+      expect((ev.payload as any).durationSec).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('does NOT flush STATUS_CLOSING battles at checkered (only ENGAGED)', () => {
+    const state = makeState();
+    const base = makeFrame({
+      sessionTime: 100,
+      cars: [{ carIdx: 0, position: 1 }, { carIdx: 1, position: 2 }],
+    });
+    detect(null, base, state);
+
+    // One frame — creates STATUS_CLOSING, not ENGAGED
+    const f1 = cloneFrame(base);
+    f1.sessionTime = 100.1;
+    f1.carIdxF2Time[1] = 0.8;
+    detect(base, f1, state);
+    expect([...state.activeBattles.values()][0].status).toBe('CLOSING');
+
+    state.checkeredFired = true;
+    const f2 = cloneFrame(f1);
+    f2.sessionTime = 101;
+    const events = detect(f1, f2, state);
+    expect(events.filter(e => e.type === 'BATTLE_BROKEN')).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #207 Bug 4: STATUS_CLOSING entries must be cleaned up when gap > 2.0s
+// ---------------------------------------------------------------------------
+
+describe('STATUS_CLOSING state leak fix (#207 Bug 4)', () => {
+  it('removes STATUS_CLOSING entry after 3 frames above 2.0s (no BATTLE_BROKEN emitted)', () => {
+    const state = makeState();
+    const base = makeFrame({
+      sessionTime: 100,
+      cars: [{ carIdx: 0, position: 1 }, { carIdx: 1, position: 2 }],
+    });
+    detect(null, base, state);
+
+    // Create STATUS_CLOSING latch
+    const f1 = cloneFrame(base);
+    f1.sessionTime = 100.1;
+    f1.carIdxF2Time[1] = 0.8;
+    detect(base, f1, state);
+    expect([...state.activeBattles.values()][0].status).toBe('CLOSING');
+
+    // Now gap exceeds 2.0s for 3 frames
+    let prev = f1;
+    let brokenEvents: any[] = [];
+    for (let i = 0; i < 3; i++) {
+      const curr = cloneFrame(prev);
+      curr.sessionTime = prev.sessionTime + 1;
+      curr.carIdxF2Time[1] = 2.5;
+      const events = detect(prev, curr, state);
+      brokenEvents.push(...events.filter(e => e.type === 'BATTLE_BROKEN'));
+      prev = curr;
+    }
+    // STATUS_CLOSING should be removed — no BATTLE_BROKEN (that only fires for ENGAGED)
+    expect(brokenEvents).toHaveLength(0);
+    expect(state.activeBattles.size).toBe(0);
+  });
+
+  it('allows fresh BATTLE_ENGAGED after STATUS_CLOSING is cleaned up', () => {
+    const state = makeState();
+    const base = makeFrame({
+      sessionTime: 100,
+      cars: [{ carIdx: 0, position: 1 }, { carIdx: 1, position: 2 }],
+    });
+    detect(null, base, state);
+
+    // Create and break STATUS_CLOSING
+    const f1 = cloneFrame(base);
+    f1.sessionTime = 100.1;
+    f1.carIdxF2Time[1] = 0.8;
+    detect(base, f1, state);
+
+    let prev = f1;
+    for (let i = 0; i < 3; i++) {
+      const curr = cloneFrame(prev);
+      curr.sessionTime = prev.sessionTime + 1;
+      curr.carIdxF2Time[1] = 2.5;
+      detect(prev, curr, state);
+      prev = curr;
+    }
+    expect(state.activeBattles.size).toBe(0);
+
+    // Re-approach: should create a fresh CLOSING latch and then ENGAGED
+    const rClose1 = cloneFrame(prev);
+    rClose1.sessionTime = prev.sessionTime + 0.1;
+    rClose1.carIdxF2Time[1] = 0.9;
+    detect(prev, rClose1, state);
+    expect(state.activeBattles.size).toBe(1);
+    expect([...state.activeBattles.values()][0].status).toBe('CLOSING');
+
+    const rClose2 = cloneFrame(rClose1);
+    rClose2.sessionTime = rClose1.sessionTime + 0.1;
+    rClose2.carIdxF2Time[1] = 0.8;
+    const events = detect(rClose1, rClose2, state);
+    expect(events.find(e => e.type === 'BATTLE_ENGAGED')).toBeDefined();
+  });
+});
+

--- a/src/extensions/iracing/publisher/event-types.ts
+++ b/src/extensions/iracing/publisher/event-types.ts
@@ -469,6 +469,8 @@ export interface BattlePayload {
   role: 'engager' | 'engaged';
   /** Overall position being contested (position of the leader car). */
   forPosition: number;
+  /** Duration of the battle in seconds from ENGAGED to BROKEN. Present on BATTLE_BROKEN only. */
+  durationSec?: number;
 }
 
 export interface TrafficPayload {

--- a/src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts
+++ b/src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts
@@ -168,6 +168,36 @@ export function detectOvertakeAndBattle(
   // For each car with a valid position, look at the car directly ahead.
   // Update or create BattleState keyed by battleKey(chaser, leader).
   // -------------------------------------------------------------------------
+
+  // Fix #207 Bug 2: flush all ENGAGED battles as BATTLE_BROKEN when the race
+  // goes to checkered.  state.checkeredFired is set by detectSessionLifecycle
+  // (which runs before this detector), so on the first frame after the flag
+  // we flush once and set checkeredBattlesFlushed to prevent repeat flushes.
+  if (state.checkeredFired && !state.checkeredBattlesFlushed) {
+    state.checkeredBattlesFlushed = true;
+    for (const [, battle] of state.activeBattles) {
+      if (battle.status !== STATUS_ENGAGED) continue;
+      const brokenChaser = carRefFromRoster(state, battle.chaserCarIdx);
+      const brokenLeader = carRefFromRoster(state, battle.leaderCarIdx);
+      if (!brokenChaser || !brokenLeader) continue;
+      const durationSec = Math.round(curr.sessionTime - battle.engagedAt);
+      const checkeredBrokenPayload = {
+        chaserCar:            brokenChaser,
+        leaderCar:            brokenLeader,
+        gapSec:               battle.gapSec,
+        closingRateSecPerLap: battle.closingRateSecPerLap,
+        status:               'BROKEN' as const,
+        role:                 'engager' as const,
+        forPosition:          curr.carIdxPosition[battle.leaderCarIdx],
+        durationSec,
+      };
+      events.push(buildEvent('BATTLE_BROKEN', brokenChaser, checkeredBrokenPayload, opts));
+      events.push(buildEvent('BATTLE_BROKEN', brokenLeader, { ...checkeredBrokenPayload, role: 'engaged' as const }, opts));
+    }
+    state.activeBattles.clear();
+    return events;
+  }
+
   for (let i = 0; i < CAR_COUNT; i++) {
     const currPos = curr.carIdxPosition[i];
     if (currPos <= 1) continue;                        // car is leading (no one ahead)
@@ -283,27 +313,35 @@ export function detectOvertakeAndBattle(
       battle.brokenFrames++;
       battle.gapSec = gap;
 
-      if (battle.brokenFrames >= BATTLE_BROKEN_FRAMES && battle.status === STATUS_ENGAGED) {
-        const brokenCar     = carRefFromRoster(state, i);
-        const brokenChaser  = carRefFromRoster(state, battle.chaserCarIdx);
-        const brokenLeader  = carRefFromRoster(state, battle.leaderCarIdx);
-        if (brokenCar && brokenChaser && brokenLeader) {
-          const brokenLeaderPos = curr.carIdxPosition[battle.leaderCarIdx];
-          const brokenPayload = {
-            chaserCar:            brokenChaser,
-            leaderCar:            brokenLeader,
-            gapSec:               gap,
-            closingRateSecPerLap: battle.closingRateSecPerLap,
-            status:               'BROKEN' as const,
-            role:                 'engager' as const,
-            forPosition:          brokenLeaderPos,
-          };
-          events.push(buildEvent('BATTLE_BROKEN', brokenChaser, brokenPayload, opts));
-          events.push(buildEvent('BATTLE_BROKEN', brokenLeader, {
-            ...brokenPayload,
-            role: 'engaged' as const,
-          }, opts));
+      if (battle.brokenFrames >= BATTLE_BROKEN_FRAMES) {
+        if (battle.status === STATUS_ENGAGED) {
+          // Fix #207 Bug 3: include durationSec computed from engagedAt.
+          const durationSec = Math.round(curr.sessionTime - battle.engagedAt);
+          const brokenCar     = carRefFromRoster(state, i);
+          const brokenChaser  = carRefFromRoster(state, battle.chaserCarIdx);
+          const brokenLeader  = carRefFromRoster(state, battle.leaderCarIdx);
+          if (brokenCar && brokenChaser && brokenLeader) {
+            const brokenLeaderPos = curr.carIdxPosition[battle.leaderCarIdx];
+            const brokenPayload = {
+              chaserCar:            brokenChaser,
+              leaderCar:            brokenLeader,
+              gapSec:               gap,
+              closingRateSecPerLap: battle.closingRateSecPerLap,
+              status:               'BROKEN' as const,
+              role:                 'engager' as const,
+              forPosition:          brokenLeaderPos,
+              durationSec,
+            };
+            events.push(buildEvent('BATTLE_BROKEN', brokenChaser, brokenPayload, opts));
+            events.push(buildEvent('BATTLE_BROKEN', brokenLeader, {
+              ...brokenPayload,
+              role: 'engaged' as const,
+            }, opts));
+          }
         }
+        // Fix #207 Bug 4: also clean up STATUS_CLOSING entries that drifted apart
+        // before becoming ENGAGED — prevents a permanent memory leak and stale
+        // re-engagement behaviour on the next approach.
         state.activeBattles.delete(key);
       }
     }

--- a/src/extensions/iracing/publisher/session-state.ts
+++ b/src/extensions/iracing/publisher/session-state.ts
@@ -420,6 +420,8 @@ export interface SessionState {
   trafficExitFrames: Map<string, number>;
   /** Whether RACE_CHECKERED has been emitted this session (prevents 53x flood). */
   checkeredFired: boolean;
+  /** Whether active battles have been flushed as BATTLE_BROKEN on the checkered flag (#207). */
+  checkeredBattlesFlushed: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -511,6 +513,7 @@ export function createSessionState(raceSessionId: string, sessionUniqueId: numbe
     raceGreenFired: false,
     trafficExitFrames: new Map(),
     checkeredFired: false,
+    checkeredBattlesFlushed: false,
   };
 }
 

--- a/src/main/director-orchestrator.test.ts
+++ b/src/main/director-orchestrator.test.ts
@@ -592,4 +592,79 @@ describe('DirectorOrchestrator', () => {
       expect(ctx.battles).toBeUndefined();
     });
   });
+
+  describe('Re-check-in on SESSION_TYPE_CHANGE (#206)', () => {
+    it('should refresh check-in when iRacing sessionType changes (e.g. Practice → Race)', async () => {
+      mockSessionManager.getCheckinId.mockReturnValue('checkin-123');
+
+      // Emit first raceStateChanged to establish the baseline sessionType
+      mockEventBus.emit('iracing.raceStateChanged', {
+        payload: { sessionFlags: 0, sessionType: 'Practice', cars: [] },
+      });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(mockSessionManager.refreshCheckin).not.toHaveBeenCalled();
+
+      // Now emit with a different sessionType — should trigger re-check-in
+      mockEventBus.emit('iracing.raceStateChanged', {
+        payload: { sessionFlags: 0, sessionType: 'Race', cars: [] },
+      });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(mockSessionManager.refreshCheckin).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT refresh check-in when sessionType stays the same', async () => {
+      mockSessionManager.getCheckinId.mockReturnValue('checkin-123');
+
+      mockEventBus.emit('iracing.raceStateChanged', {
+        payload: { sessionFlags: 0, sessionType: 'Race', cars: [] },
+      });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      mockEventBus.emit('iracing.raceStateChanged', {
+        payload: { sessionFlags: 0, sessionType: 'Race', cars: [] },
+      });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(mockSessionManager.refreshCheckin).not.toHaveBeenCalled();
+    });
+
+    it('should NOT refresh check-in on first raceStateChanged (no prior sessionType)', async () => {
+      mockSessionManager.getCheckinId.mockReturnValue('checkin-123');
+
+      // First emission — lastKnownSessionType is '' so no change detected
+      mockEventBus.emit('iracing.raceStateChanged', {
+        payload: { sessionFlags: 0, sessionType: 'Race', cars: [] },
+      });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(mockSessionManager.refreshCheckin).not.toHaveBeenCalled();
+    });
+
+    it('should NOT refresh check-in when there is no active check-in', async () => {
+      mockSessionManager.getCheckinId.mockReturnValue(null);
+
+      mockEventBus.emit('iracing.raceStateChanged', {
+        payload: { sessionFlags: 0, sessionType: 'Practice', cars: [] },
+      });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      mockEventBus.emit('iracing.raceStateChanged', {
+        payload: { sessionFlags: 0, sessionType: 'Race', cars: [] },
+      });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(mockSessionManager.refreshCheckin).not.toHaveBeenCalled();
+    });
+
+    it('should handle re-check-in failure gracefully on session type change', async () => {
+      mockSessionManager.getCheckinId.mockReturnValue('checkin-123');
+      mockSessionManager.refreshCheckin.mockRejectedValue(new Error('Network error'));
+
+      mockEventBus.emit('iracing.raceStateChanged', {
+        payload: { sessionFlags: 0, sessionType: 'Practice', cars: [] },
+      });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      mockEventBus.emit('iracing.raceStateChanged', {
+        payload: { sessionFlags: 0, sessionType: 'Race', cars: [] },
+      });
+      // Should not throw
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(mockSessionManager.refreshCheckin).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/main/director-orchestrator.ts
+++ b/src/main/director-orchestrator.ts
@@ -80,6 +80,8 @@ export class DirectorOrchestrator extends EventEmitter {
   private currentRaceSessionId: string | null = null;
   /** Last known iRacing state snapshot, updated from iracing.raceStateChanged events. */
   private lastIRacingState: any = null;
+  /** Last known iRacing sessionType — used to detect SESSION_TYPE_CHANGE and re-check-in (#206). */
+  private lastKnownSessionType: string = '';
   /** Synthesizes higher-order narrative events from raw race state history. */
   private readonly raceAnalyzer = new RaceAnalyzer();
 
@@ -126,8 +128,21 @@ export class DirectorOrchestrator extends EventEmitter {
 
       // Cache latest iRacing state for raceContext in sequences/next POST body
       this.eventBus.on('iracing.raceStateChanged', (data: { payload: any }) => {
+        const newSessionType: string = data.payload?.sessionType ?? '';
+        const prevSessionType = this.lastKnownSessionType;
         this.lastIRacingState = data.payload;
         this.raceAnalyzer.update(data.payload);
+
+        // Re-check-in when the iRacing session type changes (e.g. Practice → Race).
+        // Only trigger when both old and new types are known and the Director has an
+        // active check-in, to avoid spurious re-checks on first connect (#206).
+        if (newSessionType && prevSessionType && newSessionType !== prevSessionType && this.sessionManager.getCheckinId()) {
+          console.log(`[DirectorOrchestrator] Session type changed ${prevSessionType} → ${newSessionType}. Re-checking-in.`);
+          this.sessionManager.refreshCheckin().catch(err => {
+            console.warn('[DirectorOrchestrator] Re-check-in on session type change failed:', err);
+          });
+        }
+        if (newSessionType) this.lastKnownSessionType = newSessionType;
       });
     }
 


### PR DESCRIPTION
## Summary

Addresses two issues: **#206** (Director misses re-check-in when iRacing session type changes) and **#207** (three battle detection bugs).

---

## Issue #206 — Director re-check-in on SESSION_TYPE_CHANGE

**Root cause:** `DirectorOrchestrator` listened to `iracing.raceStateChanged` but never compared the incoming `sessionType` to the previous value. When iRacing transitioned from Practice → Qualify → Race, no re-check-in was triggered, leaving the RC cloud with a stale session context.

**Fix (`src/main/director-orchestrator.ts`):**
- Added `private lastKnownSessionType: string = ''` field
- In the `iracing.raceStateChanged` handler, when `sessionType` changes and an active check-in exists, calls `sessionManager.refreshCheckin()`
- Guards prevent spurious triggers: first-connect (no prior type), empty payloads, and no active check-in are all skipped

---

## Issue #207 — Battle detection bugs

### Bug 2 — `BATTLE_BROKEN` never fires at checkered flag

**Root cause:** `detectOvertakeAndBattle` had no mechanism to flush active battles when the race ended under the checkered flag.

**Fix (`overtake-battle-detector.ts`, `session-state.ts`):**
- Added `checkeredBattlesFlushed: boolean` to `SessionState` (init `false`)
- At the start of the battle state machine loop, when `state.checkeredFired && !state.checkeredBattlesFlushed`: emit `BATTLE_BROKEN` for every `ENGAGED` battle (with `durationSec`), clear `activeBattles`, set the flag, and return — fires exactly once per session

### Bug 3 — `durationSec` always `null`

**Root cause:** `BattlePayload` had no `durationSec` field, so the RC server received events without it and returned `null`.

**Fix (`event-types.ts`, `overtake-battle-detector.ts`):**
- Added `durationSec?: number` to `BattlePayload`
- Every `BATTLE_BROKEN` payload now includes `durationSec = Math.round(curr.sessionTime - battle.engagedAt)`

### Bug 4 — `STATUS_CLOSING` entries never cleaned up (state leak)

**Root cause:** The `brokenFrames >= BATTLE_BROKEN_FRAMES` check was gated on `battle.status === STATUS_ENGAGED`, so `STATUS_CLOSING` entries that drifted apart were never removed. This caused a permanent state leak and stale re-engagement behaviour (subsequent approaches would skip the 2-frame confirmation).

**Fix (`overtake-battle-detector.ts`):**
- `state.activeBattles.delete(key)` now runs unconditionally when `brokenFrames >= BATTLE_BROKEN_FRAMES`; `BATTLE_BROKEN` events are only emitted for `ENGAGED` entries

---

## Files changed

| File | Change |
|---|---|
| `src/main/director-orchestrator.ts` | Session type change detection + re-check-in (#206) |
| `src/extensions/iracing/publisher/event-types.ts` | `durationSec?: number` added to `BattlePayload` |
| `src/extensions/iracing/publisher/session-state.ts` | `checkeredBattlesFlushed: boolean` added to `SessionState` |
| `src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts` | All three #207 bug fixes |
| `src/main/director-orchestrator.test.ts` | 5 new tests for #206 re-check-in behaviour |
| `src/extensions/iracing/publisher/__tests__/overtake-battle-detector.test.ts` | New test suites for all three #207 fixes |

## Tests

All 93 tests pass (34 orchestrator, 59 battle detector). New test suites added:
- `Re-check-in on SESSION_TYPE_CHANGE (#206)` — 5 tests
- `BATTLE_BROKEN — durationSec (#207 Bug 3)` — 3 tests
- `BATTLE_BROKEN — checkered flag flush (#207 Bug 2)` — 5 tests
- `STATUS_CLOSING state leak fix (#207 Bug 4)` — 2 tests

Closes #206
Closes #207