### PR TITLE
fix(#209): OVERTAKE payload includes overtakingCar PublisherCarRef

### DIFF
--- a/src/extensions/iracing/publisher/__tests__/overtake-battle-detector.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/overtake-battle-detector.test.ts
@@ -88,6 +88,42 @@ describe('OVERTAKE', () => {
     expect((ev.payload as any).newPosition).toBe(1);
   });
 
+  it('OVERTAKE payload includes overtakingCar PublisherCarRef symmetric with overtakenCar (#209)', () => {
+    // The default test roster seeds carNumber=String(carIdx) and
+    // driverName='Driver <carIdx>'. We assert that overtakingCar mirrors the
+    // roster ref for the overtaker so consumers can resolve the driver/car
+    // class without an external lookup.
+    const base  = makeFrame({ cars: [{ carIdx: 0, position: 1 }, { carIdx: 1, position: 2 }] });
+    const state = prime(base);
+    const next  = cloneFrame(base);
+    next.carIdxPosition[0] = 2;
+    next.carIdxPosition[1] = 1;
+    const events = detect(base, next, state);
+    const ev = events.find(e => e.type === 'OVERTAKE')!;
+    const payload = ev.payload as any;
+
+    // The new field must be present and self-describing.
+    expect(payload.overtakingCar).toBeDefined();
+    expect(payload.overtakingCar.carIdx).toBe(1);
+    expect(payload.overtakingCar.carNumber).toBe('1');
+    expect(payload.overtakingCar.driverName).toBe('Driver 1');
+    expect(payload.overtakingCar.carClassShortName).toBe('GT3');
+    expect(payload.overtakingCar.carClassId).toBe(100);
+
+    // Symmetry: overtakingCar mirrors envelope.car (both refer to the same car).
+    expect(payload.overtakingCar.carIdx).toBe(ev.car.carIdx);
+    expect(payload.overtakingCar.carNumber).toBe(ev.car.carNumber);
+    expect(payload.overtakingCar.driverName).toBe(ev.car.driverName);
+
+    // Symmetry: overtakenCar resolved from the roster too.
+    expect(payload.overtakenCar.carIdx).toBe(0);
+    expect(payload.overtakenCar.carNumber).toBe('0');
+    expect(payload.overtakenCar.driverName).toBe('Driver 0');
+
+    // Backward compatibility: legacy overtakingCarIdx still present.
+    expect(payload.overtakingCarIdx).toBe(1);
+  });
+
   it('OVERTAKE payload includes overtakenCar PublisherCarRef (DIR-4)', () => {
     const base  = makeFrame({ cars: [{ carIdx: 0, position: 1 }, { carIdx: 1, position: 2 }] });
     const state = prime(base);

--- a/src/extensions/iracing/publisher/__tests__/session-state.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/session-state.test.ts
@@ -181,7 +181,7 @@ describe('buildEvent', () => {
   const opts = { raceSessionId: TEST_SESSION_ID, rigId: TEST_PUBLISHER_CODE, frame, leaderLap: 5 };
 
   it('assigns a UUID id', () => {
-    const event = buildEvent('OVERTAKE', car, { overtakingCarIdx: 1, overtakenCar: { carIdx: 2 }, newPosition: 3, lap: 5, lapDistPct: 0.45, classPosition: 1, forPosition: 3, gapAfterSec: 0.5 }, opts);
+    const event = buildEvent('OVERTAKE', car, { overtakingCarIdx: 1, overtakingCar: { carIdx: 1 }, overtakenCar: { carIdx: 2 }, newPosition: 3, lap: 5, lapDistPct: 0.45, classPosition: 1, forPosition: 3, gapAfterSec: 0.5 }, opts);
     expect(event.id).toMatch(/^[0-9a-f-]{36}$/);
   });
 

--- a/src/extensions/iracing/publisher/event-types.ts
+++ b/src/extensions/iracing/publisher/event-types.ts
@@ -435,7 +435,20 @@ export interface StintBestLapPayload {
 // §4 Position & battle
 
 export interface OvertakePayload {
+  /**
+   * Legacy carIdx of the overtaking car. Kept for backward compatibility with
+   * consumers that parsed the original payload shape (#209). New consumers
+   * should prefer overtakingCar, which is self-describing and symmetric
+   * with overtakenCar.
+   */
   overtakingCarIdx: number;
+  /**
+   * Self-describing ref for the overtaking car (#209). Mirrors overtakenCar so
+   * downstream consumers (story engine, sequence planner, commentary) can
+   * resolve the driver/team/car class for the overtaking side without an
+   * external roster lookup.
+   */
+  overtakingCar: PublisherCarRef;
   /** Self-describing ref for the overtaken car. */
   overtakenCar: PublisherCarRef;
   newPosition: number;

--- a/src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts
+++ b/src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts
@@ -139,6 +139,9 @@ export function detectOvertakeAndBattle(
     const currClassPos = curr.carIdxClassPosition[i];
     const overtakePayload = {
       overtakingCarIdx: i,
+      // #209: emit a self-describing ref for the overtaking car so consumers
+      // do not have to perform a roster lookup. Symmetric with overtakenCar.
+      overtakingCar:    overtakeCar,
       overtakenCar,
       newPosition:      currPos,
       lap:              curr.carIdxLapCompleted[i],


### PR DESCRIPTION
## Summary

Implements **#209** in this repo. **#210** and **#211** are story-engine concerns that live on the Race Control server side — they are not implementable in the Director repo and have been forwarded as cross-repo issues (see below).

## Changes

### #209 — OVERTAKE payload now includes `overtakingCar`

Added `overtakingCar: PublisherCarRef` to `OvertakePayload`, symmetric with the existing `overtakenCar` field. Populated from the roster ref in `overtake-battle-detector.ts`. Downstream consumers (story engine, sequence planner, commentary) can now resolve the overtaking driver's name, team, and car class without a separate roster lookup.

The legacy `overtakingCarIdx` field is retained for backward compatibility.

### Tests

- New test: `OVERTAKE payload includes overtakingCar PublisherCarRef symmetric with overtakenCar (#209)` — asserts all roster fields are populated and that `overtakingCar` mirrors `envelope.car`.
- Updated `session-state.test.ts` `buildEvent` test fixture to include the new required field.
- Full suite: **1,040 / 1,040 passing**.

## Out-of-scope (filed as cross-repo issues)

- **#210** (car number leak across SESSION_TYPE_CHANGE): root cause is in the Race Control story distillation engine — story context window is not reset on session type change, leading the AI to hallucinate car numbers. The Director's contribution (re-check-in on session type change) was already shipped in v0.3.7 via #206. The remaining fix belongs in the racecontrol repo.
- **#211** (focus driver dropped from narrative): the story distillation engine ranks events by signal strength and has no concept of focus driver priority. This is an AI prompt / chapter selection concern that lives entirely on the Race Control server.

Comments will be added to #210 and #211 with links to the corresponding racecontrol-side issues.

## Closes
- Closes #209
