### PR TITLE
chore: bump version to 0.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "director",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "director",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "ISC",
       "dependencies": {
         "@azure/msal-node": "^3.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "director",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Sim RaceCenter Director UI App",
   "main": "dist-electron/main/main.js",
   "scripts": {


### PR DESCRIPTION
Bump `package.json` and `package-lock.json` to `0.3.9`.

Tag `v0.3.9` has already been pushed to the remote.