### PR TITLE
fix: class-aware battle detection and gap trend for multi-class races

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "director",
-  "version": "0.3.2",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "director",
-      "version": "0.3.2",
+      "version": "0.3.8",
       "license": "ISC",
       "dependencies": {
         "@azure/msal-node": "^3.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "director",
-  "version": "0.3.6",
+  "version": "0.3.8",
   "description": "Sim RaceCenter Director UI App",
   "main": "dist-electron/main/main.js",
   "scripts": {

--- a/src/extensions/iracing/index.ts
+++ b/src/extensions/iracing/index.ts
@@ -45,6 +45,8 @@ interface SessionInfoResult {
   trackName: string;
   sessionLaps: number;
   sessions: { sessionNum: number; sessionType: string }[];
+  /** iRacing CarIdx for the player's own car (DriverInfo.DriverCarIdx). */
+  playerCarIdx: number;
 }
 
 // --- Telemetry Types ---
@@ -165,6 +167,13 @@ let telemetryInterval: NodeJS.Timeout | null = null;
 let cachedTrackName = '';
 let cachedSessionLaps = 0;
 let cachedSessions: { sessionNum: number; sessionType: string }[] = [];
+let cachedPlayerCarIdx = -1;
+
+// Tracks the PlayerCarIdx telemetry value across poll ticks so we can detect
+// when the driver enters/leaves a car or the session changes to a new car.
+// -1 means "not yet seen or reset". Distinct from cachedPlayerCarIdx, which
+// comes from the session YAML and may lag behind.
+let lastKnownPlayerCarIdx = -1;
 
 // Publisher orchestrator (issue #106) — instantiated at activate(), drives the
 // detector + transport pipeline. Null when the extension is inactive.
@@ -429,6 +438,8 @@ function closeSharedMemory(director: ExtensionAPI) {
     cachedDrivers = [];
     cachedTrackName = '';
     cachedSessionLaps = 0;
+    cachedPlayerCarIdx = -1;
+    lastKnownPlayerCarIdx = -1;
     director.log('info', 'iRacing shared memory unmapped');
 }
 
@@ -533,9 +544,15 @@ function readSessionInfo(director: ExtensionAPI): SessionInfoResult | null {
             }
         }
 
+        // --- Player car index ---
+        // DriverInfo.DriverCarIdx is the CarIdx for the player's own car.
+        // This is essential for the driver publisher pipeline — without it
+        // every detector short-circuits and no driver events are emitted.
+        const playerCarIdx: number = parsed?.DriverInfo?.DriverCarIdx ?? -1;
+
         lastSessionInfoUpdate = header.sessionInfoUpdate;
-        director.log('info', `Parsed session info (update #${header.sessionInfoUpdate}): ${cameraGroups.length} cameras, ${drivers.length} drivers, track="${trackName}", sessions=[${sessions.map(s => s.sessionType).join(',')}]`);
-        return { cameraGroups, drivers, trackName, sessionLaps, sessions };
+        director.log('info', `Parsed session info (update #${header.sessionInfoUpdate}): ${cameraGroups.length} cameras, ${drivers.length} drivers, track="${trackName}", sessions=[${sessions.map(s => s.sessionType).join(',')}], playerCarIdx=${playerCarIdx}`);
+        return { cameraGroups, drivers, trackName, sessionLaps, sessions, playerCarIdx };
     } catch (error: any) {
         director.log('error', `Failed to parse session info YAML: ${error.message}`);
         return null;
@@ -900,6 +917,21 @@ function pollTelemetry(director: ExtensionAPI) {
         if (varHeaders.size === 0) return;
     }
 
+    // Monitor PlayerCarIdx on every tick so we react immediately when the
+    // driver enters their car (late-join or post-session-change). The YAML-based
+    // DriverInfo.DriverCarIdx can lag; this telemetry scalar is authoritative.
+    if (publisherOrchestrator) {
+        const buf = getLatestBuffer();
+        const playerCarIdxArr = buf ? readVarInt('PlayerCarIdx', buf.offset) : null;
+        const playerCarIdx = playerCarIdxArr?.[0] ?? -1;
+        if (playerCarIdx >= 0 && playerCarIdx !== lastKnownPlayerCarIdx) {
+            director.log('info', `PlayerCarIdx changed: ${lastKnownPlayerCarIdx} → ${playerCarIdx}`);
+            lastKnownPlayerCarIdx = playerCarIdx;
+            cachedPlayerCarIdx = playerCarIdx;
+            publisherOrchestrator.setSessionMetadata({ playerCarIdx });
+        }
+    }
+
     const state = buildRaceState(director);
     if (state) {
         director.emitEvent('iracing.raceStateChanged', state);
@@ -981,6 +1013,7 @@ function pollSessionData(director: ExtensionAPI) {
             cachedTrackName = result.trackName;
             cachedSessionLaps = result.sessionLaps;
             cachedSessions = result.sessions;
+            cachedPlayerCarIdx = result.playerCarIdx;
             director.emitEvent('iracing.cameraGroupsChanged', { groups: result.cameraGroups });
             director.emitEvent('iracing.driversChanged', { drivers: result.drivers });
             // #108: keep publisher roster in sync whenever SessionInfo YAML changes
@@ -995,6 +1028,30 @@ function pollSessionData(director: ExtensionAPI) {
                     carClassId:        d.carClassId,
                 })),
             );
