### PR TITLE
fix: deep equality guard for capability re-check-ins; remove hardcoded camera group numbers (#220, #221)

### DIFF
--- a/src/extensions/iracing/package.json
+++ b/src/extensions/iracing/package.json
@@ -4,14 +4,14 @@
   "main": "index.js",
   "displayName": "iRacing Broadcast Controller",
   "description": "Controls iRacing Cameras and Replay state via Broadcast Messages.",
-  "aiContext": "The iRacing extension controls Race Director cameras and instant replay playback.\n- broadcast.showLiveCam: switches the broadcast camera to follow a specific car. carNum is the car number string (e.g. \"64\"). camGroup is the numeric iRacing camera group ID from the CAMERA GROUPS list (TV1=11, TV2=12, Chase=20, Blimp=18, PitLane=16). Best combined with obs.switchScene to the Race Director OBS scene first.\n- broadcast.replayFromTo: plays an instant replay segment between startFrame and endFrame iRacing replay frame numbers. Use for post-incident reviews only — never use during live racing sequences.\n- broadcast.setReplaySpeed: sets replay playback multiplier (e.g. 0.5 = half speed, 2 = double speed). Always follow with a system.wait step.\n- broadcast.setReplayPosition: jumps to a specific replay frame number.\n- broadcast.setReplayState: sets replay mode. state values: 0 = play, 1 = pause. Use to freeze on a key moment.",
+  "aiContext": "The iRacing extension controls Race Director cameras and instant replay playback.\n- broadcast.showLiveCam: switches the broadcast camera to follow a specific car. carNum is the car number string (e.g. \"64\"). camGroup must be a numeric groupNum from the CAMERA GROUPS list provided in the check-in cameraGroups field. Best combined with obs.switchScene to the Race Director OBS scene first.\n- broadcast.replayFromTo: plays an instant replay segment between startFrame and endFrame iRacing replay frame numbers. Use for post-incident reviews only — never use during live racing sequences.\n- broadcast.setReplaySpeed: sets replay playback multiplier (e.g. 0.5 = half speed, 2 = double speed). Always follow with a system.wait step.\n- broadcast.setReplayPosition: jumps to a specific replay frame number.\n- broadcast.setReplayState: sets replay mode. state values: 0 = play, 1 = pause. Use to freeze on a key moment.",
   "contributes": {
     "intents": [
       {
         "intent": "broadcast.showLiveCam",
         "title": "Show Live Camera",
         "category": "broadcast",
-        "description": "Switches the iRacing broadcast camera to follow a specific car. carNum is the car number string (e.g. '64'). camGroup is the numeric iRacing camera group ID from the CAMERA GROUPS list (TV1=11, TV2=12, Chase=20, Blimp=18, PitLane=16). Best combined with obs.switchScene to the Race Director OBS scene first.",
+        "description": "Switches the iRacing broadcast camera to follow a specific car. carNum is the car number string (e.g. '64'). camGroup must be a numeric groupNum from the CAMERA GROUPS list provided in the check-in cameraGroups field. Best combined with obs.switchScene to the Race Director OBS scene first.",
         "schema": {
           "type": "object",
           "properties": {

--- a/src/main/checkin-acceptance.test.ts
+++ b/src/main/checkin-acceptance.test.ts
@@ -113,6 +113,7 @@ describe('Session Check-In Acceptance Criteria', () => {
       checkinSession: vi.fn().mockResolvedValue({}),
       wrapSession: vi.fn().mockResolvedValue({}),
       refreshCheckin: vi.fn().mockResolvedValue({}),
+      getCapabilities: vi.fn(() => ({ extensions: [], connections: {} })),
       getCheckinId: vi.fn(() => sessionManagerState.checkinId),
       getCheckinTtlSeconds: vi.fn(() => sessionManagerState.checkinTtlSeconds),
       getSessionConfig: vi.fn(() => sessionManagerState.sessionConfig),
@@ -418,8 +419,9 @@ describe('Session Check-In Acceptance Criteria', () => {
 
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Should have called checkinSession (full POST) for each event
-      expect(mockSessionManager.checkinSession.mock.calls.length).toBeGreaterThanOrEqual(3);
+      // With deep-equality guarding (#220), identical capabilities across all three
+      // events means only the first event triggers a re-checkin.
+      expect(mockSessionManager.checkinSession.mock.calls.length).toBe(1);
     });
   });
 

--- a/src/main/director-orchestrator.test.ts
+++ b/src/main/director-orchestrator.test.ts
@@ -76,6 +76,7 @@ describe('DirectorOrchestrator', () => {
       checkinSession: vi.fn().mockResolvedValue({}),
       wrapSession: vi.fn().mockResolvedValue({}),
       refreshCheckin: vi.fn().mockResolvedValue({}),
+      getCapabilities: vi.fn(() => ({ extensions: [], connections: {} })),
       getCheckinId: vi.fn(() => null),
       getCheckinTtlSeconds: vi.fn(() => 120),
       getSessionConfig: vi.fn(() => null),

--- a/src/main/director-orchestrator.ts
+++ b/src/main/director-orchestrator.ts
@@ -90,6 +90,11 @@ export class DirectorOrchestrator extends EventEmitter {
   private checkinWasActive = false;
   /** Synthesizes higher-order narrative events from raw race state history. */
   private readonly raceAnalyzer = new RaceAnalyzer();
+  /**
+   * JSON snapshot of the capabilities used in the last capability-triggered re-check-in.
+   * Used to skip spurious re-check-ins when nothing has actually changed (#220).
+   */
+  private lastCapabilitiesJson: string = '';
 
   constructor(
     private authService: AuthService,
@@ -554,6 +559,7 @@ export class DirectorOrchestrator extends EventEmitter {
   private async handleSessionEnded(): Promise<void> {
     console.log('[DirectorOrchestrator] Session ended (410 Gone). Wrapping and stopping.');
     this.checkinWasActive = false; // Session ended — don't auto re-checkin.
+    this.lastCapabilitiesJson = ''; // Reset so next session's first capability event always fires (#220).
     await this.sessionManager.wrapSession('session-ended').catch(() => {});
     await this.sessionManager.clearSession();
     await this.setMode('stopped');
@@ -582,6 +588,7 @@ export class DirectorOrchestrator extends EventEmitter {
    */
   async wrapSession(reason?: string): Promise<DirectorOrchestratorState> {
     this.checkinWasActive = false; // Operator-initiated wrap — don't auto re-checkin (#216).
+    this.lastCapabilitiesJson = ''; // Reset so next session's first capability event always fires (#220).
     // Stop the loop if in auto mode
     if (this.mode === 'auto') {
       await this.setMode('manual');
@@ -642,6 +649,10 @@ export class DirectorOrchestrator extends EventEmitter {
    * Uses checkinSession() (not refreshCheckin/PATCH) so the AI Planner
    * is re-triggered with the updated capability snapshot. (#218)
    *
+   * Guards against spurious re-check-ins by serialising the current capabilities
+   * snapshot and comparing it to the last one actually sent. If the content is
+   * byte-for-byte identical the call is suppressed (#220).
+   *
    * Does nothing if no session is currently checked in.
    * Allows awaitIdentityResolved() to run (no forceCheckin) so that
    * a freshly-connected iRacing process has time to expose stable roster data.
@@ -649,6 +660,17 @@ export class DirectorOrchestrator extends EventEmitter {
   private async triggerCapabilityRecheckin(): Promise<void> {
     const smState = this.sessionManager.getState();
     if (!smState.checkinId || smState.checkinStatus !== 'standby') return;
+
+    // Deep-equality guard: only fire when the capabilities snapshot has actually
+    // changed. A fresh capabilities object is built on every poll cycle, so a
+    // reference check would always be true — we must compare serialised content.
+    const currentCapabilities = this.sessionManager.getCapabilities();
+    const currentJson = JSON.stringify(currentCapabilities);
+    if (currentJson === this.lastCapabilitiesJson) {
+      console.log('[DirectorOrchestrator] Skipping re-checkin — capabilities snapshot unchanged (#220)');
+      return;
+    }
+    this.lastCapabilitiesJson = currentJson;
 
     console.log('[DirectorOrchestrator] Full re-checkin triggered by capability change (#218)');
     await this.sessionManager.checkinSession().catch(error => {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -81,6 +81,14 @@ export class SessionManager extends EventEmitter {
   }
 
   /**
+   * Build and return the current capabilities snapshot.
+   * Used by DirectorOrchestrator to compare against the last check-in (#220).
+   */
+  getCapabilities(): DirectorCapabilities {
+    return this.buildCapabilities?.() ?? { extensions: [], connections: {} };
+  }
+
+  /**
    * Set the local sequences getter (provided by main.ts after library is ready).
    */
   setLocalSequencesGetter(getter: () => Promise<import('./director-types').PortableSequence[]>): void {


### PR DESCRIPTION
## Summary

Fixes #220 and #221.

---

## Fix #220 — Spurious re-check-ins on unchanged capabilities

**Root cause**: `triggerCapabilityRecheckin()` fired on every `extension.capabilitiesChanged` / `youtube.status` event with no guard against duplicate snapshots. Since the capabilities object is rebuilt fresh on every call, a reference comparison would always evaluate as changed.

**Fix**: Before issuing the POST re-check-in, serialise the current capabilities snapshot to JSON and compare it against `lastCapabilitiesJson` (the snapshot from the last trigger). If the content is byte-for-byte identical the call is suppressed and a log line is emitted instead.

- Added `SessionManager.getCapabilities()` — thin public wrapper around the private `buildCapabilities` callback so the orchestrator can read the snapshot without duplicating the builder logic.
- Added `private lastCapabilitiesJson: string = ''` to `DirectorOrchestrator`.
- `lastCapabilitiesJson` is reset to `''` on session wrap and session end, ensuring the first capability event for a new session always fires.

**Impact**: Eliminates the 3+ redundant AI Planner runs observed per session, preserving Vertex AI quota and narrative continuity.

---

## Fix #221 — Remove hardcoded camera group numbers from `aiContext` / `description`

**Root cause**: The iRacing extension's `aiContext` and the `broadcast.showLiveCam` intent `description` both contained a static example mapping (`TV1=11, TV2=12, Chase=20, Blimp=18, PitLane=16`). These numbers are rig-specific and contradict the live `cameraGroups[]` already present in the check-in payload.

**Fix (Option A from issue)**: Replace the numeric examples with a generic reference to the canonical live source:
> `camGroup must be a numeric groupNum from the CAMERA GROUPS list provided in the check-in cameraGroups field`

The AI Planner already has the correct live list from `cameraGroups[]`; the stale examples are no longer needed and are now gone.

---

## Tests

- Added `getCapabilities` mock to `SessionManager` stubs in both `director-orchestrator.test.ts` and `checkin-acceptance.test.ts`.
- Updated the "multiple rapid connection events" acceptance test: with identical capability snapshots, only **1** re-check-in fires (previously asserted `≥ 3`).
- All 48 tests pass.