### PR TITLE
fix: restore checkin TTL and re-checkin on session transitions (#216)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "director",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "director",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "ISC",
       "dependencies": {
         "@azure/msal-node": "^3.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "director",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Sim RaceCenter Director UI App",
   "main": "dist-electron/main/main.js",
   "scripts": {

--- a/src/main/cloud-poller.ts
+++ b/src/main/cloud-poller.ts
@@ -303,13 +303,15 @@ export class CloudPoller {
             contextTimestamp: new Date().toISOString(),
           };
 
-      // Skip POST if iRacing has no car data yet — the spec requires a non-empty drivers array.
-      // This happens during session load before the driver roster is populated.
-      // Pre-fetch calls bypass this check (skipCarCheck=true) since a sequence is already
-      // executing which confirms cars were present when it was dispatched.
+      // Issue #216: Do NOT skip the POST when carCount=0. During iRacing sub-session
+      // transitions (Practice → Qualify → Race) all car positions drop to 0 while the
+      // new roster loads. Previously, skipping the POST meant the server never received
+      // a heartbeat, causing the checkin TTL (120 s) to expire before the Race went
+      // green. Every POST to /sequences/next refreshes the TTL regardless of car count;
+      // the server will return 204 during transition, which is harmless.
+      // Pre-fetch calls already bypass this log (skipCarCheck=true).
       if (raceContext.carCount === 0 && !opts?.skipCarCheck) {
-        console.log('[CloudPoller] Skipping sequence request — no car data yet (carCount=0), will retry.');
-        return this.idleRetryMs;
+        console.log('[CloudPoller] carCount=0 (sub-session transition in progress) — sending heartbeat POST to maintain checkin TTL.');
       }
 
       const requestBody: NextSequenceRequest = {

--- a/src/main/director-orchestrator.ts
+++ b/src/main/director-orchestrator.ts
@@ -82,6 +82,12 @@ export class DirectorOrchestrator extends EventEmitter {
   private lastIRacingState: any = null;
   /** Last known iRacing sessionType — used to detect SESSION_TYPE_CHANGE and re-check-in (#206). */
   private lastKnownSessionType: string = '';
+  /**
+   * True once we have had at least one successful check-in for the current selected session.
+   * Used to distinguish TTL-expiry state resets (should auto re-checkin) from the initial
+   * session-select state (no checkin yet — should not auto re-checkin). Issue #216.
+   */
+  private checkinWasActive = false;
   /** Synthesizes higher-order narrative events from raw race state history. */
   private readonly raceAnalyzer = new RaceAnalyzer();
 
@@ -134,13 +140,27 @@ export class DirectorOrchestrator extends EventEmitter {
         this.raceAnalyzer.update(data.payload);
 
         // Re-check-in when the iRacing session type changes (e.g. Practice → Race).
-        // Only trigger when both old and new types are known and the Director has an
-        // active check-in, to avoid spurious re-checks on first connect (#206).
-        if (newSessionType && prevSessionType && newSessionType !== prevSessionType && this.sessionManager.getCheckinId()) {
-          console.log(`[DirectorOrchestrator] Session type changed ${prevSessionType} → ${newSessionType}. Re-checking-in.`);
-          this.sessionManager.refreshCheckin().catch(err => {
-            console.warn('[DirectorOrchestrator] Re-check-in on session type change failed:', err);
-          });
+        // Issue #216: distinguish Race start (needs full POST to update roster and
+        // re-trigger the Planner) from other transitions (PATCH refresh is sufficient).
+        if (newSessionType && prevSessionType && newSessionType !== prevSessionType) {
+          const isRaceStart = newSessionType === 'Race';
+          const hasSelectedSession = this.sessionManager.getSelectedSession() !== null;
+          const isActiveMode = this.mode === 'auto' || this.mode === 'manual';
+
+          if (isRaceStart && hasSelectedSession && isActiveMode) {
+            // Race sub-session starting — POST a fresh checkin so Race Control gets
+            // the updated car-number roster and re-runs the Planner for Race sequences.
+            console.log(`[DirectorOrchestrator] Race sub-session starting (${prevSessionType} → Race) — full POST re-checkin (#216).`);
+            this.sessionManager.checkinSession({ forceCheckin: true }).catch(err => {
+              console.warn('[DirectorOrchestrator] Re-checkin on Race start failed:', err);
+            });
+          } else if (this.sessionManager.getCheckinId()) {
+            // Non-Race transition (e.g. Practice → Qualifying) — PATCH refresh is sufficient.
+            console.log(`[DirectorOrchestrator] Session type changed ${prevSessionType} → ${newSessionType}. Refreshing check-in.`);
+            this.sessionManager.refreshCheckin().catch(err => {
+              console.warn('[DirectorOrchestrator] Check-in refresh on session type change failed:', err);
+            });
+          }
         }
         if (newSessionType) this.lastKnownSessionType = newSessionType;
       });
@@ -327,6 +347,7 @@ export class DirectorOrchestrator extends EventEmitter {
       // Uses executeInternalDirective (not executeIntent) so this lifecycle
       // call is never exposed as a broadcast capability to the RC AI planner.
       if (sessionState === 'checked-in') {
+        this.checkinWasActive = true; // Record that we've had an active checkin (#216).
         this.extensionHost.executeInternalDirective('iracing.publisher.bindSession', {
           raceSessionId: selectedSession.raceSessionId,
         });
@@ -347,12 +368,25 @@ export class DirectorOrchestrator extends EventEmitter {
           if (checkinId) {
             this.cloudPoller.updateCheckin(checkinId, ttl);
           }
+        } else if (sessionState === 'selected' && this.checkinWasActive && !this.sessionManager.getCheckinId()) {
+          // The checkin TTL expired and SessionManager reset to 'selected' while we
+          // are still in an active director mode. Re-establish the checkin automatically
+          // so sequences keep flowing after a sub-session transition. Issue #216.
+          const smState = this.sessionManager.getState();
+          if (smState.checkinStatus !== 'checking-in') {
+            console.log('[DirectorOrchestrator] Checkin TTL expired in active mode — re-checking in automatically (#216).');
+            this.checkinWasActive = false; // Reset to prevent re-entry before the new checkin lands.
+            this.sessionManager.checkinSession({ forceCheckin: true }).catch(err => {
+              console.warn('[DirectorOrchestrator] Auto re-checkin after TTL expiry failed:', err);
+            });
+          }
         }
         // Emit state change so renderer sees updated checkin status
         this.emitStateChanged();
       }
     } else if (sessionState === 'none' || sessionState === 'discovered') {
       // Session cleared
+      this.checkinWasActive = false; // Reset guard — session explicitly cleared.
       if (this.mode !== 'stopped') {
         console.log('[DirectorOrchestrator] Session cleared. Transitioning to stopped mode');
         await this.setMode('stopped');
@@ -519,6 +553,7 @@ export class DirectorOrchestrator extends EventEmitter {
    */
   private async handleSessionEnded(): Promise<void> {
     console.log('[DirectorOrchestrator] Session ended (410 Gone). Wrapping and stopping.');
+    this.checkinWasActive = false; // Session ended — don't auto re-checkin.
     await this.sessionManager.wrapSession('session-ended').catch(() => {});
     await this.sessionManager.clearSession();
     await this.setMode('stopped');
@@ -546,6 +581,7 @@ export class DirectorOrchestrator extends EventEmitter {
    * @deprecated Use sessionManager.wrapSession() directly via session:wrap IPC.
    */
   async wrapSession(reason?: string): Promise<DirectorOrchestratorState> {
+    this.checkinWasActive = false; // Operator-initiated wrap — don't auto re-checkin (#216).
     // Stop the loop if in auto mode
     if (this.mode === 'auto') {
       await this.setMode('manual');


### PR DESCRIPTION
Fixes #216 — Director stops receiving sequences when iRacing transitions between sub-sessions (Practice → Qualifying → Race).

## Root Causes

### 1. CloudPoller carCount=0 guard prevented TTL heartbeat
`fetchNextSequence()` had an early `return` when `carCount === 0`. During iRacing sub-session transitions all car positions drop to 0 while the new roster loads. This meant no POST was sent to `/sequences/next`, so the server's 120s checkin TTL expired before the Race went green.

Evidence: Sunday Testing session `3ab07317` — last POST at 17:49, TTL expired at ~17:51 (exactly 120s later), 0 sequences delivered for the entire Race.

**Fix:** Remove the early return. `carCount=0` now logs a warning and falls through to the POST. The server returns 204 harmlessly during transition but the TTL stays alive.

### 2. Race start needed a full POST checkin, not just PATCH
On every session-type change, only `PATCH /checkin` was called. PATCH does not re-trigger the Planner for Race sequences — Director was receiving sequences scoped to Practice/Qualify even after the Race went green.

**Fix:** Detect `* → Race` transitions specifically and call `checkinSession({ forceCheckin: true })` (POST) to update the car-number roster and re-trigger the Race Planner. Other transitions (e.g. Practice → Qualifying) continue to use PATCH.

### 3. No auto-recovery when TTL expired mid-session
If PATCH `/checkin` returned 404 (TTL expired), `refreshCheckin()` called `resetCheckinState()` → SessionManager state reset to `'selected'` with no further action. Director stayed silent for the rest of the session.

**Fix:** Track a `checkinWasActive` flag. When state resets to `'selected'` in an active director mode (auto/manual) with no checkin ID, automatically call `checkinSession({ forceCheckin: true })` to re-establish the checkin.

## Files Changed
- `src/main/cloud-poller.ts` — removed carCount=0 early return
- `src/main/director-orchestrator.ts` — added `checkinWasActive` tracking, Race-start POST re-checkin, TTL-expiry auto-recovery

## Testing
- All **1040 tests pass** (54 test files), no TypeScript errors
- Specifically: `cloud-poller.test.ts` (24 tests), `director-orchestrator.test.ts`, `session-manager.test.ts` all green