+
+            // Push derived per-car maps so all publisher detectors can resolve
+            // car numbers and class identities correctly. These are only available
+            // from the session YAML, never from telemetry scalars.
+            if (publisherOrchestrator) {
+                const carNumberByCarIdx = new Map<number, string>(
+                    result.drivers.map(d => [d.carIdx, d.carNumber]),
+                );
+                const carClassByCarIdx = new Map<number, number>(
+                    result.drivers.map(d => [d.carIdx, d.carClassId]),
+                );
+                const carClassShortNames = new Map<number, string>(
+                    result.drivers
+                        .filter(d => d.carClassName)
+                        .map(d => [d.carClassId, d.carClassName]),
+                );
+                publisherOrchestrator.setSessionMetadata({
+                    playerCarIdx:     cachedPlayerCarIdx >= 0 ? cachedPlayerCarIdx : undefined,
+                    carNumberByCarIdx,
+                    carClassByCarIdx,
+                    carClassShortNames,
+                    estimatedStintLaps: cachedSessionLaps > 0 ? cachedSessionLaps : undefined,
+                });
+            }
         }
 
         // Always resolve the current session type from telemetry SessionNum so
@@ -1006,7 +1063,18 @@ function pollSessionData(director: ExtensionAPI) {
             const entry = cachedSessions.find(s => s.sessionNum === sessionNum);
             const sessionType = entry?.sessionType ?? '';
             if (sessionType) {
-                publisherOrchestrator.setSessionMetadata({ sessionType });
+                // Include identity settings so the driver publisher can resolve
+                // the player's display name for identity events.
+                const directorRef = directorAPI;
+                publisherOrchestrator.setSessionMetadata({
+                    sessionType,
+                    iracingUserName:     directorRef
+                        ? String(directorRef.settings['iracing.userName'] ?? '').trim() || undefined
+                        : undefined,
+                    identityDisplayName: directorRef
+                        ? String(directorRef.settings['publisher.driver.displayName'] ?? '').trim() || undefined
+                        : undefined,
+                });
             }
         }
     }

