### PR TITLE
chore: bump version to 0.3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "director",
-  "version": "0.3.2",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "director",
-      "version": "0.3.2",
+      "version": "0.3.8",
       "license": "ISC",
       "dependencies": {
         "@azure/msal-node": "^3.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "director",
-  "version": "0.3.6",
+  "version": "0.3.8",
   "description": "Sim RaceCenter Director UI App",
   "main": "dist-electron/main/main.js",
   "scripts": {


### PR DESCRIPTION
Aligns `package.json` / `package-lock.json` with the released tag **v0.3.8** (#212).