--- a/src/extensions/iracing/publisher/__tests__/race-state-aggregator.test.ts
+++ b/src/extensions/iracing/publisher/__tests__/race-state-aggregator.test.ts
@@ -56,13 +56,17 @@ describe('RaceStateAggregator (#151 / #152)', () => {
 
   it('forms classGroups for same-class cars within 1.0s', () => {
     const state = createSessionState('s1', 1);
-    // Two GT3 cars 0.6s apart, plus a third GT3 4s back (excluded).
+    // Three GT3 cars. Cars 0 and 1 are ~0.6s apart (in group), car 2 is ~4s
+    // behind car 1 (out of group). Gaps are expressed as lapDistPct differences
+    // since computeClassGroups now uses estimateSameClassGap (lapDistPct-based)
+    // instead of CarIdxF2Time to avoid cross-class prototype pollution.
+    // With lastLapTime=90s: 0.6s → Δpct≈0.00667; 4.0s → Δpct≈0.0444.
     seedRoster(state, [0, 1, 2], { carClassId: 100, carClassShortName: 'GT3' });
     const frame = makeFrame({
       cars: [
-        { carIdx: 0, position: 1, classPosition: 1, f2Time: 0 },
-        { carIdx: 1, position: 2, classPosition: 2, f2Time: 0.6 },
-        { carIdx: 2, position: 3, classPosition: 3, f2Time: 4.0 },
+        { carIdx: 0, position: 1, classPosition: 1, lapsCompleted: 5, lapDistPct: 0.5,     lastLapTime: 90 },
+        { carIdx: 1, position: 2, classPosition: 2, lapsCompleted: 5, lapDistPct: 0.4933,  lastLapTime: 90 },
+        { carIdx: 2, position: 3, classPosition: 3, lapsCompleted: 5, lapDistPct: 0.4489 },
       ],
     });
     aggregateRaceState(null, frame, state, { playerCarIdx: 0 });

--- a/src/extensions/iracing/publisher/driver-publisher/gap-trend-detector.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/gap-trend-detector.ts
@@ -11,7 +11,7 @@
  */
 
 import type { TelemetryFrame, SessionState } from '../session-state';
-import { buildEvent, carRefFromRoster, getOrCreateCarState } from '../session-state';
+import { buildEvent, carRefFromRoster, getOrCreateCarState, estimateSameClassGap } from '../session-state';
 import type { PublisherEvent } from '../event-types';
 
 export const GAP_TREND_GAP_THRESHOLD_SEC = 3.0;
@@ -25,6 +25,12 @@ export interface GapTrendContext {
   raceSessionId: string;
   /** Required — driver-pipeline detectors are scoped to the player car only. */
   playerCarIdx: number;
+  /**
+   * Per-car class id map (carIdx → CarClassID). When provided, gap-ahead is
+   * computed from same-class lapDistPct rather than CarIdxF2Time, avoiding
+   * cross-class prototype-traffic interference in multi-class sessions.
+   */
+  carClassByCarIdx?: Map<number, number>;
 }
 
 export function detectGapTrend(
@@ -48,7 +54,9 @@ export function detectGapTrend(
   const opts = { raceSessionId: ctx.raceSessionId, rigId: ctx.rigId, frame: curr };
 
   // ---- Ahead ----
-  const gapAhead = curr.carIdxF2Time[ctx.playerCarIdx];
+  // Prefer same-class gap (lapDistPct-based) when class data is available to
+  // avoid CarIdxF2Time pollution from prototype traffic in multi-class sessions.
+  const [gapAhead, sameClassAheadIdx] = findSameClassAheadGap(curr, ctx.playerCarIdx, state, ctx.carClassByCarIdx);
   if (
     gapAhead > 0
     && gapAhead < GAP_TREND_GAP_THRESHOLD_SEC
@@ -64,7 +72,8 @@ export function detectGapTrend(
         curr.sessionTime - state.lastGapTrendEmittedAt.ahead >= GAP_TREND_COOLDOWN_SEC
         || state.lastGapTrendDirection.ahead !== direction;
       if (cooldownOk) {
-        const targetCarIdx = findCarAhead(curr, ctx.playerCarIdx);
+        // Use same-class car ahead if found, otherwise fall back to overall position.
+        const targetCarIdx = sameClassAheadIdx >= 0 ? sameClassAheadIdx : findCarAhead(curr, ctx.playerCarIdx);
         const playerRef = carRefFromRoster(state, ctx.playerCarIdx);
         const targetRef = targetCarIdx >= 0 ? carRefFromRoster(state, targetCarIdx) : undefined;
         if (playerRef && targetRef) {
@@ -118,6 +127,35 @@ export function detectGapTrend(
   }
 
   return events;
+}
+
+/**
+ * Returns [gapSec, leaderCarIdx] for the same-class car immediately ahead of
+ * the player (by class position). Falls back to F2Time and overall-position
+ * car-ahead when class data is unavailable.
+ */
+function findSameClassAheadGap(
+  curr: TelemetryFrame,
+  playerCarIdx: number,
+  state: SessionState,
+  carClassByCarIdx?: Map<number, number>,
+): [number, number] {
+  if (carClassByCarIdx && carClassByCarIdx.size > 0) {
+    const playerClassId  = carClassByCarIdx.get(playerCarIdx);
+    const playerClassPos = curr.carIdxClassPosition[playerCarIdx];
+    if (playerClassId !== undefined && playerClassPos > 1) {
+      for (const [cIdx] of state.knownRoster) {
+        if (carClassByCarIdx.get(cIdx) === playerClassId
+            && curr.carIdxClassPosition[cIdx] === playerClassPos - 1) {
+          const gap = estimateSameClassGap(curr, playerCarIdx, cIdx);
+          return gap < 999 ? [gap, cIdx] : [-1, -1];
+        }
+      }
+    }
+    return [-1, -1]; // player is class leader
+  }
+  // Fallback: F2Time
+  return [curr.carIdxF2Time[playerCarIdx], -1];
 }
 
 function findCarAhead(frame: TelemetryFrame, playerCarIdx: number): number {

--- a/src/extensions/iracing/publisher/driver-publisher/orchestrator.ts
+++ b/src/extensions/iracing/publisher/driver-publisher/orchestrator.ts
@@ -77,6 +77,7 @@ export class DriverPublisherOrchestrator {
   private playerCarIdx: number | undefined = undefined;
   private estimatedStintLaps = 0;
   private carNumberByCarIdx: Map<number, string> = new Map();
+  private carClassByCarIdx: Map<number, number> = new Map();
   private identityDisplayName = '';
   private iracingUserName = '';
 
@@ -170,6 +171,7 @@ export class DriverPublisherOrchestrator {
         playerCarIdx,
         estimatedStintLaps: this.estimatedStintLaps,
         playerFuelPerLap: this.driverState?.fuelPerLap ?? 0,
+        carClassByCarIdx: this.carClassByCarIdx.size > 0 ? this.carClassByCarIdx : undefined,
       });
 
       // Derived-metrics aggregator (#182) — also runs BEFORE detectors so the
@@ -224,7 +226,11 @@ export class DriverPublisherOrchestrator {
     }));
 
     // Race-narrative detectors (#153–#156) — all gated on playerCarIdx.
-    events.push(...detectGapTrend(this.prevFrame, frame, this.state, { ...ctx, playerCarIdx }));
+    events.push(...detectGapTrend(this.prevFrame, frame, this.state, {
+      ...ctx,
+      playerCarIdx,
+      carClassByCarIdx: this.carClassByCarIdx.size > 0 ? this.carClassByCarIdx : undefined,
+    }));
     events.push(...detectClassPositionChange(this.prevFrame, frame, this.state, { ...ctx, playerCarIdx }));
     events.push(...detectOverallPositionChange(this.prevFrame, frame, this.state, { ...ctx, playerCarIdx }));
     events.push(...detectPlayerStopped(this.prevFrame, frame, this.state, this.driverState!, { ...ctx, playerCarIdx }));
@@ -286,12 +292,14 @@ export class DriverPublisherOrchestrator {
     playerCarIdx?: number;
     estimatedStintLaps?: number;
     carNumberByCarIdx?: Map<number, string>;
+    carClassByCarIdx?: Map<number, number>;
     iracingUserName?: string;
     identityDisplayName?: string;
   }): void {
     if (meta.playerCarIdx !== undefined)         this.playerCarIdx = meta.playerCarIdx;
     if (meta.estimatedStintLaps !== undefined)   this.estimatedStintLaps = meta.estimatedStintLaps;
     if (meta.carNumberByCarIdx)                  this.carNumberByCarIdx = meta.carNumberByCarIdx;
+    if (meta.carClassByCarIdx)                   this.carClassByCarIdx = meta.carClassByCarIdx;
     if (meta.iracingUserName !== undefined)      this.iracingUserName = meta.iracingUserName;
     if (meta.identityDisplayName !== undefined)  this.identityDisplayName = meta.identityDisplayName;
   }

--- a/src/extensions/iracing/publisher/orchestrator.ts
+++ b/src/extensions/iracing/publisher/orchestrator.ts
@@ -415,6 +415,7 @@ export class PublisherOrchestrator {
       playerCarIdx:        meta.playerCarIdx,
       estimatedStintLaps:  meta.estimatedStintLaps,
       carNumberByCarIdx:   meta.carNumberByCarIdx,
+      carClassByCarIdx:    meta.carClassByCarIdx,
       iracingUserName:     meta.iracingUserName,
       identityDisplayName: meta.identityDisplayName,
     });

--- a/src/extensions/iracing/publisher/session-publisher/orchestrator.ts
+++ b/src/extensions/iracing/publisher/session-publisher/orchestrator.ts
@@ -132,7 +132,10 @@ export class SessionPublisherOrchestrator {
     events.push(...detectSessionLifecycle(this.prevFrame, frame, this.state, ctx));
     events.push(...detectFlags(this.prevFrame, frame, this.state, ctx));
     events.push(...detectLapCompleted(this.prevFrame, frame, this.state, ctx));
-    events.push(...detectOvertakeAndBattle(this.prevFrame, frame, this.state, ctx));
+    events.push(...detectOvertakeAndBattle(this.prevFrame, frame, this.state, {
+      ...ctx,
+      carClassByCarIdx: this.carClassByCarIdx.size > 0 ? this.carClassByCarIdx : undefined,
+    }));
     events.push(...detectPitLifecycle(this.prevFrame, frame, this.state, {
       ...ctx,
       playerCarIdx: this.playerCarIdx ?? -1,

--- a/src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts
+++ b/src/extensions/iracing/publisher/session-publisher/overtake-battle-detector.ts
@@ -23,7 +23,7 @@
  */
 
 import type { TelemetryFrame, SessionState, BattleState } from '../session-state';
-import { getOrCreateCarState, battleKey, carRefFromRoster } from '../session-state';
+import { getOrCreateCarState, battleKey, carRefFromRoster, estimateSameClassGap } from '../session-state';
 import type { PublisherEvent } from '../event-types';
 import { buildEvent } from '../session-state';
 
@@ -59,6 +59,13 @@ const STATUS_ENGAGED  = 'ENGAGED' as const;
 export interface OvertakeBattleDetectorContext {
   rigId: string;
   raceSessionId: string;
+  /**
+   * Per-car class id map (carIdx → CarClassID).
+   * When provided, the battle state machine uses same-class car-ahead pairing
+   * and lapDistPct-based gap estimation instead of CarIdxF2Time, which is
+   * polluted by cross-class prototype traffic in multi-class sessions.
+   */
+  carClassByCarIdx?: Map<number, number>;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,6 +102,21 @@ export function detectOvertakeAndBattle(
     const cp = curr.carIdxPosition[i];
     if (pp > 0) prevPosMap.set(pp, i);
     if (cp > 0) currPosMap.set(cp, i);
+  }
+
+  // Per-class position maps: classId → (classPos → carIdx).
+  // Used by the battle state machine so that only same-class rivals are
+  // matched — prototype traffic never creates false battle pairs with GTD cars.
+  const currClassPosMaps = new Map<number, Map<number, number>>();
+  if (ctx.carClassByCarIdx && ctx.carClassByCarIdx.size > 0) {
+    for (let i = 0; i < CAR_COUNT; i++) {
+      const classId = ctx.carClassByCarIdx.get(i);
+      if (classId === undefined) continue;
+      const classPos = curr.carIdxClassPosition[i];
+      if (classPos <= 0) continue;
+      if (!currClassPosMaps.has(classId)) currClassPosMaps.set(classId, new Map());
+      currClassPosMaps.get(classId)!.set(classPos, i);
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -203,15 +225,42 @@ export function detectOvertakeAndBattle(
 
   for (let i = 0; i < CAR_COUNT; i++) {
     const currPos = curr.carIdxPosition[i];
-    if (currPos <= 1) continue;                        // car is leading (no one ahead)
+    if (currPos <= 0) continue;                        // car not active
     if (curr.carIdxOnPitRoad[i] !== 0) continue;      // skip pit-road cars
 
-    const leaderIdx = currPosMap.get(currPos - 1);
-    if (leaderIdx === undefined) continue;
-    if (curr.carIdxOnPitRoad[leaderIdx] !== 0) continue;
+    // ---- Determine the same-class rival immediately ahead ----
+    // Prefer class-position-based lookup: this ensures we only form battle
+    // pairs between cars in the same class, preventing cross-class F2Time
+    // pollution in multi-class (IMSA/LMPC) sessions where prototypes
+    // physically pass through GTD groups and spike the F2Time signal.
+    const chaserClassId  = ctx.carClassByCarIdx?.get(i);
+    const chaserClassPos = curr.carIdxClassPosition[i];
+    let leaderIdx: number;
+    let gap: number;
 
-    const gap = curr.carIdxF2Time[i];
-    if (gap < 0) continue;                             // iRacing returns -1 when invalid
+    if (chaserClassId !== undefined && currClassPosMaps.size > 0) {
+      if (chaserClassPos <= 1) continue;               // class leader, nobody same-class ahead
+      const classMap = currClassPosMaps.get(chaserClassId);
+      const found    = classMap?.get(chaserClassPos - 1);
+      if (found === undefined) continue;               // no same-class car at classPos-1
+      leaderIdx = found;
+      // Compute same-class gap from lap-distance progress.  CarIdxF2Time is
+      // NOT used here: in multi-class it reflects the nearest car physically
+      // ahead regardless of class — the same reason Step 4 avoids it.
+      gap = estimateSameClassGap(curr, i, leaderIdx);
+      if (gap >= 999) continue;                        // invalid (chaser ahead or >2 laps)
+    } else {
+      // No class data available (single-class or early boot before YAML).
+      // Fall back to overall-position adjacency + F2Time.
+      if (currPos <= 1) continue;                      // overall leader
+      const found = currPosMap.get(currPos - 1);
+      if (found === undefined) continue;
+      leaderIdx = found;
+      gap = curr.carIdxF2Time[i];
+      if (gap < 0) continue;                           // iRacing returns -1 when invalid
+    }
+
+    if (curr.carIdxOnPitRoad[leaderIdx] !== 0) continue;
 
     const key     = battleKey(i, leaderIdx);
     const battle  = state.activeBattles.get(key);

--- a/src/extensions/iracing/publisher/session-state.ts
+++ b/src/extensions/iracing/publisher/session-state.ts
@@ -582,6 +582,36 @@ export interface EventBuilderOptions {
   leaderLap?: number;
 }
 
+/**
+ * Estimates the on-track time gap between two cars using their normalized lap
+ * progress (lapCompleted + lapDistPct) and a reference lap time.
+ *
+ * This is the class-aware alternative to CarIdxF2Time. In multi-class races
+ * F2Time reflects the gap to the physically nearest car ahead regardless of
+ * class, so prototype traffic constantly corrupts GTD/GT3 battle detection.
+ * By computing the gap from lap-distance fractions we always get the true
+ * same-class inter-car interval.
+ *
+ * Returns 999 when the gap is invalid (chaser is ahead, cars are more than
+ * 2 laps apart, or no usable lap-time reference is available).
+ */
+export function estimateSameClassGap(
+  frame: TelemetryFrame,
+  chaserIdx: number,
+  leaderIdx: number,
+): number {
+  const leaderProg = frame.carIdxLapCompleted[leaderIdx] + frame.carIdxLapDistPct[leaderIdx];
+  const chaserProg = frame.carIdxLapCompleted[chaserIdx] + frame.carIdxLapDistPct[chaserIdx];
+  const diff = leaderProg - chaserProg;
+  if (diff < 0 || diff > 2) return 999;
+  // Use the leader's last lap time as the lap-time reference; fall back to a
+  // reasonable default when the lap hasn't been completed yet.
+  const refLapTime = frame.carIdxLastLapTime[leaderIdx] > 0
+    ? frame.carIdxLastLapTime[leaderIdx]
+    : 90;
+  return diff * refLapTime;
+}
+
 export function buildEvent<T extends PublisherEventType>(
   type: T,
   car: CarRefInput,

--- a/src/extensions/iracing/publisher/shared/race-state-aggregator.ts
+++ b/src/extensions/iracing/publisher/shared/race-state-aggregator.ts
@@ -11,7 +11,7 @@
  */
 
 import type { TelemetryFrame, SessionState, CarState } from '../session-state';
-import { getOrCreateCarState } from '../session-state';
+import { getOrCreateCarState, estimateSameClassGap } from '../session-state';
 
 /** Maximum samples kept in a rolling gap window. */
 export const GAP_WINDOW_SIZE = 5;
@@ -62,22 +62,65 @@ export function aggregateRaceState(
     if (carIdx < 0 || carIdx >= carCount) continue;
     const cs = getOrCreateCarState(state, carIdx);
 
-    // Gap to car ahead — CarIdxF2Time. iRacing reports 0 for the leader.
-    const gapAhead = curr.carIdxF2Time[carIdx];
-    if (Number.isFinite(gapAhead) && gapAhead > 0) {
-      pushWindow(cs.recentGapToAhead, gapAhead);
-      cs.closingRateToAhead = computeClosingRate(cs.recentGapToAhead);
+    // Gap to car ahead — use same-class lapDistPct gap for the player car
+    // (to avoid cross-class F2Time pollution in multi-class sessions); use
+    // F2Time for all other cars since their gap windows are only consumed
+    // by classGroups, which is now also class-aware.
+    if (carIdx === playerCarIdx && ctx.carClassByCarIdx) {
+      const playerClassId  = ctx.carClassByCarIdx.get(playerCarIdx);
+      const playerClassPos = curr.carIdxClassPosition[playerCarIdx];
+      if (playerClassId !== undefined && playerClassPos > 1) {
+        // Find same-class car at class position - 1.
+        for (const [cIdx] of state.knownRoster) {
+          if (ctx.carClassByCarIdx.get(cIdx) === playerClassId
+              && curr.carIdxClassPosition[cIdx] === playerClassPos - 1) {
+            const scGap = estimateSameClassGap(curr, playerCarIdx, cIdx);
+            if (scGap < 999) {
+              pushWindow(cs.recentGapToAhead, scGap);
+              cs.closingRateToAhead = computeClosingRate(cs.recentGapToAhead);
+            }
+            break;
+          }
+        }
+      }
+    } else {
+      const gapAhead = curr.carIdxF2Time[carIdx];
+      if (Number.isFinite(gapAhead) && gapAhead > 0) {
+        pushWindow(cs.recentGapToAhead, gapAhead);
+        cs.closingRateToAhead = computeClosingRate(cs.recentGapToAhead);
+      }
     }
 
-    // Gap-to-car-behind for the player only (we don't have CarIdxF2Time
-    // for "behind us" — derive from the car-behind's gapToCarAhead).
+    // Gap-to-car-behind for the player only.
+    // Same-class: find same-class car at classPos + 1; fall back to F2Time
+    // of the overall-position car behind when class data is unavailable.
     if (carIdx === playerCarIdx) {
-      const carBehindIdx = findCarBehind(curr, playerPosition);
-      if (carBehindIdx >= 0) {
-        const gapBehind = curr.carIdxF2Time[carBehindIdx];
-        if (Number.isFinite(gapBehind) && gapBehind > 0) {
-          pushWindow(cs.recentGapToBehind, gapBehind);
-          cs.closingRateToBehind = computeClosingRate(cs.recentGapToBehind);
+      const playerClassId  = ctx.carClassByCarIdx?.get(playerCarIdx);
+      const playerClassPos = curr.carIdxClassPosition[playerCarIdx];
+      let foundBehindGap   = false;
+      if (playerClassId !== undefined && playerClassPos > 0) {
+        for (const [cIdx] of state.knownRoster) {
+          if (ctx.carClassByCarIdx!.get(cIdx) === playerClassId
+              && curr.carIdxClassPosition[cIdx] === playerClassPos + 1) {
+            const scGapBehind = estimateSameClassGap(curr, cIdx, playerCarIdx);
+            if (scGapBehind < 999) {
+              pushWindow(cs.recentGapToBehind, scGapBehind);
+              cs.closingRateToBehind = computeClosingRate(cs.recentGapToBehind);
+              foundBehindGap = true;
+            }
+            break;
+          }
+        }
+      }
+      if (!foundBehindGap) {
+        // Fallback: overall-position car behind via F2Time (single-class or no class data).
+        const carBehindIdx = findCarBehind(curr, playerPosition);
+        if (carBehindIdx >= 0) {
+          const gapBehind = curr.carIdxF2Time[carBehindIdx];
+          if (Number.isFinite(gapBehind) && gapBehind > 0) {
+            pushWindow(cs.recentGapToBehind, gapBehind);
+            cs.closingRateToBehind = computeClosingRate(cs.recentGapToBehind);
+          }
         }
       }
     }
@@ -198,16 +241,18 @@ function computeClassGroups(
   carClassByCarIdx?: Map<number, number>,
 ): Map<number, number[][]> {
   const groups = new Map<number, number[][]>();
-  // Build per-class lists of [carIdx, classPosition, gapToAhead] tuples.
-  const byClass = new Map<number, Array<{ carIdx: number; classPos: number; gap: number }>>();
+  // Build per-class lists sorted by class position.  We no longer store gap
+  // here — gaps are computed on-the-fly from lapDistPct in the grouping step
+  // so we avoid the cross-class F2Time pollution that previously caused
+  // prototype traffic to masquerade as same-class battle proximity.
+  const byClass = new Map<number, Array<{ carIdx: number; classPos: number }>>();
   for (const [carIdx, ref] of state.knownRoster) {
     const classId = ref.carClassId ?? carClassByCarIdx?.get(carIdx);
     if (classId === undefined) continue;
     const classPos = frame.carIdxClassPosition[carIdx];
     if (classPos <= 0) continue;
-    const gap = frame.carIdxF2Time[carIdx] ?? 0;
     if (!byClass.has(classId)) byClass.set(classId, []);
-    byClass.get(classId)!.push({ carIdx, classPos, gap });
+    byClass.get(classId)!.push({ carIdx, classPos });
   }
 
   for (const [classId, entries] of byClass) {
@@ -219,10 +264,13 @@ function computeClassGroups(
         current.push(entries[i].carIdx);
         continue;
       }
-      // gap value on this entry is gap-to-car-ahead in OVERALL order; for a
-      // class-grouping heuristic we treat any same-class car within
-      // CLASS_GROUP_GAP_SEC of its class-predecessor as part of the group.
-      if (entries[i].gap > 0 && entries[i].gap < CLASS_GROUP_GAP_SEC) {
+      // Same-class gap via lap-distance progress: avoids cross-class F2Time
+      // where a prototype physically between two GTD cars would produce a
+      // small gap reading that doesn't represent a real GTD battle.
+      const leaderIdx = entries[i - 1].carIdx;
+      const chaserIdx = entries[i].carIdx;
+      const gap = estimateSameClassGap(frame, chaserIdx, leaderIdx);
+      if (gap < CLASS_GROUP_GAP_SEC) {
         current.push(entries[i].carIdx);
       } else {
         if (current.length > 1) classGroups.push(current);


### PR DESCRIPTION
## Problem

In multi-class sessions (IMSA/LMPC), `CarIdxF2Time` measures the gap to the **physically nearest car ahead on track regardless of class**. GTP/LMP2 prototypes constantly circulate through GTD groups, spiking F2Time and preventing sustained same-class battle detection.

**Evidence from Sunday Testing session (IMSA Road Atlanta race, ~1080s of racing):**
- 0 `BATTLE_ENGAGED` events during the sustained race phase despite a 4-car same-class battle
- 223 `BEING_LAPPED` + 246 `LAPPED_TRAFFIC_AHEAD` events prove F2Time IS active — prototypes were registering as < 2s gaps and immediately resetting the battle state machine

Three consumers were affected:
1. `detectOvertakeAndBattle` (session publisher) — Step 3 battle state machine used F2Time + overall-position-adjacency pairing
2. `computeClassGroups` (race-state-aggregator) — class group formation used F2Time (had a comment noting the known inaccuracy)
3. `detectGapTrend` + aggregator windows (driver publisher) — `GAP_CLOSING`/`GAP_OPENING` used F2Time directly

Also includes two fixes from previous work:
- `playerCarIdx` was never extracted from session YAML so all driver publisher detectors short-circuited on `-1`
- Live `PlayerCarIdx` telemetry monitoring added to handle late-join and session-change scenarios

## Solution

Introduce `estimateSameClassGap()` in `session-state.ts` that computes the true inter-car time gap from `carIdxLapCompleted + carIdxLapDistPct × refLapTime`. This is the same technique already used in Step 4 (BEING_LAPPED / LAPPED_TRAFFIC) which explicitly avoids F2Time for cross-lap detection.

### Changes

| File | Change |
|------|--------|
| `session-state.ts` | Added `estimateSameClassGap()` exported utility |
| `overtake-battle-detector.ts` | Step 3 builds per-class position maps and pairs each car with its same-class rival at `classPos-1`; uses `estimateSameClassGap` instead of F2Time. Falls back to F2Time + overall-position adjacency when no class data is available (single-class sessions unaffected) |
| `session-publisher/orchestrator.ts` | Passes `carClassByCarIdx` into `detectOvertakeAndBattle` |
| `race-state-aggregator.ts` | Player car gap-ahead/behind windows use same-class lapDistPct gaps; `computeClassGroups` rewritten to use same-class gaps |
| `gap-trend-detector.ts` | `findSameClassAheadGap()` prefers same-class lapDistPct gap; falls back to F2Time |
| `driver-publisher/orchestrator.ts` | Stores `carClassByCarIdx`, passes to aggregator and `detectGapTrend` |
| `orchestrator.ts` | Forwards `carClassByCarIdx` to `driverPublisher.setSessionMetadata` |
| `race-state-aggregator.test.ts` | Updated classGroups test to use lapDistPct fixture values matching new computation |

## Testing

- All 1040 tests pass
- Single-class behaviour is unchanged: `carIdxClassPosition === carIdxPosition` in single-class races, so class-position pairing is equivalent to overall-position pairing
